### PR TITLE
Support duration-related Polars fixes in exprs

### DIFF
--- a/lib/explorer/backend/lazy_frame.ex
+++ b/lib/explorer/backend/lazy_frame.ex
@@ -73,7 +73,7 @@ defmodule Explorer.Backend.LazyFrame do
   @impl true
   def pull(df, column) do
     dtype_for_column = df.dtypes[column]
-    data = LazySeries.new(:column, [column])
+    data = LazySeries.new(:column, [column], dtype_for_column)
     Backend.Series.new(data, dtype_for_column)
   end
 

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -9,11 +9,11 @@ defmodule Explorer.Backend.LazySeries do
 
   @behaviour Explorer.Backend.Series
 
-  defstruct op: nil, args: [], aggregation: false
+  defstruct op: nil, args: [], dtype: nil, aggregation: false
 
   @valid_dtypes Explorer.Shared.dtypes()
 
-  @type t :: %__MODULE__{op: atom(), args: list(), aggregation: boolean()}
+  @type t :: %__MODULE__{op: atom(), args: list(), dtype: any(), aggregation: boolean()}
 
   @operations [
     # Element-wise

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2800,34 +2800,34 @@ defmodule Explorer.DataFrame do
 
           number when is_number(number) ->
             dtype = if is_integer(number), do: :integer, else: :float
-            lazy_s = LazySeries.new(:to_lazy, [number])
+            lazy_s = LazySeries.new(:to_lazy, [number], dtype)
 
             Explorer.Backend.Series.new(lazy_s, dtype)
 
           string when is_binary(string) ->
-            lazy_s = LazySeries.new(:to_lazy, [string])
+            lazy_s = LazySeries.new(:to_lazy, [string], :string)
 
             Explorer.Backend.Series.new(lazy_s, :string)
 
           boolean when is_boolean(boolean) ->
-            lazy_s = LazySeries.new(:to_lazy, [boolean])
+            lazy_s = LazySeries.new(:to_lazy, [boolean], :boolean)
 
             Explorer.Backend.Series.new(lazy_s, :boolean)
 
           date = %Date{} ->
-            lazy_s = LazySeries.new(:to_lazy, [date])
+            lazy_s = LazySeries.new(:to_lazy, [date], :date)
 
             Explorer.Backend.Series.new(lazy_s, :date)
 
           datetime = %NaiveDateTime{} ->
-            lazy_s = LazySeries.new(:to_lazy, [datetime])
+            lazy_s = LazySeries.new(:to_lazy, [datetime], {:datetime, :microsecond})
 
             Explorer.Backend.Series.new(lazy_s, {:datetime, :microsecond})
 
-          duration = %Explorer.Duration{} ->
-            lazy_s = LazySeries.new(:to_lazy, [duration])
+          duration = %Explorer.Duration{precision: precision} ->
+            lazy_s = LazySeries.new(:to_lazy, [duration], {:datetime, precision})
 
-            Explorer.Backend.Series.new(lazy_s, {:datetime, duration.precision})
+            Explorer.Backend.Series.new(lazy_s, {:datetime, precision})
 
           other ->
             raise ArgumentError,

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -13,7 +13,6 @@ defmodule Explorer.PolarsBackend.Expression do
   @type t :: %__MODULE__{resource: reference()}
 
   @all_expressions [
-    add: 2,
     all_equal: 2,
     argmax: 1,
     argmin: 1,
@@ -29,7 +28,6 @@ defmodule Explorer.PolarsBackend.Expression do
     minute: 1,
     second: 1,
     distinct: 1,
-    divide: 2,
     equal: 2,
     exp: 1,
     abs: 1,
@@ -50,7 +48,6 @@ defmodule Explorer.PolarsBackend.Expression do
     mean: 1,
     median: 1,
     min: 1,
-    multiply: 2,
     n_distinct: 1,
     nil_count: 1,
     not_equal: 2,
@@ -130,6 +127,9 @@ defmodule Explorer.PolarsBackend.Expression do
   ]
 
   @custom_expressions [
+    add: 2,
+    divide: 2,
+    multiply: 2,
     cast: 2,
     fill_missing_with_strategy: 2,
     from_list: 2,
@@ -241,6 +241,47 @@ defmodule Explorer.PolarsBackend.Expression do
     end
   end
 
+  def to_expr(%LazySeries{op: :add, args: [left, right]}) do
+    # `duration + date` is not supported by polars for some reason.
+    # `date + duration` is, so we're swapping arguments as a work around.
+    [left, right] =
+      case [dtype(left), dtype(right)] do
+        [{:duration, _}, :date] -> [right, left]
+        _ -> [left, right]
+      end
+
+    Native.expr_add(to_expr(left), to_expr(right))
+  end
+
+  def to_expr(%LazySeries{op: :multiply, args: [left, right] = args}) do
+    expr = Native.expr_multiply(to_expr(left), to_expr(right))
+
+    input_dtypes = Enum.map(args, &dtype/1)
+    duration_dtype = Enum.find(input_dtypes, &match?({:duration, _}, &1))
+    numeric? = Enum.any?(input_dtypes, &(&1 in [:integer, :float]))
+
+    if duration_dtype && numeric? do
+      wrap_in_cast(expr, duration_dtype)
+    else
+      expr
+    end
+  end
+
+  def to_expr(%LazySeries{op: :divide, args: [left, right]}) do
+    expr = Native.expr_divide(to_expr(left), to_expr(right))
+
+    cond do
+      match?({:duration, _}, dtype(left)) and dtype(right) in [:integer, :float] ->
+        wrap_in_cast(expr, dtype(left))
+
+      match?({:duration, _}, dtype(right)) ->
+        raise(ArgumentError, "cannot divide by duration")
+
+      true ->
+        expr
+    end
+  end
+
   for {op, arity} <- @all_expressions do
     args = Macro.generate_arguments(arity, __MODULE__)
 
@@ -276,5 +317,18 @@ defmodule Explorer.PolarsBackend.Expression do
   # Only for inspecting the expression in tests
   def describe_filter_plan(%DataFrame{data: polars_df}, %__MODULE__{} = expression) do
     Native.expr_describe_filter_plan(polars_df, expression)
+  end
+
+  defp wrap_in_cast(lazy_series_expr, dtype) do
+    dtype_expr = Explorer.Shared.dtype_to_string(dtype)
+    Native.expr_cast(lazy_series_expr, dtype_expr)
+  end
+
+  defp dtype(%LazySeries{dtype: dtype}), do: dtype
+
+  defp dtype(%PolarsSeries{} = polars_series) do
+    with {:ok, dtype} <- Native.s_dtype(polars_series) do
+      Explorer.PolarsBackend.Shared.normalise_dtype(dtype)
+    end
   end
 end

--- a/test/explorer/backend/lazy_series_test.exs
+++ b/test/explorer/backend/lazy_series_test.exs
@@ -5,7 +5,7 @@ defmodule Explorer.Backend.LazySeriesTest do
   alias Explorer.Backend.LazySeries
 
   test "inspect/2 gives a basic hint of lazy series" do
-    data = LazySeries.new(:column, ["col_a"])
+    data = LazySeries.new(:column, ["col_a"], :unknown)
     opaque_series = Backend.Series.new(data, :integer)
 
     assert inspect(opaque_series) ==
@@ -19,8 +19,8 @@ defmodule Explorer.Backend.LazySeriesTest do
   end
 
   test "inspect/2 with nested operations" do
-    col = LazySeries.new(:column, ["col_a"])
-    equal = LazySeries.new(:equal, [col, 5])
+    col = LazySeries.new(:column, ["col_a"], :unknown)
+    equal = LazySeries.new(:equal, [col, 5], :boolean)
 
     series = Backend.Series.new(equal, :boolean)
 
@@ -35,8 +35,8 @@ defmodule Explorer.Backend.LazySeriesTest do
   end
 
   test "inspect/2 with single-element series" do
-    col = LazySeries.new(:column, ["col_a"])
-    equal = LazySeries.new(:equal, [col, Explorer.Series.from_list([5]).data])
+    col = LazySeries.new(:column, ["col_a"], :unknown)
+    equal = LazySeries.new(:equal, [col, Explorer.Series.from_list([5]).data], :boolean)
 
     series = Backend.Series.new(equal, :boolean)
 
@@ -51,8 +51,8 @@ defmodule Explorer.Backend.LazySeriesTest do
   end
 
   test "inspect/2 with nested series" do
-    col = LazySeries.new(:column, ["col_a"])
-    equal = LazySeries.new(:equal, [col, Explorer.Series.from_list([1, 2, 3]).data])
+    col = LazySeries.new(:column, ["col_a"], :unknown)
+    equal = LazySeries.new(:equal, [col, Explorer.Series.from_list([1, 2, 3]).data], :boolean)
 
     series = Backend.Series.new(equal, :boolean)
 


### PR DESCRIPTION
## Description

This PR attempts to fix the expr-related inconsistencies introduced by: https://github.com/elixir-explorer/explorer/pull/696.

Reminder: Polars was returning unexpected dtypes for duration arithmetic. We fixed it for the eager series functions but got stuck on doing the same thing for the lazy ones. The issue was that we didn't have the dtype info we needed for an analogous fix.

* Where we left it:
    * https://github.com/elixir-explorer/explorer/pull/696#issuecomment-1697566043
* Discussion on possible fixes:
    * https://github.com/elixir-explorer/explorer/pull/696#issuecomment-1697957315

## Approach

I noticed that, so far as I could tell, every time we made a `LazySeries` struct we also happened to have the `dtype` on hand. So tried just adding a `dtype` field to the `LazySeries` struct and it seemed to work. The only questionable thing I found was a test that I'll call out below.

With a `:dtype` field on the `LazySeries` struct, it was straightforward to add a patch to `expression.ex`.

## Main Question

**Is this actually something that's safe to do?**

I haven't audited enough of the code to know if we'll actually always have the dtype info. But it sure seemed like it.