### PR TITLE
Series callbacks accept `out_dtype` as input

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -383,9 +383,7 @@ defmodule Explorer.Backend.LazySeries do
 
   for op <- @basic_arithmetic_operations do
     @impl true
-    def unquote(op)(%Series{} = left, %Series{} = right) do
-      dtype = Explorer.Shared.cast_to_arithmetic(unquote(op), dtype(left), dtype(right))
-
+    def unquote(op)(%Series{} = left, %Series{} = right, dtype) do
       args = [data!(left), data!(right)]
       data = new(unquote(op), args, dtype, aggregations?(args))
 

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -383,7 +383,7 @@ defmodule Explorer.Backend.LazySeries do
 
   for op <- @basic_arithmetic_operations do
     @impl true
-    def unquote(op)(%Series{} = left, %Series{} = right, dtype) do
+    def unquote(op)(dtype, %Series{} = left, %Series{} = right) do
       args = [data!(left), data!(right)]
       data = new(unquote(op), args, dtype, aggregations?(args))
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -11,7 +11,16 @@ defmodule Explorer.Backend.Series do
   @type lazy_s :: Explorer.Series.lazy_t()
   @type df :: Explorer.DataFrame.t()
   @type dtype :: Explorer.Series.dtype()
-  @type valid_types :: number() | boolean() | String.t() | Date.t() | Time.t() | NaiveDateTime.t()
+
+  @type valid_types ::
+          number()
+          | boolean()
+          | String.t()
+          | Date.t()
+          | Time.t()
+          | NaiveDateTime.t()
+          | Explorer.Duration.t()
+
   @type non_finite :: Explorer.Series.non_finite()
   @type option(type) :: type | nil
   # x - x is defined for type x.

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -23,8 +23,6 @@ defmodule Explorer.Backend.Series do
 
   @type non_finite :: Explorer.Series.non_finite()
   @type option(type) :: type | nil
-  # x - x is defined for type x.
-  @type diffable :: number() | Date.t() | NaiveDateTime.t() | Explorer.Duration.t()
 
   # Conversion
 
@@ -112,10 +110,10 @@ defmodule Explorer.Backend.Series do
 
   # Arithmetic
 
-  @callback add(s | diffable(), s | diffable(), out_dtype :: dtype()) :: s
-  @callback subtract(s | diffable(), s | diffable(), out_dtype :: dtype()) :: s
-  @callback multiply(s | diffable(), s | diffable(), out_dtype :: dtype()) :: s
-  @callback divide(s | diffable(), s | number(), out_dtype :: dtype()) :: s
+  @callback add(out_dtype :: dtype(), s, s) :: s
+  @callback subtract(out_dtype :: dtype(), s, s) :: s
+  @callback multiply(out_dtype :: dtype(), s, s) :: s
+  @callback divide(out_dtype :: dtype(), s, s) :: s
   @callback quotient(s | neg_integer() | pos_integer(), s | neg_integer() | pos_integer()) :: s
   @callback remainder(s | neg_integer() | pos_integer(), s | neg_integer() | pos_integer()) :: s
   @callback pow(s | number(), s | number()) :: s

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -14,6 +14,8 @@ defmodule Explorer.Backend.Series do
   @type valid_types :: number() | boolean() | String.t() | Date.t() | Time.t() | NaiveDateTime.t()
   @type non_finite :: Explorer.Series.non_finite()
   @type option(type) :: type | nil
+  # x - x is defined for type x.
+  @type diffable :: number() | Date.t() | NaiveDateTime.t() | Explorer.Duration.t()
 
   # Conversion
 
@@ -101,10 +103,10 @@ defmodule Explorer.Backend.Series do
 
   # Arithmetic
 
-  @callback add(s | number(), s | number()) :: s
-  @callback subtract(s | number(), s | number()) :: s
-  @callback multiply(s | number(), s | number()) :: s
-  @callback divide(s | number(), s | number()) :: s
+  @callback add(s | diffable(), s | diffable(), out_dtype :: dtype()) :: s
+  @callback subtract(s | diffable(), s | diffable(), out_dtype :: dtype()) :: s
+  @callback multiply(s | diffable(), s | diffable(), out_dtype :: dtype()) :: s
+  @callback divide(s | diffable(), s | number(), out_dtype :: dtype()) :: s
   @callback quotient(s | neg_integer() | pos_integer(), s | neg_integer() | pos_integer()) :: s
   @callback remainder(s | neg_integer() | pos_integer(), s | neg_integer() | pos_integer()) :: s
   @callback pow(s | number(), s | number()) :: s

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -279,14 +279,14 @@ defmodule Explorer.PolarsBackend.Series do
   # Arithmetic
 
   @impl true
-  def add(left, right, out_dtype) do
+  def add(out_dtype, left, right) do
     left = matching_size!(left, right)
 
     # `duration + date` is not supported by polars for some reason.
     # `date + duration` is, so we're swapping arguments as a work around.
     [left, right] =
-      case {dtype(left), dtype(right), out_dtype} do
-        {{:duration, _}, :date, :date} -> [right, left]
+      case {out_dtype, dtype(left), dtype(right)} do
+        {:date, {:duration, _}, :date} -> [right, left]
         _ -> [left, right]
       end
 
@@ -294,11 +294,11 @@ defmodule Explorer.PolarsBackend.Series do
   end
 
   @impl true
-  def subtract(left, right, _out_dtype),
+  def subtract(_out_dtype, left, right),
     do: Shared.apply_series(matching_size!(left, right), :s_subtract, [right.data])
 
   @impl true
-  def multiply(left, right, out_dtype) do
+  def multiply(out_dtype, left, right) do
     result = Shared.apply_series(matching_size!(left, right), :s_multiply, [right.data])
 
     # Polars currently returns inconsistent dtypes, e.g.:
@@ -313,7 +313,7 @@ defmodule Explorer.PolarsBackend.Series do
   end
 
   @impl true
-  def divide(left, right, out_dtype) do
+  def divide(out_dtype, left, right) do
     result = Shared.apply_series(matching_size!(left, right), :s_divide, [right.data])
 
     # Polars currently returns inconsistent dtypes, e.g.:

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -279,14 +279,14 @@ defmodule Explorer.PolarsBackend.Series do
   # Arithmetic
 
   @impl true
-  def add(left, right) do
+  def add(left, right, out_dtype) do
     left = matching_size!(left, right)
 
     # `duration + date` is not supported by polars for some reason.
     # `date + duration` is, so we're swapping arguments as a work around.
     [left, right] =
-      case {dtype(left), dtype(right)} do
-        {{:duration, _}, :date} -> [right, left]
+      case {dtype(left), dtype(right), out_dtype} do
+        {{:duration, _}, :date, :date} -> [right, left]
         _ -> [left, right]
       end
 
@@ -294,36 +294,34 @@ defmodule Explorer.PolarsBackend.Series do
   end
 
   @impl true
-  def subtract(left, right),
+  def subtract(left, right, _out_dtype),
     do: Shared.apply_series(matching_size!(left, right), :s_subtract, [right.data])
 
   @impl true
-  def multiply(left, right) do
+  def multiply(left, right, out_dtype) do
     result = Shared.apply_series(matching_size!(left, right), :s_multiply, [right.data])
-    expected_dtype = Explorer.Shared.cast_to_arithmetic(:multiply, dtype(left), dtype(right))
 
     # Polars currently returns inconsistent dtypes, e.g.:
     #   * `integer * duration -> duration` when `integer` is a scalar
     #   * `integer * duration ->  integer` when `integer` is a series
     # We need to return duration in these cases, so we need an additional cast.
-    if match?({:duration, _}, expected_dtype) and expected_dtype != dtype(result) do
-      cast(result, expected_dtype)
+    if match?({:duration, _}, out_dtype) and out_dtype != dtype(result) do
+      cast(result, out_dtype)
     else
       result
     end
   end
 
   @impl true
-  def divide(left, right) do
+  def divide(left, right, out_dtype) do
     result = Shared.apply_series(matching_size!(left, right), :s_divide, [right.data])
-    expected_dtype = Explorer.Shared.cast_to_arithmetic(:divide, dtype(left), dtype(right))
 
     # Polars currently returns inconsistent dtypes, e.g.:
     #   * `duration / integer -> duration` when `integer` is a scalar
     #   * `duration / integer ->  integer` when `integer` is a series
     # We need to return duration in these cases, so we need an additional cast.
-    if match?({:duration, _}, expected_dtype) and expected_dtype != dtype(result) do
-      cast(result, expected_dtype)
+    if match?({:duration, _}, out_dtype) and out_dtype != dtype(result) do
+      cast(result, out_dtype)
     else
       result
     end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2574,12 +2574,23 @@ defmodule Explorer.Series do
   def add(left, right) do
     [left, right] = cast_for_arithmetic("add/2", [left, right])
 
-    if _dtype = Shared.cast_to_arithmetic(:add, dtype(left), dtype(right)) do
-      apply_series_list(:add, [left, right])
+    if out_dtype = cast_to_add(dtype(left), dtype(right)) do
+      apply_series_list(:add, [left, right, out_dtype])
     else
       dtype_mismatch_error("add/2", left, right)
     end
   end
+
+  defp cast_to_add(:integer, :integer), do: :integer
+  defp cast_to_add(:integer, :float), do: :float
+  defp cast_to_add(:float, :integer), do: :float
+  defp cast_to_add(:float, :float), do: :float
+  defp cast_to_add(:date, {:duration, _}), do: :date
+  defp cast_to_add({:duration, _}, :date), do: :date
+  defp cast_to_add({:datetime, p}, {:duration, p}), do: {:datetime, p}
+  defp cast_to_add({:duration, p}, {:datetime, p}), do: {:datetime, p}
+  defp cast_to_add({:duration, p}, {:duration, p}), do: {:duration, p}
+  defp cast_to_add(_, _), do: nil
 
   @doc """
   Subtracts right from left, element-wise.
@@ -2629,12 +2640,23 @@ defmodule Explorer.Series do
   def subtract(left, right) do
     [left, right] = cast_for_arithmetic("subtract/2", [left, right])
 
-    if _dtype = Shared.cast_to_arithmetic(:subtract, dtype(left), dtype(right)) do
-      apply_series_list(:subtract, [left, right])
+    if out_dtype = cast_to_subtract(dtype(left), dtype(right)) do
+      apply_series_list(:subtract, [left, right, out_dtype])
     else
       dtype_mismatch_error("subtract/2", left, right)
     end
   end
+
+  defp cast_to_subtract(:integer, :integer), do: :integer
+  defp cast_to_subtract(:integer, :float), do: :float
+  defp cast_to_subtract(:float, :integer), do: :float
+  defp cast_to_subtract(:float, :float), do: :float
+  defp cast_to_subtract(:date, :date), do: {:duration, :millisecond}
+  defp cast_to_subtract(:date, {:duration, _}), do: :date
+  defp cast_to_subtract({:datetime, p}, {:datetime, p}), do: {:duration, p}
+  defp cast_to_subtract({:datetime, p}, {:duration, p}), do: {:datetime, p}
+  defp cast_to_subtract({:duration, p}, {:duration, p}), do: {:duration, p}
+  defp cast_to_subtract(_, _), do: nil
 
   @doc """
   Multiplies left and right, element-wise.
@@ -2675,12 +2697,22 @@ defmodule Explorer.Series do
   def multiply(left, right) do
     [left, right] = cast_for_arithmetic("multiply/2", [left, right])
 
-    if _dtype = Shared.cast_to_arithmetic(:multiply, dtype(left), dtype(right)) do
-      apply_series_list(:multiply, [left, right])
+    if out_dtype = cast_to_multiply(dtype(left), dtype(right)) do
+      apply_series_list(:multiply, [left, right, out_dtype])
     else
       dtype_mismatch_error("multiply/2", left, right)
     end
   end
+
+  defp cast_to_multiply(:integer, :integer), do: :integer
+  defp cast_to_multiply(:integer, :float), do: :float
+  defp cast_to_multiply(:float, :integer), do: :float
+  defp cast_to_multiply(:float, :float), do: :float
+  defp cast_to_multiply(:integer, {:duration, p}), do: {:duration, p}
+  defp cast_to_multiply({:duration, p}, :integer), do: {:duration, p}
+  defp cast_to_multiply(:float, {:duration, p}), do: {:duration, p}
+  defp cast_to_multiply({:duration, p}, :float), do: {:duration, p}
+  defp cast_to_multiply(_, _), do: nil
 
   @doc """
   Divides left by right, element-wise.
@@ -2736,8 +2768,8 @@ defmodule Explorer.Series do
   def divide(left, right) do
     [left, right] = cast_for_arithmetic("divide/2", [left, right])
 
-    if _dtype = Shared.cast_to_arithmetic(:divide, dtype(left), dtype(right)) do
-      apply_series_list(:divide, [left, right])
+    if out_dtype = cast_to_divide(dtype(left), dtype(right)) do
+      apply_series_list(:divide, [left, right, out_dtype])
     else
       case dtype(right) do
         {:duration, _} -> raise(ArgumentError, "cannot divide by duration")
@@ -2745,6 +2777,14 @@ defmodule Explorer.Series do
       end
     end
   end
+
+  defp cast_to_divide(:integer, :integer), do: :float
+  defp cast_to_divide(:integer, :float), do: :float
+  defp cast_to_divide(:float, :integer), do: :float
+  defp cast_to_divide(:float, :float), do: :float
+  defp cast_to_divide({:duration, p}, :integer), do: {:duration, p}
+  defp cast_to_divide({:duration, p}, :float), do: {:duration, p}
+  defp cast_to_divide(_, _), do: nil
 
   @doc """
   Raises a numeric series to the power of the exponent.

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2575,7 +2575,7 @@ defmodule Explorer.Series do
     [left, right] = cast_for_arithmetic("add/2", [left, right])
 
     if out_dtype = cast_to_add(dtype(left), dtype(right)) do
-      apply_series_list(:add, [left, right, out_dtype])
+      apply_series_list(:add, [out_dtype, left, right])
     else
       dtype_mismatch_error("add/2", left, right)
     end
@@ -2641,7 +2641,7 @@ defmodule Explorer.Series do
     [left, right] = cast_for_arithmetic("subtract/2", [left, right])
 
     if out_dtype = cast_to_subtract(dtype(left), dtype(right)) do
-      apply_series_list(:subtract, [left, right, out_dtype])
+      apply_series_list(:subtract, [out_dtype, left, right])
     else
       dtype_mismatch_error("subtract/2", left, right)
     end
@@ -2698,7 +2698,7 @@ defmodule Explorer.Series do
     [left, right] = cast_for_arithmetic("multiply/2", [left, right])
 
     if out_dtype = cast_to_multiply(dtype(left), dtype(right)) do
-      apply_series_list(:multiply, [left, right, out_dtype])
+      apply_series_list(:multiply, [out_dtype, left, right])
     else
       dtype_mismatch_error("multiply/2", left, right)
     end
@@ -2769,7 +2769,7 @@ defmodule Explorer.Series do
     [left, right] = cast_for_arithmetic("divide/2", [left, right])
 
     if out_dtype = cast_to_divide(dtype(left), dtype(right)) do
-      apply_series_list(:divide, [left, right, out_dtype])
+      apply_series_list(:divide, [out_dtype, left, right])
     else
       case dtype(right) do
         {:duration, _} -> raise(ArgumentError, "cannot divide by duration")

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -218,51 +218,6 @@ defmodule Explorer.Shared do
   defp type(item, _type), do: raise(ArgumentError, "unsupported datatype: #{inspect(item)}")
 
   @doc """
-  The return dtype for the basic arithmetic operations: add, subtract, multiply, and divide.
-
-  This function assumes that the inputs have already had the highest precision enforced.
-  """
-  def cast_to_arithmetic(:add, :integer, :integer), do: :integer
-  def cast_to_arithmetic(:add, :integer, :float), do: :float
-  def cast_to_arithmetic(:add, :float, :integer), do: :float
-  def cast_to_arithmetic(:add, :float, :float), do: :float
-  def cast_to_arithmetic(:add, :date, {:duration, _}), do: :date
-  def cast_to_arithmetic(:add, {:duration, _}, :date), do: :date
-  def cast_to_arithmetic(:add, {:datetime, p}, {:duration, p}), do: {:datetime, p}
-  def cast_to_arithmetic(:add, {:duration, p}, {:datetime, p}), do: {:datetime, p}
-  def cast_to_arithmetic(:add, {:duration, p}, {:duration, p}), do: {:duration, p}
-  def cast_to_arithmetic(:add, _, _), do: nil
-
-  def cast_to_arithmetic(:subtract, :integer, :integer), do: :integer
-  def cast_to_arithmetic(:subtract, :integer, :float), do: :float
-  def cast_to_arithmetic(:subtract, :float, :integer), do: :float
-  def cast_to_arithmetic(:subtract, :float, :float), do: :float
-  def cast_to_arithmetic(:subtract, :date, :date), do: {:duration, :millisecond}
-  def cast_to_arithmetic(:subtract, :date, {:duration, _}), do: :date
-  def cast_to_arithmetic(:subtract, {:datetime, p}, {:datetime, p}), do: {:duration, p}
-  def cast_to_arithmetic(:subtract, {:datetime, p}, {:duration, p}), do: {:datetime, p}
-  def cast_to_arithmetic(:subtract, {:duration, p}, {:duration, p}), do: {:duration, p}
-  def cast_to_arithmetic(:subtract, _, _), do: nil
-
-  def cast_to_arithmetic(:multiply, :integer, :integer), do: :integer
-  def cast_to_arithmetic(:multiply, :integer, :float), do: :float
-  def cast_to_arithmetic(:multiply, :float, :integer), do: :float
-  def cast_to_arithmetic(:multiply, :float, :float), do: :float
-  def cast_to_arithmetic(:multiply, :integer, {:duration, p}), do: {:duration, p}
-  def cast_to_arithmetic(:multiply, {:duration, p}, :integer), do: {:duration, p}
-  def cast_to_arithmetic(:multiply, :float, {:duration, p}), do: {:duration, p}
-  def cast_to_arithmetic(:multiply, {:duration, p}, :float), do: {:duration, p}
-  def cast_to_arithmetic(:multiply, _, _), do: nil
-
-  def cast_to_arithmetic(:divide, :integer, :integer), do: :float
-  def cast_to_arithmetic(:divide, :integer, :float), do: :float
-  def cast_to_arithmetic(:divide, :float, :integer), do: :float
-  def cast_to_arithmetic(:divide, :float, :float), do: :float
-  def cast_to_arithmetic(:divide, {:duration, p}, :integer), do: {:duration, p}
-  def cast_to_arithmetic(:divide, {:duration, p}, :float), do: {:duration, p}
-  def cast_to_arithmetic(:divide, _, _), do: nil
-
-  @doc """
   Downcasts lists of mixed numeric types (float and int) to float.
   """
   def cast_numerics(list, type) when type == :numeric do


### PR DESCRIPTION
## Description

This PR changes several `Explorer.Backend.Series` callbacks to require the expected output dtype as one of the arguments. This change was made for:

  * `Series.add/2`
  * `Series.subtract/2`
  * `Series.multiply/2`
  * `Series.divide/2`

## Related Work

Closes: https://github.com/elixir-explorer/explorer/issues/702

## Notes

Reviewing `Explorer.Backend.Series`, I noticed a few categories WRT the output dtype:

`out_dtype`                  | Example
:--                          | :--
N/A (result is not a series) | `Series.dtype/1`
Known at compile time        | `Series.is_nil/1`
Always matches the input     | `Series.head/1`
More complicated             | `Series.add/2`

I could see requiring `out_dtype` as a generally useful pattern when defining callbacks. But I wasn't sure how often requiring `out_dtype` would actually help given the above categories, so I stuck to the 4 basic arithmetic operations with this PR.

How often do we think this pattern would be helpful?