### PR TITLE
Convert numeric values to series early

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -519,16 +519,9 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def select(%Series{} = predicate, on_true, on_false) do
+  def select(%Series{} = predicate, %{dtype: dtype} = on_true, on_false) do
     args = [series_or_lazy_series!(predicate) | binary_args(on_true, on_false)]
     data = new(:select, args, aggregations?(args))
-
-    dtype =
-      case {on_true, on_false} do
-        {%Series{dtype: dtype}, _} -> dtype
-        {_, %Series{dtype: dtype}} -> dtype
-        _ -> Explorer.Shared.check_types!([on_true])
-      end
 
     dtype =
       if dtype in [:float, :integer] do

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -186,17 +186,6 @@ defmodule Explorer.PolarsBackend.Series do
     Shared.apply_series(predicate, :s_select, [on_true.data, on_false.data])
   end
 
-  def select(%Series{} = predicate, %Series{} = on_true, on_false),
-    do: select(predicate, on_true, to_series(on_false, on_true))
-
-  def select(%Series{} = predicate, on_true, %Series{} = on_false),
-    do: select(predicate, to_series(on_true, on_false), on_false)
-
-  def select(%Series{} = predicate, on_true, on_false) do
-    on_true = from_list([on_true], Explorer.Shared.check_types!([on_true]))
-    select(predicate, on_true, on_false)
-  end
-
   # Aggregation
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -245,16 +245,11 @@ defmodule Explorer.PolarsBackend.Series do
 
   @impl true
   def correlation(left, right, ddof),
-    do:
-      Shared.apply_series(to_series(left, right), :s_correlation, [
-        to_polars_series(right, left),
-        ddof
-      ])
+    do: Shared.apply_series(matching_size!(left, right), :s_correlation, [right.data, ddof])
 
   @impl true
   def covariance(left, right),
-    do:
-      Shared.apply_series(to_series(left, right), :s_covariance, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_covariance, [right.data])
 
   # Cumulative
 
@@ -284,39 +279,38 @@ defmodule Explorer.PolarsBackend.Series do
 
   @impl true
   def add(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_add, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_add, [right.data])
 
   @impl true
   def subtract(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_subtract, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_subtract, [right.data])
 
   @impl true
   def multiply(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_multiply, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_multiply, [right.data])
 
   @impl true
   def divide(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_divide, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_divide, [right.data])
 
   @impl true
   def quotient(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_quotient, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_quotient, [right.data])
 
   @impl true
   def remainder(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_remainder, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_remainder, [right.data])
 
   @impl true
   def pow(left, right),
-    do: Shared.apply_series(to_series(left, right), :s_pow, [to_polars_series(right, left)])
+    do: Shared.apply_series(matching_size!(left, right), :s_pow, [right.data])
 
   @impl true
   def log(%Series{} = argument), do: Shared.apply_series(argument, :s_log_natural, [])
 
   @impl true
-  def log(%Series{} = argument, base) when is_numerical(base) do
-    Shared.apply_series(argument, :s_log, [base])
-  end
+  def log(%Series{} = argument, base) when is_numerical(base),
+    do: Shared.apply_series(argument, :s_log, [base])
 
   @impl true
   def exp(%Series{} = s), do: Shared.apply_series(s, :s_exp, [])

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1220,15 +1220,14 @@ defmodule Explorer.Series do
           on_false :: Series.t() | inferable_scalar()
         ) ::
           Series.t()
-  def select(
-        %Series{dtype: predicate_dtype} = predicate,
-        %Series{dtype: on_true_dtype} = on_true,
-        %Series{dtype: on_false_dtype} = on_false
-      ) do
+  def select(%Series{dtype: predicate_dtype} = predicate, on_true, on_false) do
     if predicate_dtype != :boolean do
       raise ArgumentError,
             "Explorer.Series.select/3 expect the first argument to be a series of booleans, got: #{inspect(predicate_dtype)}"
     end
+
+    %Series{dtype: on_true_dtype} = on_true = maybe_from_list(on_true)
+    %Series{dtype: on_false_dtype} = on_false = maybe_from_list(on_false)
 
     cond do
       K.and(is_numeric_dtype(on_true_dtype), is_numeric_dtype(on_false_dtype)) ->
@@ -1242,9 +1241,8 @@ defmodule Explorer.Series do
     end
   end
 
-  def select(%Series{} = predicate, on_true, on_false) do
-    apply_series_list(:select, [predicate, on_true, on_false])
-  end
+  defp maybe_from_list(%Series{} = series), do: series
+  defp maybe_from_list(other), do: from_list([other])
 
   @doc """
   Returns a random sample of the series.

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2602,22 +2602,6 @@ defmodule Explorer.SeriesTest do
       assert Series.format([s1, " / ", s2, " - ", s3, " / ", s4]) |> Series.to_list() ==
                ["a / e - i / m", "b / f - j / n", nil, "d / h - l / p"]
     end
-
-    test "with series that have different sizes" do
-      s1 = Series.from_list([1, 2, 3])
-      s2 = Series.from_list([3, 2, 1, 4])
-
-      assert_raise ArgumentError,
-                   "series must either have the same size or one of them must have size of 1, got: 3 and 4",
-                   fn -> Series.pow(s1, s2) end
-
-      s1 = Series.from_list([1, 2, 3, 4])
-      s2 = Series.from_list([3, 2, 1])
-
-      assert_raise ArgumentError,
-                   "series must either have the same size or one of them must have size of 1, got: 4 and 3",
-                   fn -> Series.pow(s1, s2) end
-    end
   end
 
   describe "sample/2" do
@@ -3788,13 +3772,11 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list(["a", "b"])
 
       assert_raise ArgumentError,
-                   "Explorer.Series.correlation/3 not implemented for dtype :string. " <>
-                     "Valid dtypes are [:integer, :float]",
+                   "cannot invoke Explorer.Series.correlation/3 with mismatched dtypes: :float and :string",
                    fn -> Series.correlation(s1, s2) end
 
       assert_raise ArgumentError,
-                   "Explorer.Series.covariance/2 not implemented for dtype :string. " <>
-                     "Valid dtypes are [:integer, :float]",
+                   "cannot invoke Explorer.Series.covariance/2 with mismatched dtypes: :float and :string",
                    fn -> Series.covariance(s1, s2) end
     end
   end


### PR DESCRIPTION
To be merged after #683.

We can also do similar work for comparison operators, effectively removing the need for `to_series`/`to_polars_series` in the Explorer.PolarsBackend.Series.