### PR TITLE
Write parquet from eager dataframe to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,35 @@ mix localstack.setup
 mix test --only cloud_integration
 ```
 
+## Precompilation
+
+Explorer ships with the NIF code precompiled for the most popular architectures out there.
+We support the following:
+
+- `aarch64-apple-darwin` - MacOS running on ARM 64 bits CPUs.
+- `aarch64-unknown-linux-gnu` - Linux running on ARM 64 bits CPUs, compiled with GCC.
+- `aarch64-unknown-linux-musl` - Linux running on ARM 64 bits CPUs, compiled with Musl.
+- `riscv64gc-unknown-linux-gnu` - Linux running on RISCV 64 bits CPUs, compiled with GCC.
+- `x86_64-apple-darwin` - MacOS running on Intel/AMD 64 bits CPUs.
+- `x86_64-pc-windows-msvc` - Windows running on Intel/AMD 64 bits CPUs, compiled with Visual C++.
+- `x86_64-pc-windows-gnu` - Windows running on Intel/AMD 64 bits CPUs, compiled with GCC.
+- `x86_64-unknown-linux-gnu` - Linux running on Intel/AMD 64 bits CPUs, compiled with GCC.
+- `x86_64-unknown-linux-musl` - Linux running on Intel/AMD 64 bits CPUs, compiled with Musl.
+- `x86_64-unknown-freebsd` - FreeBSD running on Intel/AMD 64 bits.
+
+This means that the problem is going to work without the need to compile it from source.
+This currently **only works for Hex releases**. For more information on how it works, please
+check the [RustlerPrecompiled project](https://hexdocs.pm/rustler_precompiled).
+
+### Features disabled
+
+Some of the features cannot be compiled to some targets, because one of the dependencies
+don't work on it.
+
+This is the case for the **NDJSON** reads and writes, that don't work for the RISCV target.
+We also disable the AWS S3 reads and writes for the RISCV target, because one of the dependencies
+of `ObjectStore` does not compile on it.
+
 ## Sponsors
 
 <a href="https://amplified.ai"><img src="sponsors/amplified.png" width=100 alt="Amplified"></a>

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -785,7 +785,7 @@ defmodule Explorer.DataFrame do
   @doc type: :io
   @spec to_parquet(df :: DataFrame.t(), filename :: String.t() | fs_entry(), opts :: Keyword.t()) ::
           :ok | {:error, term()}
-  def to_parquet(df, filename, opts \\ []) do
+  def to_parquet(%DataFrame{} = df, filename, opts \\ []) do
     opts = Keyword.validate!(opts, compression: nil, streaming: true, config: nil)
     compression = parquet_compression(opts[:compression])
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -280,12 +280,19 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def to_parquet(
-        _df,
-        %S3.Entry{},
-        _compression,
+        %DataFrame{data: df},
+        %S3.Entry{} = entry,
+        {compression, compression_level},
         _streaming
       ) do
-    raise "S3 is not supported yet"
+    case Native.df_to_parquet_cloud(
+           df,
+           entry,
+           parquet_compression(compression, compression_level)
+         ) do
+      {:ok, _} -> :ok
+      {:error, error} -> {:error, error}
+    end
   end
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -134,15 +134,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
     raise "S3 is not supported yet"
   end
 
-  def to_csv_writer_sample(%DataFrame{data: df}, path, header?, delimiter) do
-    <<delimiter::utf8>> = delimiter
-
-    case Native.df_to_csv_writer_sample(df, path, header?, delimiter) do
-      {:ok, _} -> :ok
-      {:error, error} -> {:error, error}
-    end
-  end
-
   @impl true
   def dump_csv(%DataFrame{} = df, header?, <<delimiter::utf8>>) do
     Native.df_dump_csv(df.data, header?, delimiter)

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -133,6 +133,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_lazy(_df), do: err()
   def df_to_ndjson(_df, _filename), do: err()
   def df_to_parquet(_df, _filename, _compression), do: err()
+  def df_to_parquet_cloud(_df, _ex_entry, _compression), do: err()
   def df_width(_df), do: err()
   def df_describe(_df, _percentiles), do: err()
   def df_nil_count(_df), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -126,7 +126,6 @@ defmodule Explorer.PolarsBackend.Native do
   def df_summarise_with_exprs(_df, _groups_exprs, _aggs_pairs), do: err()
   def df_tail(_df, _length, _groups), do: err()
   def df_to_csv(_df, _filename, _has_headers, _delimiter), do: err()
-  def df_to_csv_writer_sample(_df, _path, _has_headers, _delimiter), do: err()
   def df_to_dummies(_df, _columns), do: err()
   def df_to_ipc(_df, _filename, _compression), do: err()
   def df_to_ipc_stream(_df, _filename, _compression), do: err()

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,9 +19,11 @@ rand_pcg = "0.3"
 rustler = { version = "0.29", default-features = false, features = ["derive"] }
 thiserror = "1"
 smartstring = "1"
-tokio = { version = "1.29.1", features = ["rt"] }
-tokio-util = { version = "0.7.8", features = ["io", "io-util"] }
-object_store = "0.6.1"
+
+# Deps necessary for cloud features.
+tokio = { version = "1.29.1", default-features = false, features = ["rt"], optional = true }
+tokio-util = { version = "0.7.8", default-features = false, features = ["io", "io-util"], optional = true }
+object_store = { version = "0.6.1", default-features = false, optional = true }
 
 # MiMalloc won´t compile on Windows with the GCC compiler.
 # On Linux with Musl it won´t load correctly.
@@ -79,7 +81,7 @@ version = "0.31"
 [features]
 default = ["ndjson", "cloud", "nif_version_2_15"]
 
-cloud = ["aws"]
+cloud = ["object_store", "tokio", "tokio-util", "aws"]
 ndjson = ["polars/json"]
 aws = ["polars/async", "polars/aws"]
 

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -21,9 +21,9 @@ thiserror = "1"
 smartstring = "1"
 
 # Deps necessary for cloud features.
-tokio = { version = "1.29.1", default-features = false, features = ["rt"], optional = true }
-tokio-util = { version = "0.7.8", default-features = false, features = ["io", "io-util"], optional = true }
-object_store = { version = "0.6.1", default-features = false, optional = true }
+tokio = { version = "1.29", default-features = false, features = ["rt"], optional = true }
+tokio-util = { version = "0.7", default-features = false, features = ["io", "io-util"], optional = true }
+object_store = { version = "0.6", default-features = false, optional = true }
 
 # MiMalloc won´t compile on Windows with the GCC compiler.
 # On Linux with Musl it won´t load correctly.

--- a/native/explorer/src/cloud_writer.rs
+++ b/native/explorer/src/cloud_writer.rs
@@ -29,6 +29,8 @@ impl CloudWriter {
     /// which bridges the sync writing process with the async ObjectStore multipart uploading.
     pub fn new(object_store: Box<dyn ObjectStore>, path: Path) -> Self {
         let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .enable_io()
             .build()
             .unwrap();
         let (multipart_id, writer) =

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -515,6 +515,7 @@ pub fn df_load_ndjson(
     )))
 }
 
+#[cfg(feature = "cloud")]
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn df_to_csv_writer_sample(
     data: ExDataFrame,
@@ -533,4 +534,17 @@ pub fn df_to_csv_writer_sample(
         .with_delimiter(delimiter)
         .finish(&mut data.clone())?;
     Ok(())
+}
+
+#[cfg(not(feature = "cloud"))]
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn df_to_csv_writer_sample(
+    _data: ExDataFrame,
+    _path: &str,
+    _has_headers: bool,
+    _delimiter: u8,
+) -> Result<(), ExplorerError> {
+    Err(ExplorerError::Other(format!(
+        "Writing to a cloud storage is not enabled for this machine."
+    )))
 }

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -568,37 +568,3 @@ pub fn df_load_ndjson(
         "NDJSON loading is not enabled for this machine"
     )))
 }
-
-#[cfg(feature = "cloud")]
-#[rustler::nif(schedule = "DirtyIo")]
-pub fn df_to_csv_writer_sample(
-    data: ExDataFrame,
-    path: &str,
-    has_headers: bool,
-    delimiter: u8,
-) -> Result<(), ExplorerError> {
-    use object_store::ObjectStore;
-
-    // Hard-coded local file system object store for now:
-    let object_store: Box<dyn ObjectStore> = Box::new(object_store::local::LocalFileSystem::new());
-    let mut cloud_writer = crate::cloud_writer::CloudWriter::new(object_store, path.into());
-
-    CsvWriter::new(&mut cloud_writer)
-        .has_header(has_headers)
-        .with_delimiter(delimiter)
-        .finish(&mut data.clone())?;
-    Ok(())
-}
-
-#[cfg(not(feature = "cloud"))]
-#[rustler::nif(schedule = "DirtyIo")]
-pub fn df_to_csv_writer_sample(
-    _data: ExDataFrame,
-    _path: &str,
-    _has_headers: bool,
-    _delimiter: u8,
-) -> Result<(), ExplorerError> {
-    Err(ExplorerError::Other(format!(
-        "Writing to a cloud storage is not enabled for this machine."
-    )))
-}

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -269,7 +269,7 @@ pub fn df_to_parquet_cloud(
     Ok(())
 }
 fn object_store_to_explorer_error(error: impl std::fmt::Debug) -> ExplorerError {
-    ExplorerError::Other(format!("Internal Object Store error: #{error:?}"))
+    ExplorerError::Other(format!("Internal ObjectStore error: #{error:?}"))
 }
 
 #[cfg(not(feature = "aws"))]
@@ -280,7 +280,9 @@ pub fn df_to_parquet_cloud(
     _ex_compression: ExParquetCompression,
 ) -> Result<(), ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "AWS reads and writes are not enabled for this machine"
+        "Explorer was compiled without the \"aws\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }
 

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -539,7 +539,9 @@ pub fn df_from_ndjson(
     _batch_size: usize,
 ) -> Result<ExDataFrame, ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "NDJSON parsing is not enabled for this machine"
+        "Explorer was compiled without the \"ndjson\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }
 
@@ -547,7 +549,9 @@ pub fn df_from_ndjson(
 #[rustler::nif]
 pub fn df_to_ndjson(_data: ExDataFrame, _filename: &str) -> Result<(), ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "NDJSON writing is not enabled for this machine"
+        "Explorer was compiled without the \"ndjson\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }
 
@@ -555,7 +559,9 @@ pub fn df_to_ndjson(_data: ExDataFrame, _filename: &str) -> Result<(), ExplorerE
 #[rustler::nif]
 pub fn df_dump_ndjson(_data: ExDataFrame) -> Result<Binary<'static>, ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "NDJSON dumping is not enabled for this machine"
+        "Explorer was compiled without the \"ndjson\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }
 
@@ -567,6 +573,8 @@ pub fn df_load_ndjson(
     _batch_size: usize,
 ) -> Result<ExDataFrame, ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "NDJSON loading is not enabled for this machine"
+        "Explorer was compiled without the \"ndjson\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -1,8 +1,8 @@
 // This file contains the IO functions related to a dataframe.
 // Each format has 8 functions related. They do the following:
 //
-// - dump: dump a dataframe to a string using the given format (like in a CSV string).
-// - load: load a dataframe from a given string (let's say, from a CSV string).
+// - dump: dump a dataframe to a binary/string using the given format (like in a CSV string).
+// - load: load a dataframe from a given binary/string (let's say, from a CSV string).
 // - from: reads a dataframe from a file that is encoded in a given format.
 // - to: writes a dataframe to a file in a given format.
 //
@@ -18,8 +18,9 @@ use std::result::Result;
 use std::sync::Arc;
 
 use crate::dataframe::normalize_numeric_dtypes;
-use crate::datatypes::ExParquetCompression;
+use crate::datatypes::{ExParquetCompression, ExS3Entry};
 use crate::{ExDataFrame, ExplorerError};
+
 // Note that we have two types of "Compression" for IPC: this one and IpcCompresion.
 use polars::export::arrow::io::ipc::write::Compression;
 
@@ -228,6 +229,59 @@ pub fn df_to_parquet(
         .with_compression(compression)
         .finish(&mut data.clone())?;
     Ok(())
+}
+
+#[cfg(feature = "aws")]
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn df_to_parquet_cloud(
+    data: ExDataFrame,
+    ex_entry: ExS3Entry,
+    ex_compression: ExParquetCompression,
+) -> Result<(), ExplorerError> {
+    use object_store::{aws::AmazonS3Builder, ObjectStore};
+    let config = ex_entry.config;
+    let mut aws_builder = AmazonS3Builder::new()
+        .with_region(config.region)
+        .with_bucket_name(ex_entry.bucket)
+        .with_access_key_id(config.access_key_id)
+        .with_secret_access_key(config.secret_access_key);
+
+    if let Some(endpoint) = config.endpoint {
+        aws_builder = aws_builder.with_allow_http(true).with_endpoint(endpoint);
+    }
+
+    if let Some(token) = config.token {
+        aws_builder = aws_builder.with_token(token);
+    }
+
+    let aws = aws_builder
+        .build()
+        .map_err(object_store_to_explorer_error)?;
+
+    let object_store: Box<dyn ObjectStore> = Box::new(aws);
+    let mut cloud_writer = crate::cloud_writer::CloudWriter::new(object_store, ex_entry.key.into());
+
+    let compression = ParquetCompression::try_from(ex_compression)?;
+
+    ParquetWriter::new(&mut cloud_writer)
+        .with_compression(compression)
+        .finish(&mut data.clone())?;
+    Ok(())
+}
+fn object_store_to_explorer_error(error: impl std::fmt::Debug) -> ExplorerError {
+    ExplorerError::Other(format!("Internal Object Store error: #{error:?}"))
+}
+
+#[cfg(not(feature = "aws"))]
+#[rustler::nif]
+pub fn df_to_parquet_cloud(
+    _data: ExDataFrame,
+    _ex_entry: ExS3Entry,
+    _ex_compression: ExParquetCompression,
+) -> Result<(), ExplorerError> {
+    Err(ExplorerError::Other(format!(
+        "AWS reads and writes are not enabled for this machine"
+    )))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -63,7 +63,9 @@ pub fn lf_from_parquet_cloud(
     _columns: Option<Vec<String>>,
 ) -> Result<ExLazyFrame, ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "AWS reads and writes are not enabled for this machine"
+        "Explorer was compiled without the \"aws\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }
 

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -106,7 +106,7 @@ pub fn lf_to_parquet(
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 pub fn lf_from_ipc(filename: &str) -> Result<ExLazyFrame, ExplorerError> {
     let lf = LazyFrame::scan_ipc(filename, Default::default())?;
 
@@ -192,7 +192,7 @@ pub fn lf_from_csv(
     Ok(ExLazyFrame::new(df))
 }
 
-#[cfg(not(any(target_arch = "arm", target_arch = "riscv64")))]
+#[cfg(feature = "ndjson")]
 #[rustler::nif]
 pub fn lf_from_ndjson(
     filename: String,
@@ -207,7 +207,7 @@ pub fn lf_from_ndjson(
     Ok(ExLazyFrame::new(lf))
 }
 
-#[cfg(any(target_arch = "arm", target_arch = "riscv64"))]
+#[cfg(not(feature = "ndjson"))]
 #[rustler::nif]
 pub fn lf_from_ndjson(
     _filename: &str,
@@ -215,6 +215,8 @@ pub fn lf_from_ndjson(
     _batch_size: usize,
 ) -> Result<ExLazyFrame, ExplorerError> {
     Err(ExplorerError::Other(format!(
-        "NDJSON parsing is not enabled for this machine"
+        "Explorer was compiled without the \"ndjson\" feature enabled. \
+        This is mostly due to this feature being incompatible with your computer's architecture. \
+        Please read the section about precompilation in our README.md: https://github.com/elixir-explorer/explorer#precompilation"
     )))
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -14,7 +14,9 @@ use rustler::{Env, Term};
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
+#[cfg(feature = "cloud")]
 mod cloud_writer;
+
 mod dataframe;
 mod datatypes;
 mod encoding;

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -128,6 +128,7 @@ rustler::init!(
         df_to_lazy,
         df_to_ndjson,
         df_to_parquet,
+        df_to_parquet_cloud,
         df_width,
         // expressions
         expr_atom,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -121,7 +121,6 @@ rustler::init!(
         df_summarise_with_exprs,
         df_tail,
         df_to_csv,
-        df_to_csv_writer_sample,
         df_to_dummies,
         df_to_ipc,
         df_to_ipc_stream,

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -227,4 +227,28 @@ defmodule Explorer.DataFrame.ParquetTest do
       end
     end
   end
+
+  describe "to_parquet/2 - cloud" do
+    setup do
+      [df: Explorer.Datasets.wine()]
+    end
+
+    @tag :cloud_integration
+    test "writes a parquet file to S3", %{df: df} do
+      config = %FSS.S3.Config{
+        access_key_id: "test",
+        secret_access_key: "test",
+        endpoint: "http://localhost:4566",
+        region: "us-east-1"
+      }
+
+      path = "s3://test-bucket/test-writes/wine-#{System.monotonic_time()}.parquet"
+
+      assert :ok = DF.to_parquet(df, path, config: config)
+
+      saved_df = DF.from_parquet!(path, config: config)
+
+      assert DF.to_columns(saved_df) == DF.to_columns(Explorer.Datasets.wine())
+    end
+  end
 end


### PR DESCRIPTION
This is the first of the "write" operations using the abstraction from #653.
It implements the `to_parquet/3`.

I wanted to open this PR first to evaluate if the structure looks good.