### PR TITLE
implement slice_string/3

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -116,7 +116,7 @@ defmodule Explorer.Backend.LazySeries do
     trim: 2,
     upcase: 1,
     downcase: 1,
-    slice_string: 3,
+    substring: 3,
     # Float round
     round: 2,
     floor: 1,
@@ -892,8 +892,8 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def slice_string(series, offset, length) do
-    data = new(:slice_string, [lazy_series!(series), offset, length])
+  def substring(series, offset, length) do
+    data = new(:substring, [lazy_series!(series), offset, length])
 
     Backend.Series.new(data, :string)
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -116,6 +116,7 @@ defmodule Explorer.Backend.LazySeries do
     trim: 2,
     upcase: 1,
     downcase: 1,
+    slice_string: 3,
     # Float round
     round: 2,
     floor: 1,
@@ -886,6 +887,13 @@ defmodule Explorer.Backend.LazySeries do
   @impl true
   def trim_trailing(series) do
     data = new(:trim_trailing, [lazy_series!(series)])
+
+    Backend.Series.new(data, :string)
+  end
+
+  @impl true
+  def slice_string(series, offset, length) do
+    data = new(:slice_string, [lazy_series!(series), offset, length])
 
     Backend.Series.new(data, :string)
   end

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -240,7 +240,7 @@ defmodule Explorer.Backend.Series do
   @callback trim(s, String.t() | nil) :: s
   @callback trim_leading(s) :: s
   @callback trim_trailing(s) :: s
-  @callback slice_string(s, integer(), integer()) :: s
+  @callback substring(s, integer(), non_neg_integer() | nil) :: s
 
   # Date / DateTime
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -240,6 +240,7 @@ defmodule Explorer.Backend.Series do
   @callback trim(s, String.t() | nil) :: s
   @callback trim_leading(s) :: s
   @callback trim_trailing(s) :: s
+  @callback slice_string(s, integer(), integer()) :: s
 
   # Date / DateTime
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -125,7 +125,7 @@ defmodule Explorer.PolarsBackend.Expression do
     trim_trailing: 1,
     downcase: 1,
     upcase: 1,
-    slice_string: 3
+    substring: 3
   ]
 
   @custom_expressions [

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -124,7 +124,8 @@ defmodule Explorer.PolarsBackend.Expression do
     trim_leading: 1,
     trim_trailing: 1,
     downcase: 1,
-    upcase: 1
+    upcase: 1,
+    slice_string: 3
   ]
 
   @custom_expressions [

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -332,7 +332,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_unordered_distinct(_s), do: err()
   def s_frequencies(_s), do: err()
   def s_cut(_s, _bins, _labels, _break_point_label, _category_label), do: err()
-  def s_slice_string(_s, _offset, _length), do: err()
+  def s_substring(_s, _offset, _length), do: err()
 
   def s_qcut(_s, _quantiles, _labels, _break_point_label, _category_label),
     do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -332,6 +332,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_unordered_distinct(_s), do: err()
   def s_frequencies(_s), do: err()
   def s_cut(_s, _bins, _labels, _break_point_label, _category_label), do: err()
+  def s_slice_string(_s, _offset, _length), do: err()
 
   def s_qcut(_s, _quantiles, _labels, _break_point_label, _category_label),
     do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -626,6 +626,10 @@ defmodule Explorer.PolarsBackend.Series do
   def trim_trailing(series),
     do: Shared.apply_series(series, :s_trim_trailing)
 
+  @impl true
+  def slice_string(series, offset, length),
+    do: Shared.apply_series(series, :s_slice_string, [offset, length])
+
   # Float round
   @impl true
   def round(series, decimals),

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -627,8 +627,8 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(series, :s_trim_trailing)
 
   @impl true
-  def slice_string(series, offset, length),
-    do: Shared.apply_series(series, :s_slice_string, [offset, length])
+  def substring(series, offset, length),
+    do: Shared.apply_series(series, :s_substring, [offset, length])
 
   # Float round
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -4355,6 +4355,61 @@ defmodule Explorer.Series do
 
   def trim_trailing(%Series{dtype: dtype}), do: dtype_error("trim_trailing/1", dtype, [:string])
 
+  @doc """
+  Returns a string sliced from the offset to the end of the string, supporting
+  negative indexing
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
+      iex> Explorer.Series.slice_string(s, -3)
+      #Explorer.Series<
+        Polars[3]
+        string ["rth", "ars", "une"]
+      >
+
+      iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
+      iex> Explorer.Series.slice_string(s, 1)
+      #Explorer.Series<
+        Polars[3]
+        string ["arth", "ars", "eptune"]
+      >
+  """
+  @doc type: :string_wise
+  @spec slice_string(Series.t(), integer()) :: Series.t()
+  def slice_string(%Series{dtype: :string} = series, offset) when is_integer(offset),
+    do: apply_series(series, :slice_string, [offset, nil])
+
+  @doc """
+  Returns a string sliced from the offset to the length provided, supporting
+  negative indexing
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
+      iex> Explorer.Series.slice_string(s, -3, 2)
+      #Explorer.Series<
+        Polars[3]
+        string ["rt", "ar", "un"]
+      >
+
+      iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
+      iex> Explorer.Series.slice_string(s, 1, 5)
+      #Explorer.Series<
+        Polars[3]
+        string ["arth", "ars", "eptun"]
+      >
+  """
+  @doc type: :string_wise
+  @spec slice_string(Series.t(), integer(), integer()) :: Series.t()
+  def slice_string(%Series{dtype: :string} = series, offset, length)
+      when is_integer(offset)
+      when is_integer(length),
+      do: apply_series(series, :slice_string, [offset, length])
+
+  def slice_string(%Series{dtype: dtype}, _offset, _length),
+    do: dtype_error("slice_string/3", dtype, [:string])
+
   # Float
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -4362,23 +4362,23 @@ defmodule Explorer.Series do
   ## Examples
 
       iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
-      iex> Explorer.Series.slice_string(s, -3)
+      iex> Explorer.Series.substring(s, -3)
       #Explorer.Series<
         Polars[3]
         string ["rth", "ars", "une"]
       >
 
       iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
-      iex> Explorer.Series.slice_string(s, 1)
+      iex> Explorer.Series.substring(s, 1)
       #Explorer.Series<
         Polars[3]
         string ["arth", "ars", "eptune"]
       >
   """
   @doc type: :string_wise
-  @spec slice_string(Series.t(), integer()) :: Series.t()
-  def slice_string(%Series{dtype: :string} = series, offset) when is_integer(offset),
-    do: apply_series(series, :slice_string, [offset, nil])
+  @spec substring(Series.t(), integer()) :: Series.t()
+  def substring(%Series{dtype: :string} = series, offset) when is_integer(offset),
+    do: apply_series(series, :substring, [offset, nil])
 
   @doc """
   Returns a string sliced from the offset to the length provided, supporting
@@ -4387,28 +4387,36 @@ defmodule Explorer.Series do
   ## Examples
 
       iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
-      iex> Explorer.Series.slice_string(s, -3, 2)
+      iex> Explorer.Series.substring(s, -3, 2)
       #Explorer.Series<
         Polars[3]
         string ["rt", "ar", "un"]
       >
 
       iex> s = Explorer.Series.from_list(["earth", "mars", "neptune"])
-      iex> Explorer.Series.slice_string(s, 1, 5)
+      iex> Explorer.Series.substring(s, 1, 5)
       #Explorer.Series<
         Polars[3]
         string ["arth", "ars", "eptun"]
       >
+
+      iex> d = Explorer.Series.from_list(["こんにちは世界", "مرحبًا", "안녕하세요"])
+      iex> Explorer.Series.substring(d, 1, 3)
+      #Explorer.Series<
+        Polars[3]
+        string ["んにち", "رحب", "녕하세"]
+      >
   """
   @doc type: :string_wise
-  @spec slice_string(Series.t(), integer(), integer()) :: Series.t()
-  def slice_string(%Series{dtype: :string} = series, offset, length)
+  @spec substring(Series.t(), integer(), integer()) :: Series.t()
+  def substring(%Series{dtype: :string} = series, offset, length)
       when is_integer(offset)
-      when is_integer(length),
-      do: apply_series(series, :slice_string, [offset, length])
+      when is_integer(length)
+      when length >= 0,
+      do: apply_series(series, :substring, [offset, length])
 
-  def slice_string(%Series{dtype: dtype}, _offset, _length),
-    do: dtype_error("slice_string/3", dtype, [:string])
+  def substring(%Series{dtype: dtype}, _offset, _length),
+    do: dtype_error("substring/3", dtype, [:string])
 
   # Float
 

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -765,6 +765,12 @@ pub fn expr_trim_trailing(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_slice_string(expr: ExExpr, offset: i64, length: Option<u64>) -> ExExpr {
+    let expr = expr.clone_inner();
+    ExExpr::new(expr.str().str_slice(offset, length))
+}
+
+#[rustler::nif]
 pub fn expr_round(expr: ExExpr, decimals: u32) -> ExExpr {
     let expr = expr.clone_inner();
     ExExpr::new(expr.round(decimals))

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -765,7 +765,7 @@ pub fn expr_trim_trailing(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_slice_string(expr: ExExpr, offset: i64, length: Option<u64>) -> ExExpr {
+pub fn expr_substring(expr: ExExpr, offset: i64, length: Option<u64>) -> ExExpr {
     let expr = expr.clone_inner();
     ExExpr::new(expr.str().str_slice(offset, length))
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -244,6 +244,7 @@ rustler::init!(
         expr_trim,
         expr_trim_leading,
         expr_trim_trailing,
+        expr_slice_string,
         // float round expressions
         expr_round,
         expr_floor,
@@ -396,6 +397,7 @@ rustler::init!(
         s_standard_deviation,
         s_tan,
         s_trim,
+        s_slice_string,
         s_subtract,
         s_sum,
         s_tail,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -244,7 +244,7 @@ rustler::init!(
         expr_trim,
         expr_trim_leading,
         expr_trim_trailing,
-        expr_slice_string,
+        expr_substring,
         // float round expressions
         expr_round,
         expr_floor,
@@ -397,7 +397,7 @@ rustler::init!(
         s_standard_deviation,
         s_tan,
         s_trim,
-        s_slice_string,
+        s_substring,
         s_subtract,
         s_sum,
         s_tail,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1365,7 +1365,7 @@ pub fn s_trim_trailing(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_slice_string(
+pub fn s_substring(
     s1: ExSeries,
     offset: i64,
     length: Option<u64>,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1365,6 +1365,17 @@ pub fn s_trim_trailing(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_slice_string(
+    s1: ExSeries,
+    offset: i64,
+    length: Option<u64>,
+) -> Result<ExSeries, ExplorerError> {
+    Ok(ExSeries::new(
+        s1.utf8()?.str_slice(offset, length)?.into_series(),
+    ))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_round(s: ExSeries, decimals: u32) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.round(decimals)?.into_series()))
 }

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1519,23 +1519,31 @@ defmodule Explorer.DataFrameTest do
         DF.new(
           a: ["_hello", "_world", "_foo", "_bar"],
           b: ["venus", "earth", "mars", "jupiter"],
-          c: ["_foo", "_bar", "_baz", "_quox"]
+          c: ["_foo", "_bar", "_baz", "_quox"],
+          d: ["_foo", "_bar", "_baz", "_quox"],
+          e: ["_foo", "_bar", "_baz", "_quox"]
         )
 
       df1 =
         DF.mutate(df,
-          d: slice_string(a, 1),
-          e: slice_string(b, 2, 5),
-          f: slice_string(c, -3)
+          f: substring(a, 1),
+          g: substring(b, 2, 5),
+          h: substring(c, -3),
+          i: substring(d, 6, 10),
+          j: substring(e, -15, 2)
         )
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: ["_hello", "_world", "_foo", "_bar"],
                b: ["venus", "earth", "mars", "jupiter"],
                c: ["_foo", "_bar", "_baz", "_quox"],
-               d: ["hello", "world", "foo", "bar"],
-               e: ["nus", "rth", "rs", "piter"],
-               f: ["foo", "bar", "baz", "uox"]
+               d: ["_foo", "_bar", "_baz", "_quox"],
+               e: ["_foo", "_bar", "_baz", "_quox"],
+               f: ["hello", "world", "foo", "bar"],
+               g: ["nus", "rth", "rs", "piter"],
+               h: ["foo", "bar", "baz", "uox"],
+               i: ["", "", "", ""],
+               j: ["_f", "_b", "_b", "_q"]
              }
     end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1514,6 +1514,31 @@ defmodule Explorer.DataFrameTest do
       end
     end
 
+    test "slice strings" do
+      df =
+        DF.new(
+          a: ["_hello", "_world", "_foo", "_bar"],
+          b: ["venus", "earth", "mars", "jupiter"],
+          c: ["_foo", "_bar", "_baz", "_quox"]
+        )
+
+      df1 =
+        DF.mutate(df,
+          d: slice_string(a, 1),
+          e: slice_string(b, 2, 5),
+          f: slice_string(c, -3)
+        )
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: ["_hello", "_world", "_foo", "_bar"],
+               b: ["venus", "earth", "mars", "jupiter"],
+               c: ["_foo", "_bar", "_baz", "_quox"],
+               d: ["hello", "world", "foo", "bar"],
+               e: ["nus", "rth", "rs", "piter"],
+               f: ["foo", "bar", "baz", "uox"]
+             }
+    end
+
     test "trim characters from string" do
       df =
         DF.new(

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3980,6 +3980,32 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "string_slicing" do
+    test "string_slice/2 positive offset" do
+      series = Series.from_list(["earth", "mars", "neptune"])
+
+      assert Series.slice_string(series, 2) |> Series.to_list() == ["rth", "rs", "ptune"]
+    end
+
+    test "string_slice/2 negative offset" do
+      series = Series.from_list(["earth", "mars", "neptune"])
+
+      assert Series.slice_string(series, -3) |> Series.to_list() == ["rth", "ars", "une"]
+    end
+
+    test "string_slice/3 positive offset" do
+      series = Series.from_list(["earth", "mars", "neptune"])
+
+      assert Series.slice_string(series, 2, 3) |> Series.to_list() == ["rth", "rs", "ptu"]
+    end
+
+    test "string_slice/3 negative offset" do
+      series = Series.from_list(["earth", "mars", "neptune"])
+
+      assert Series.slice_string(series, -4, 4) |> Series.to_list() == ["arth", "mars", "tune"]
+    end
+  end
+
   describe "strptime/2 and strftime/2" do
     test "parse datetime from string" do
       series = Series.from_list(["2023-01-05 12:34:56", "XYZ", nil])

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3984,25 +3984,29 @@ defmodule Explorer.SeriesTest do
     test "string_slice/2 positive offset" do
       series = Series.from_list(["earth", "mars", "neptune"])
 
-      assert Series.slice_string(series, 2) |> Series.to_list() == ["rth", "rs", "ptune"]
+      assert Series.substring(series, 2) |> Series.to_list() == ["rth", "rs", "ptune"]
+      assert Series.substring(series, 20) |> Series.to_list() == ["", "", ""]
     end
 
     test "string_slice/2 negative offset" do
       series = Series.from_list(["earth", "mars", "neptune"])
 
-      assert Series.slice_string(series, -3) |> Series.to_list() == ["rth", "ars", "une"]
+      assert Series.substring(series, -3) |> Series.to_list() == ["rth", "ars", "une"]
+      assert Series.substring(series, -9) |> Series.to_list() == ["earth", "mars", "neptune"]
     end
 
     test "string_slice/3 positive offset" do
       series = Series.from_list(["earth", "mars", "neptune"])
 
-      assert Series.slice_string(series, 2, 3) |> Series.to_list() == ["rth", "rs", "ptu"]
+      assert Series.substring(series, 2, 3) |> Series.to_list() == ["rth", "rs", "ptu"]
+      assert Series.substring(series, 12, 13) |> Series.to_list() == ["", "", ""]
     end
 
     test "string_slice/3 negative offset" do
       series = Series.from_list(["earth", "mars", "neptune"])
 
-      assert Series.slice_string(series, -4, 4) |> Series.to_list() == ["arth", "mars", "tune"]
+      assert Series.substring(series, -4, 4) |> Series.to_list() == ["arth", "mars", "tune"]
+      assert Series.substring(series, -20, 4) |> Series.to_list() == ["eart", "mars", "nept"]
     end
   end
 


### PR DESCRIPTION
add implementation for slicing strings. 

implements a slice_string/2 and a slice_string/3, the former just takes an offset and the latter takes an offset and length

references https://github.com/elixir-explorer/explorer/issues/663