### PR TITLE
Add remaining write operations to AWS S3

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -217,8 +217,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
     end
   end
 
-  def to_ndjson(_, %S3.Entry{}) do
-    raise "S3 is not supported yet"
+  @impl true
+  def to_ndjson(%DataFrame{data: df}, %S3.Entry{} = entry) do
+    with {:ok, _} <- Native.df_to_ndjson_cloud(df, entry) do
+      :ok
+    end
   end
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -130,8 +130,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_csv(_df, %S3.Entry{}, _header?, _delimiter) do
-    raise "S3 is not supported yet"
+  def to_csv(%DataFrame{data: df}, %S3.Entry{} = entry, header?, delimiter) do
+    <<delimiter::utf8>> = delimiter
+
+    case Native.df_to_csv_cloud(df, entry, header?, delimiter) do
+      {:ok, _} -> :ok
+      {:error, error} -> {:error, error}
+    end
   end
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -329,20 +329,23 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def to_ipc(%DataFrame{data: df}, %Local.Entry{} = entry, {compression, _level}, _streaming) do
-    case Native.df_to_ipc(df, entry.path, Atom.to_string(compression)) do
+    case Native.df_to_ipc(df, entry.path, maybe_atom_to_string(compression)) do
       {:ok, _} -> :ok
       {:error, error} -> {:error, error}
     end
   end
 
   @impl true
-  def to_ipc(_df, %S3.Entry{}, _, _) do
-    raise "S3 is not supported yet"
+  def to_ipc(%DataFrame{data: df}, %S3.Entry{} = entry, {compression, _level}, _streaming) do
+    case Native.df_to_ipc_cloud(df, entry, maybe_atom_to_string(compression)) do
+      {:ok, _} -> :ok
+      {:error, error} -> {:error, error}
+    end
   end
 
   @impl true
   def dump_ipc(%DataFrame{data: df}, {compression, _level}) do
-    Native.df_dump_ipc(df, Atom.to_string(compression))
+    Native.df_dump_ipc(df, maybe_atom_to_string(compression))
   end
 
   @impl true
@@ -372,7 +375,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def to_ipc_stream(%DataFrame{data: df}, %Local.Entry{} = entry, {compression, _level}) do
-    case Native.df_to_ipc_stream(df, entry.path, Atom.to_string(compression)) do
+    case Native.df_to_ipc_stream(df, entry.path, maybe_atom_to_string(compression)) do
       {:ok, _} -> :ok
       {:error, error} -> {:error, error}
     end
@@ -385,7 +388,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def dump_ipc_stream(%DataFrame{data: df}, {compression, _level}) do
-    Native.df_dump_ipc_stream(df, Atom.to_string(compression))
+    Native.df_dump_ipc_stream(df, maybe_atom_to_string(compression))
   end
 
   @impl true
@@ -397,6 +400,9 @@ defmodule Explorer.PolarsBackend.DataFrame do
       {:error, error} -> {:error, error}
     end
   end
+
+  defp maybe_atom_to_string(nil), do: nil
+  defp maybe_atom_to_string(atom) when is_atom(atom), do: Atom.to_string(atom)
 
   # Conversion
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -382,8 +382,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_ipc_stream(_df, %S3.Entry{}, _compression) do
-    raise "S3 is not supported yet"
+  def to_ipc_stream(%DataFrame{data: df}, %S3.Entry{} = entry, {compression, _level}) do
+    case Native.df_to_ipc_stream_cloud(df, entry, maybe_atom_to_string(compression)) do
+      {:ok, _} -> :ok
+      {:error, error} -> {:error, error}
+    end
   end
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -281,8 +281,15 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def to_parquet(_df, %S3.Entry{}, _compression, _streaming) do
-    raise "S3 is not supported yet"
+  def to_parquet(_df, %S3.Entry{}, _compression, _streaming = true) do
+    {:error, ArgumentError.exception("streaming is not supported for writes to AWS S3")}
+  end
+
+  @impl true
+  def to_parquet(%DF{} = ldf, %S3.Entry{} = entry, compression, _streaming = false) do
+    eager_df = collect(ldf)
+
+    Eager.to_parquet(eager_df, entry, compression, false)
   end
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -301,8 +301,15 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def to_ipc(_df, %S3.Entry{}, _compression, _streaming) do
-    raise "S3 is not supported yet"
+  def to_ipc(_df, %S3.Entry{}, _compression, _streaming = true) do
+    {:error, ArgumentError.exception("streaming is not supported for writes to AWS S3")}
+  end
+
+  @impl true
+  def to_ipc(%DF{} = ldf, %S3.Entry{} = entry, compression, _streaming = false) do
+    eager_df = collect(ldf)
+
+    Eager.to_ipc(eager_df, entry, compression, false)
   end
 
   @impl true

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -134,6 +134,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_ipc_stream_cloud(_df, _ex_entry, _compression), do: err()
   def df_to_lazy(_df), do: err()
   def df_to_ndjson(_df, _filename), do: err()
+  def df_to_ndjson_cloud(_df, _ex_entry), do: err()
   def df_to_parquet(_df, _filename, _compression), do: err()
   def df_to_parquet_cloud(_df, _ex_entry, _compression), do: err()
   def df_width(_df), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -131,6 +131,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_ipc(_df, _filename, _compression), do: err()
   def df_to_ipc_cloud(_df, _ex_entry, _compression), do: err()
   def df_to_ipc_stream(_df, _filename, _compression), do: err()
+  def df_to_ipc_stream_cloud(_df, _ex_entry, _compression), do: err()
   def df_to_lazy(_df), do: err()
   def df_to_ndjson(_df, _filename), do: err()
   def df_to_parquet(_df, _filename, _compression), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -129,6 +129,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_csv_cloud(_df, _ex_entry, _has_headers, _delimiter), do: err()
   def df_to_dummies(_df, _columns), do: err()
   def df_to_ipc(_df, _filename, _compression), do: err()
+  def df_to_ipc_cloud(_df, _ex_entry, _compression), do: err()
   def df_to_ipc_stream(_df, _filename, _compression), do: err()
   def df_to_lazy(_df), do: err()
   def df_to_ndjson(_df, _filename), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -126,6 +126,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_summarise_with_exprs(_df, _groups_exprs, _aggs_pairs), do: err()
   def df_tail(_df, _length, _groups), do: err()
   def df_to_csv(_df, _filename, _has_headers, _delimiter), do: err()
+  def df_to_csv_cloud(_df, _ex_entry, _has_headers, _delimiter), do: err()
   def df_to_dummies(_df, _columns), do: err()
   def df_to_ipc(_df, _filename, _compression), do: err()
   def df_to_ipc_stream(_df, _filename, _compression), do: err()

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -121,6 +121,7 @@ rustler::init!(
         df_summarise_with_exprs,
         df_tail,
         df_to_csv,
+        df_to_csv_cloud,
         df_to_dummies,
         df_to_ipc,
         df_to_ipc_stream,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -126,6 +126,7 @@ rustler::init!(
         df_to_ipc,
         df_to_ipc_cloud,
         df_to_ipc_stream,
+        df_to_ipc_stream_cloud,
         df_to_lazy,
         df_to_ndjson,
         df_to_parquet,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -129,6 +129,7 @@ rustler::init!(
         df_to_ipc_stream_cloud,
         df_to_lazy,
         df_to_ndjson,
+        df_to_ndjson_cloud,
         df_to_parquet,
         df_to_parquet_cloud,
         df_width,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -124,6 +124,7 @@ rustler::init!(
         df_to_csv_cloud,
         df_to_dummies,
         df_to_ipc,
+        df_to_ipc_cloud,
         df_to_ipc_stream,
         df_to_lazy,
         df_to_ndjson,

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -479,4 +479,46 @@ defmodule Explorer.DataFrame.CSVTest do
              }
     end
   end
+
+  describe "to_csv/3" do
+    setup do
+      [df: Explorer.Datasets.wine()]
+    end
+
+    @tag :tmp_dir
+    test "can write a CSV to file", %{df: df, tmp_dir: tmp_dir} do
+      csv_path = Path.join(tmp_dir, "test.csv")
+
+      assert :ok = DF.to_csv(df, csv_path)
+      assert {:ok, csv_df} = DF.from_csv(csv_path)
+
+      assert DF.names(df) == DF.names(csv_df)
+      assert DF.dtypes(df) == DF.dtypes(csv_df)
+      assert DF.to_columns(df) == DF.to_columns(csv_df)
+    end
+  end
+
+  describe "to_csv/3 - cloud" do
+    setup do
+      [df: Explorer.Datasets.wine()]
+    end
+
+    @tag :cloud_integration
+    test "writes a CSV file to S3", %{df: df} do
+      config = %FSS.S3.Config{
+        access_key_id: "test",
+        secret_access_key: "test",
+        endpoint: "http://localhost:4566",
+        region: "us-east-1"
+      }
+
+      path = "s3://test-bucket/test-writes/wine-#{System.monotonic_time()}.csv"
+
+      assert :ok = DF.to_csv(df, path, config: config)
+
+      # When we have the reader, we can activate this assertion.
+      # saved_df = DF.from_csv!(path, config: config)
+      # assert DF.to_columns(saved_df) == DF.to_columns(Explorer.Datasets.wine())
+    end
+  end
 end

--- a/test/explorer/data_frame/ipc_test.exs
+++ b/test/explorer/data_frame/ipc_test.exs
@@ -102,4 +102,46 @@ defmodule Explorer.DataFrame.IPCTest do
       assert_ipc(:datetime, "1664624050123456", ~N[2022-10-01 11:34:10.123456])
     end
   end
+
+  describe "to_ipc/3" do
+    setup do
+      [df: Explorer.Datasets.wine()]
+    end
+
+    @tag :tmp_dir
+    test "can write a CSV to file", %{df: df, tmp_dir: tmp_dir} do
+      ipc_path = Path.join(tmp_dir, "test.ipc")
+
+      assert :ok = DF.to_ipc(df, ipc_path)
+      assert {:ok, ipc_df} = DF.from_ipc(ipc_path)
+
+      assert DF.names(df) == DF.names(ipc_df)
+      assert DF.dtypes(df) == DF.dtypes(ipc_df)
+      assert DF.to_columns(df) == DF.to_columns(ipc_df)
+    end
+  end
+
+  describe "to_ipc/3 - cloud" do
+    setup do
+      s3_config = %FSS.S3.Config{
+        access_key_id: "test",
+        secret_access_key: "test",
+        endpoint: "http://localhost:4566",
+        region: "us-east-1"
+      }
+
+      [df: Explorer.Datasets.wine(), s3_config: s3_config]
+    end
+
+    @tag :cloud_integration
+    test "writes an IPC file to S3", %{df: df, s3_config: s3_config} do
+      path = "s3://test-bucket/test-writes/wine-#{System.monotonic_time()}.ipc"
+
+      assert :ok = DF.to_ipc(df, path, config: s3_config)
+
+      # When we have the reader, we can activate this assertion.
+      # saved_df = DF.from_ipc!(path, config: config)
+      # assert DF.to_columns(saved_df) == DF.to_columns(Explorer.Datasets.wine())
+    end
+  end
 end

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -282,6 +282,37 @@ defmodule Explorer.DataFrame.LazyTest do
     assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
   end
 
+  test "to_parquet/2 - cloud with streaming enabled", %{ldf: ldf} do
+    config = %FSS.S3.Config{
+      access_key_id: "test",
+      secret_access_key: "test",
+      endpoint: "http://localhost:4566",
+      region: "us-east-1"
+    }
+
+    path = "s3://test-bucket/test-lazy-writes/wine-#{System.monotonic_time()}.parquet"
+
+    ldf = DF.head(ldf, 15)
+    assert {:error, error} = DF.to_parquet(ldf, path, streaming: true, config: config)
+
+    assert error == ArgumentError.exception("streaming is not supported for writes to AWS S3")
+  end
+
+  @tag :cloud_integration
+  test "to_parquet/2 - cloud with streaming disabled", %{ldf: ldf} do
+    config = %FSS.S3.Config{
+      access_key_id: "test",
+      secret_access_key: "test",
+      endpoint: "http://localhost:4566",
+      region: "us-east-1"
+    }
+
+    path = "s3://test-bucket/test-lazy-writes/wine-#{System.monotonic_time()}.parquet"
+
+    ldf = DF.head(ldf, 15)
+    assert :ok = DF.to_parquet(ldf, path, streaming: false, config: config)
+  end
+
   @tag :tmp_dir
   test "from_ndjson/2 - with defaults", %{df: df, tmp_dir: tmp_dir} do
     path = Path.join([tmp_dir, "fossil_fuels.ndjson"])

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -256,6 +256,37 @@ defmodule Explorer.DataFrame.LazyTest do
     assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
   end
 
+  test "to_ipc/3 - cloud with streaming enabled", %{ldf: ldf} do
+    config = %FSS.S3.Config{
+      access_key_id: "test",
+      secret_access_key: "test",
+      endpoint: "http://localhost:4566",
+      region: "us-east-1"
+    }
+
+    path = "s3://test-bucket/test-lazy-writes/wine-#{System.monotonic_time()}.ipc"
+
+    ldf = DF.head(ldf, 15)
+    assert {:error, error} = DF.to_ipc(ldf, path, streaming: true, config: config)
+
+    assert error == ArgumentError.exception("streaming is not supported for writes to AWS S3")
+  end
+
+  @tag :cloud_integration
+  test "to_ipc/2 - cloud with streaming disabled", %{ldf: ldf} do
+    config = %FSS.S3.Config{
+      access_key_id: "test",
+      secret_access_key: "test",
+      endpoint: "http://localhost:4566",
+      region: "us-east-1"
+    }
+
+    path = "s3://test-bucket/test-lazy-writes/wine-#{System.monotonic_time()}.ipc"
+
+    ldf = DF.head(ldf, 15)
+    assert :ok = DF.to_ipc(ldf, path, streaming: false, config: config)
+  end
+
   @tag :tmp_dir
   test "to_parquet/2 - with defaults", %{ldf: ldf, tmp_dir: tmp_dir} do
     path = Path.join([tmp_dir, "fossil_fuels.parquet"])

--- a/test/explorer/data_frame/ndjson_test.exs
+++ b/test/explorer/data_frame/ndjson_test.exs
@@ -209,4 +209,28 @@ defmodule Explorer.DataFrame.NDJSONTest do
              """
     end
   end
+
+  describe "to_ndjson/3 - cloud" do
+    setup do
+      s3_config = %FSS.S3.Config{
+        access_key_id: "test",
+        secret_access_key: "test",
+        endpoint: "http://localhost:4566",
+        region: "us-east-1"
+      }
+
+      [df: Explorer.Datasets.wine(), s3_config: s3_config]
+    end
+
+    @tag :cloud_integration
+    test "writes a NDJSON file to S3", %{df: df, s3_config: s3_config} do
+      path = "s3://test-bucket/test-writes/wine-#{System.monotonic_time()}.ndjson"
+
+      assert :ok = DF.to_ndjson(df, path, config: s3_config)
+
+      # When we have the reader, we can activate this assertion.
+      # saved_df = DF.from_ipc!(path, config: config)
+      # assert DF.to_columns(saved_df) == DF.to_columns(Explorer.Datasets.wine())
+    end
+  end
 end

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -228,7 +228,7 @@ defmodule Explorer.DataFrame.ParquetTest do
     end
   end
 
-  describe "to_parquet/2 - cloud" do
+  describe "to_parquet/3 - cloud" do
     setup do
       [df: Explorer.Datasets.wine()]
     end


### PR DESCRIPTION
This PR adds support for writing to S3 using the following APIs:

- [x] `DF.to_csv/3` for eager dataframes.
- [x] `DF.to_ipc/3` for eager dataframes.
- [x] `DF.to_ipc_stream/3` for eager dataframes.
- [x] `DF.to_ndjson/3` for eager dataframes.
- [x] `DF.to_parquet/3` for lazy dataframes, using the eager backend. 
- [x] `DF.to_ipc/3` for lazy dataframes, using the eager backend. 

This PR carries some improvements regarding compression selection in the Rust side. It also includes a small refactor
to easily build the S3 object store needed for the CloudWriter.

This follows https://github.com/elixir-explorer/explorer/pull/665 and https://github.com/elixir-explorer/explorer/pull/653