### PR TITLE
Return exception instead of string

### DIFF
--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -149,7 +149,7 @@ defmodule Explorer.PolarsBackend.Shared do
   def internal_from_dtype(:integer), do: "i64"
   def internal_from_dtype(:string), do: "str"
 
-  defp error_message(error) when is_binary(error), do: error
+  defp error_message(error) when is_binary(error), do: RuntimeError.exception(error)
 
   def parquet_compression(nil, _), do: :uncompressed
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -326,7 +326,7 @@ fn array_to_dataframe(
 }
 
 fn arrow_to_explorer_error(error: impl std::fmt::Debug) -> ExplorerError {
-    ExplorerError::Other(format!("Internal Arrow error: #{:?}", error))
+    ExplorerError::Other(format!("Internal Arrow error: #{error:?}"))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]


### PR DESCRIPTION
This PR resolves https://github.com/elixir-explorer/explorer/issues/646

After this PR, the error_message/1 function will return an exception instead of a string.