### PR TITLE
Add FSS abstraction to remaining `from_*` IO functions

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -90,7 +90,7 @@ defmodule Explorer.Backend.DataFrame do
 
   # IO: IPC
   @callback from_ipc(
-              filename :: String.t(),
+              entry :: fs_entry(),
               columns :: columns_for_io()
             ) :: result(df)
   @callback to_ipc(df, filename :: String.t(), compression(), streaming :: boolean()) ::

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -103,7 +103,7 @@ defmodule Explorer.Backend.DataFrame do
 
   # IO: IPC Stream
   @callback from_ipc_stream(
-              filename :: String.t(),
+              filename :: fs_entry(),
               columns :: columns_for_io()
             ) :: result(df)
   @callback to_ipc_stream(

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -120,7 +120,7 @@ defmodule Explorer.Backend.DataFrame do
 
   # IO: IPC NDJSON
   @callback from_ndjson(
-              filename :: String.t(),
+              filename :: fs_entry(),
               infer_schema_length :: integer(),
               batch_size :: integer()
             ) :: result(df)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1061,16 +1061,23 @@ defmodule Explorer.DataFrame do
 
     * `:lazy` - force the results into the lazy version of the current backend.
 
+    * `:config` - An optional config struct or map, normally associated with remote
+      file systems. See [IO section](#module-io-operations) for more details. (default: `nil`)
+
   """
   @doc type: :io
-  @spec from_ipc_stream(filename :: String.t()) :: {:ok, DataFrame.t()} | {:error, term()}
+  @spec from_ipc_stream(filename :: String.t() | fs_entry()) ::
+          {:ok, DataFrame.t()} | {:error, term()}
   def from_ipc_stream(filename, opts \\ []) do
     {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
 
-    opts = Keyword.validate!(opts, columns: nil)
+    opts = Keyword.validate!(opts, columns: nil, config: nil)
     backend = backend_from_options!(backend_opts)
 
-    backend.from_ipc_stream(filename, to_columns_for_io(opts[:columns]))
+    backend.from_ipc_stream(
+      normalise_entry(filename, opts[:config]),
+      to_columns_for_io(opts[:columns])
+    )
   end
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -717,14 +717,7 @@ defmodule Explorer.DataFrame do
   defp normalise_entry("file://" <> path, _config), do: {:ok, %Local.Entry{path: path}}
 
   defp normalise_entry(filepath, _config) when is_binary(filepath) do
-    if File.exists?(filepath) do
-      {:ok, %Local.Entry{path: filepath}}
-    else
-      {:error,
-       ArgumentError.exception(
-         "cannot read entry because it's not a valid file, or its filesystem is not supported"
-       )}
-    end
+    {:ok, %Local.Entry{path: filepath}}
   end
 
   defp s3_config(%S3.Config{} = config), do: config

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -547,20 +547,22 @@ defmodule Explorer.DataFrame do
 
     backend = backend_from_options!(backend_opts)
 
-    backend.from_csv(
-      normalise_entry(filename, opts[:config]),
-      check_dtypes!(opts[:dtypes]),
-      opts[:delimiter],
-      opts[:null_character],
-      opts[:skip_rows],
-      opts[:header],
-      opts[:encoding],
-      opts[:max_rows],
-      to_columns_for_io(opts[:columns]),
-      opts[:infer_schema_length],
-      opts[:parse_dates],
-      opts[:eol_delimiter]
-    )
+    with {:ok, entry} <- normalise_entry(filename, opts[:config]) do
+      backend.from_csv(
+        entry,
+        check_dtypes!(opts[:dtypes]),
+        opts[:delimiter],
+        opts[:null_character],
+        opts[:skip_rows],
+        opts[:header],
+        opts[:encoding],
+        opts[:max_rows],
+        to_columns_for_io(opts[:columns]),
+        opts[:infer_schema_length],
+        opts[:parse_dates],
+        opts[:eol_delimiter]
+      )
+    end
   end
 
   @doc """
@@ -570,8 +572,14 @@ defmodule Explorer.DataFrame do
   @spec from_csv!(filename :: String.t(), opts :: Keyword.t()) :: DataFrame.t()
   def from_csv!(filename, opts \\ []) do
     case from_csv(filename, opts) do
-      {:ok, df} -> df
-      {:error, error} -> raise "from_csv failed: #{inspect(error)}"
+      {:ok, df} ->
+        df
+
+      {:error, %module{} = e} when module in [ArgumentError, RuntimeError] ->
+        raise module, "from_csv failed: #{inspect(e.message)}"
+
+      {:error, error} ->
+        raise "from_csv failed: #{inspect(error)}"
     end
   end
 
@@ -682,34 +690,40 @@ defmodule Explorer.DataFrame do
 
     backend = backend_from_options!(backend_opts)
 
-    backend.from_parquet(
-      normalise_entry(filename, opts[:config]),
-      opts[:max_rows],
-      to_columns_for_io(opts[:columns])
-    )
+    with {:ok, entry} <- normalise_entry(filename, opts[:config]) do
+      backend.from_parquet(
+        entry,
+        opts[:max_rows],
+        to_columns_for_io(opts[:columns])
+      )
+    end
   end
 
   defp normalise_entry(%_{} = entry, config) when config != nil do
-    raise ArgumentError,
-          ":config key is only supported when the argument is a string, got #{inspect(entry)} with config #{inspect(config)}"
+    {:error,
+     ArgumentError.message(
+       ":config key is only supported when the argument is a string, got #{inspect(entry)} with config #{inspect(config)}"
+     )}
   end
 
-  defp normalise_entry(%Local.Entry{} = entry, nil), do: entry
-  defp normalise_entry(%S3.Entry{config: %S3.Config{}} = entry, nil), do: entry
+  defp normalise_entry(%Local.Entry{} = entry, nil), do: {:ok, entry}
+  defp normalise_entry(%S3.Entry{config: %S3.Config{}} = entry, nil), do: {:ok, entry}
 
   defp normalise_entry("s3://" <> _rest = entry, config) do
     config = s3_config(config)
-    %S3.Entry{url: entry, config: config}
+    {:ok, %S3.Entry{url: entry, config: config}}
   end
 
-  defp normalise_entry("file://" <> path, _config), do: %Local.Entry{path: path}
+  defp normalise_entry("file://" <> path, _config), do: {:ok, %Local.Entry{path: path}}
 
   defp normalise_entry(filepath, _config) when is_binary(filepath) do
     if File.exists?(filepath) do
-      %Local.Entry{path: filepath}
+      {:ok, %Local.Entry{path: filepath}}
     else
-      raise ArgumentError,
-            "cannot read entry because it's not a valid file, or its filesystem is not supported"
+      {:error,
+       ArgumentError.exception(
+         "cannot read entry because it's not a valid file, or its filesystem is not supported"
+       )}
     end
   end
 
@@ -726,8 +740,14 @@ defmodule Explorer.DataFrame do
   @spec from_parquet!(filename :: String.t(), opts :: Keyword.t()) :: DataFrame.t()
   def from_parquet!(filename, opts \\ []) do
     case from_parquet(filename, opts) do
-      {:ok, df} -> df
-      {:error, error} -> raise "from_parquet failed: #{inspect(error)}"
+      {:ok, df} ->
+        df
+
+      {:error, %module{} = e} when module in [ArgumentError, RuntimeError] ->
+        raise module, "from_parquet failed: #{inspect(e.message)}"
+
+      {:error, error} ->
+        raise "from_parquet failed: #{inspect(error)}"
     end
   end
 
@@ -895,10 +915,12 @@ defmodule Explorer.DataFrame do
 
     backend = backend_from_options!(backend_opts)
 
-    backend.from_ipc(
-      normalise_entry(filename, opts[:config]),
-      to_columns_for_io(opts[:columns])
-    )
+    with {:ok, entry} <- normalise_entry(filename, opts[:config]) do
+      backend.from_ipc(
+        entry,
+        to_columns_for_io(opts[:columns])
+      )
+    end
   end
 
   @doc """
@@ -908,8 +930,14 @@ defmodule Explorer.DataFrame do
   @spec from_ipc!(filename :: String.t(), opts :: Keyword.t()) :: DataFrame.t()
   def from_ipc!(filename, opts \\ []) do
     case from_ipc(filename, opts) do
-      {:ok, df} -> df
-      {:error, error} -> raise "from_ipc failed: #{inspect(error)}"
+      {:ok, df} ->
+        df
+
+      {:error, %module{} = e} when module in [ArgumentError, RuntimeError] ->
+        raise module, "from_ipc failed: #{inspect(e.message)}"
+
+      {:error, error} ->
+        raise "from_ipc failed: #{inspect(error)}"
     end
   end
 
@@ -1074,21 +1102,30 @@ defmodule Explorer.DataFrame do
     opts = Keyword.validate!(opts, columns: nil, config: nil)
     backend = backend_from_options!(backend_opts)
 
-    backend.from_ipc_stream(
-      normalise_entry(filename, opts[:config]),
-      to_columns_for_io(opts[:columns])
-    )
+    with {:ok, entry} <- normalise_entry(filename, opts[:config]) do
+      backend.from_ipc_stream(
+        entry,
+        to_columns_for_io(opts[:columns])
+      )
+    end
   end
 
   @doc """
   Similar to `from_ipc_stream/2` but raises if there is a problem reading the IPC Stream file.
   """
   @doc type: :io
-  @spec from_ipc_stream!(filename :: String.t(), opts :: Keyword.t()) :: DataFrame.t()
+  @spec from_ipc_stream!(filename :: String.t() | fs_entry(), opts :: Keyword.t()) ::
+          DataFrame.t()
   def from_ipc_stream!(filename, opts \\ []) do
     case from_ipc_stream(filename, opts) do
-      {:ok, df} -> df
-      {:error, error} -> raise "from_ipc_stream failed: #{inspect(error)}"
+      {:ok, df} ->
+        df
+
+      {:error, %module{} = e} when module in [ArgumentError, RuntimeError] ->
+        raise module, "from_ipc_stream failed: #{inspect(e.message)}"
+
+      {:error, error} ->
+        raise "from_ipc_stream failed: #{inspect(error)}"
     end
   end
 
@@ -1288,38 +1325,50 @@ defmodule Explorer.DataFrame do
     * `:backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
 
     * `:lazy` - force the results into the lazy version of the current backend.
+
+    * `:config` - An optional config struct or map, normally associated with remote
+      file systems. See [IO section](#module-io-operations) for more details. (default: `nil`)
   """
   @doc type: :io
-  @spec from_ndjson(filename :: String.t(), opts :: Keyword.t()) ::
+  @spec from_ndjson(filename :: String.t() | fs_entry(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def from_ndjson(filename, opts \\ []) do
     {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
 
     opts =
       Keyword.validate!(opts,
+        config: nil,
         batch_size: 1000,
         infer_schema_length: @default_infer_schema_length
       )
 
     backend = backend_from_options!(backend_opts)
 
-    backend.from_ndjson(
-      filename,
-      opts[:infer_schema_length],
-      opts[:batch_size]
-    )
+    with {:ok, entry} <- normalise_entry(filename, opts[:config]) do
+      backend.from_ndjson(
+        entry,
+        opts[:infer_schema_length],
+        opts[:batch_size]
+      )
+    end
   end
 
   @doc """
   Similar to `from_ndjson/2`, but raises in case of error.
   """
   @doc type: :io
-  @spec from_ndjson!(filename :: String.t(), opts :: Keyword.t()) ::
+  @spec from_ndjson!(filename :: String.t() | fs_entry(), opts :: Keyword.t()) ::
           DataFrame.t()
   def from_ndjson!(filename, opts \\ []) do
     case from_ndjson(filename, opts) do
-      {:ok, df} -> df
-      {:error, error} -> raise "from_ndjson failed: #{inspect(error)}"
+      {:ok, df} ->
+        df
+
+      {:error, %module{} = e} when module in [ArgumentError, RuntimeError] ->
+        raise module, "from_ndjson failed: #{inspect(e.message)}"
+
+      {:error, error} ->
+        raise "from_ndjson failed: #{inspect(error)}"
     end
   end
 
@@ -1437,8 +1486,14 @@ defmodule Explorer.DataFrame do
           DataFrame.t()
   def load_ndjson!(contents, opts \\ []) do
     case load_ndjson(contents, opts) do
-      {:ok, df} -> df
-      {:error, error} -> raise "load_ndjson failed: #{inspect(error)}"
+      {:ok, df} ->
+        df
+
+      {:error, %module{} = e} when module in [ArgumentError, RuntimeError] ->
+        raise module, "load_ndjson failed: #{inspect(e.message)}"
+
+      {:error, error} ->
+        raise "load_ndjson failed: #{inspect(error)}"
     end
   end
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -189,8 +189,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
   defp char_byte(<<char::utf8>>), do: char
 
   @impl true
-  def from_ndjson(filename, infer_schema_length, batch_size) do
-    with {:ok, df} <- Native.df_from_ndjson(filename, infer_schema_length, batch_size) do
+  def from_ndjson(%S3.Entry{}, _, _) do
+    raise "S3 is not supported yet"
+  end
+
+  @impl true
+  def from_ndjson(%Local.Entry{} = entry, infer_schema_length, batch_size) do
+    with {:ok, df} <- Native.df_from_ndjson(entry.path, infer_schema_length, batch_size) do
       {:ok, Shared.create_dataframe(df)}
     end
   end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -268,10 +268,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def from_ipc(filename, columns) do
+  def from_ipc(%S3.Entry{}, _) do
+    raise "S3 is not supported yet"
+  end
+
+  @impl true
+  def from_ipc(%Local.Entry{} = entry, columns) do
     {columns, projection} = column_names_or_projection(columns)
 
-    case Native.df_from_ipc(filename, columns, projection) do
+    case Native.df_from_ipc(entry.path, columns, projection) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -306,10 +306,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def from_ipc_stream(filename, columns) do
+  def from_ipc_stream(%S3.Entry{}, _) do
+    raise "S3 is not supported yet"
+  end
+
+  @impl true
+  def from_ipc_stream(%Local.Entry{} = entry, columns) do
     {columns, projection} = column_names_or_projection(columns)
 
-    case Native.df_from_ipc_stream(filename, columns, projection) do
+    case Native.df_from_ipc_stream(entry.path, columns, projection) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -165,8 +165,13 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def from_ndjson(filename, infer_schema_length, batch_size) do
-    case Native.lf_from_ndjson(filename, infer_schema_length, batch_size) do
+  def from_ndjson(%S3.Entry{}, _, _) do
+    raise "S3 is not supported yet"
+  end
+
+  @impl true
+  def from_ndjson(%Local.Entry{} = entry, infer_schema_length, batch_size) do
+    case Native.lf_from_ndjson(entry.path, infer_schema_length, batch_size) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -173,14 +173,19 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def from_ipc(filename, columns) do
+  def from_ipc(%S3.Entry{}, _) do
+    raise "S3 is not supported yet"
+  end
+
+  @impl true
+  def from_ipc(%Local.Entry{} = entry, columns) do
     if columns do
       raise ArgumentError,
             "`columns` is not supported by Polars' lazy backend. " <>
               "Consider using `select/2` after reading the IPC file"
     end
 
-    case Native.lf_from_ipc(filename) do
+    case Native.lf_from_ipc(entry.path) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -192,8 +192,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def from_ipc_stream(filename, columns) do
-    case Eager.from_ipc_stream(filename, columns) do
+  def from_ipc_stream(%_{} = fs_entry, columns) do
+    case Eager.from_ipc_stream(fs_entry, columns) do
       {:ok, df} -> {:ok, Eager.to_lazy(df)}
       {:error, error} -> {:error, error}
     end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "adbc": {:git, "https://github.com/elixir-explorer/adbc.git", "eb3443a3da195ba492aa7934bb156533cb2148b6", []},
+  "adbc": {:git, "https://github.com/elixir-explorer/adbc.git", "596b99277777eda028210c555c13db4d78e1957e", []},
   "benchee": {:hex, :benchee, "1.1.0", "f3a43817209a92a1fade36ef36b86e1052627fd8934a8b937ac9ab3a76c43062", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}], "hexpm", "7da57d545003165a012b587077f6ba90b89210fd88074ce3c60ce239eb5e6d93"},
   "castore": {:hex, :castore, "1.0.3", "7130ba6d24c8424014194676d608cb989f62ef8039efd50ff4b3f33286d06db8", [:mix], [], "hexpm", "680ab01ef5d15b161ed6a95449fac5c6b8f60055677a8e79acf01b27baa4390b"},
   "cc_precompiler": {:hex, :cc_precompiler, "0.1.7", "77de20ac77f0e53f20ca82c563520af0237c301a1ec3ab3bc598e8a96c7ee5d9", [:mix], [{:elixir_make, "~> 0.7.3", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "2768b28bf3c2b4f788c995576b39b8cb5d47eb788526d93bd52206c1d8bf4b75"},

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -51,8 +51,8 @@ defmodule Explorer.DataFrame.CSVTest do
   end
 
   test "from_csv/2 error" do
-    assert_raise ArgumentError,
-                 "from_csv failed: \"cannot read entry because it's not a valid file, or its filesystem is not supported\"",
+    assert_raise RuntimeError,
+                 ~r/No such file or directory/,
                  fn ->
                    DF.from_csv!("unknown")
                  end

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -52,7 +52,7 @@ defmodule Explorer.DataFrame.CSVTest do
 
   test "from_csv/2 error" do
     assert_raise ArgumentError,
-                 "cannot read entry because it's not a valid file, or its filesystem is not supported",
+                 "from_csv failed: \"cannot read entry because it's not a valid file, or its filesystem is not supported\"",
                  fn ->
                    DF.from_csv!("unknown")
                  end


### PR DESCRIPTION
This is a continuation of #645 

PS: I left out the introduction of `endpoint / base_url` to another PR.