### PR TITLE
Fixes a documentation typo

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -4774,7 +4774,7 @@ defmodule Explorer.Series do
     do: dtype_error("is_infinite/1", dtype, [:float])
 
   @doc """
-  Returns a mask of infinite values.
+  Returns a mask of nan values.
 
   ## Examples
 


### PR DESCRIPTION
Before:

<img width="332" alt="Screen Shot 2023-08-24 at 3 53 01 PM" src="https://github.com/elixir-explorer/explorer/assets/37887/3cc2ee66-c706-450f-a024-802f5aad3204">

After:

<img width="278" alt="Screen Shot 2023-08-24 at 3 53 42 PM" src="https://github.com/elixir-explorer/explorer/assets/37887/b1950df4-6fbf-45e0-85be-01fa6a48e4d4">


