### PR TITLE
add shell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ explorer-*.tar
 
 # For the Mac users
 .DS_Store
+
+# Accommodate Nix folks
+.nix-mix
+.nix-hex
+.direnv

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+with import <nixpkgs> {};
+let
+  basePackages = [
+    elixir
+    cargo
+    rustc
+  ];
+
+  hooks = ''
+    # this allows mix to work on the local directory
+    mkdir -p .nix-mix
+    mkdir -p .nix-hex
+    export MIX_HOME=$PWD/.nix-mix
+    export HEX_HOME=$PWD/.nix-hex
+    export PATH=$MIX_HOME/bin:$PATH
+    export PATH=$HEX_HOME/bin:$PATH
+  '';
+
+in mkShell {
+  buildInputs = basePackages;
+  shellHook = hooks;
+}


### PR DESCRIPTION
I'm using NixOS full time at the minute. The changes to `.gitignore` are necessary. The `shell.nix` is not but I figured I'd put it up in case there are any other Nix-curious folks like me.