### PR TITLE
Adds test showing :nif_not_loaded from DF.mutate_with using Series.is_nan

### DIFF
--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -655,6 +655,36 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b"]
       assert df1.dtypes == %{"a" => :float, "b" => :string}
     end
+
+    test "changes a column with boolean series and select" do
+      df = DF.new(%{a: Series.from_list([0.2, :nan])})
+
+      # mutate_with works with Series.equal
+      df =
+        DF.mutate_with(df, fn ldf ->
+          updated =
+            ldf["a"]
+            |> Series.equal(0.2)
+            |> Series.select(nil, ldf["a"])
+
+          [a: updated]
+        end)
+
+      assert DF.to_columns(df, atom_keys: true) == %{a: [nil, :nan]}
+
+      # mutate_with works with Series.is_nan
+      df =
+        DF.mutate_with(df, fn ldf ->
+          updated =
+            ldf["a"]
+            |> Series.is_nan()
+            |> Series.select(nil, ldf["a"])
+
+          [a: updated]
+        end)
+
+      assert DF.to_columns(df, atom_keys: true) == %{a: [0.2, nil]}
+    end
   end
 
   describe "mutate/2" do


### PR DESCRIPTION
*** CANNOT BE MERGED AS IS ***

Adds a test that generates `:nif_not_loaded` when `Series.is_nan` is used in `Dataframe.mutate_with`.

I apologize for creating PRs that are incomplete (only a failing test). 😳

Thank you for the amazing Explorer!

```
test mutate_with/2 changes a column with boolean series and select (Explorer.DataFrameTest)
     test/explorer/data_frame_test.exs:659
     ** (ErlangError) Erlang error: :nif_not_loaded
     code: DF.mutate_with(df, fn ldf ->
     stacktrace:
       :erlang.nif_error(:nif_not_loaded)
       (explorer 0.7.0-dev) lib/explorer/polars_backend/native.ex:366: Explorer.PolarsBackend.Native.err/0
       (explorer 0.7.0-dev) Explorer.PolarsBackend.Expression.to_expr/1
       (explorer 0.7.0-dev) lib/explorer/polars_backend/data_frame.ex:629: anonymous fn/2 in Explorer.PolarsBackend.DataFrame.mutate_with/3
       (elixir 1.14.5) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
       (explorer 0.7.0-dev) lib/explorer/polars_backend/data_frame.ex:627: Explorer.PolarsBackend.DataFrame.mutate_with/3
       test/explorer/data_frame_test.exs:677: (test)
```