### PR TITLE
Fix `Series.in/2` to work with series of the `:category` dtype

### DIFF
--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -104,6 +104,11 @@ defmodule Explorer.PolarsBackend.Series do
       when dtype in [:string, :category],
       do: Shared.apply_series(series, :s_categorise, [categories.data])
 
+  @impl true
+  def categorise(%Series{dtype: :string} = series, %Series{dtype: dtype} = categories)
+      when dtype in [:string, :category],
+      do: Shared.apply_series(series, :s_categorise, [categories.data])
+
   # Slice and dice
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1057,11 +1057,11 @@ defmodule Explorer.Series do
   def categories(%Series{dtype: dtype}), do: dtype_error("categories/1", dtype, [:category])
 
   @doc """
-  Categorise a series of integers according to `categories`.
+  Categorise a series of integers or strings according to `categories`.
 
-  This function receives a series of integers and convert them into the
-  categories specified by the second argument. The second argument can
-  be one of:
+  This function receives a series of integers or strings and convert them
+  into the categories specified by the second argument.
+  The second argument can be one of:
 
     * a series with dtype `:category`. The integers will be indexes into
       the categories of the given series (returned by `categories/1`)
@@ -1114,22 +1114,25 @@ defmodule Explorer.Series do
         category ["a", "c", nil, "a", "c", nil]
       >
 
+  Strings can be used as "indexes" to create a categorical series
+  with the intersection of members:
+
+      iex> strings = Explorer.Series.from_list(["a", "c", nil, "c", "b", "d"])
+      iex> Explorer.Series.categorise(strings, ["a", "b", "c"])
+      #Explorer.Series<
+        Polars[6]
+        category ["a", "c", nil, "c", "b", nil]
+      >
+
   """
   @doc type: :element_wise
-  def categorise(%Series{dtype: :integer} = series, %Series{dtype: dtype} = categories)
-      when K.in(dtype, [:string, :category]),
+  def categorise(%Series{dtype: l_dtype} = series, %Series{dtype: dtype} = categories)
+      when K.and(K.in(l_dtype, [:integer, :string]), K.in(dtype, [:string, :category])),
       do: apply_series(series, :categorise, [categories])
 
-  def categorise(%Series{dtype: :integer} = series, [head | _] = categories) when is_binary(head),
-    do: apply_series(series, :categorise, [from_list(categories, dtype: :string)])
-
-  def categorise(%Series{dtype: :string} = series, %Series{dtype: dtype} = categories)
-      when K.in(dtype, [:string, :category]),
-      do: apply_series(series, :categorise, [categories])
-
-  def categorise([head | _] = indexes, %Series{dtype: dtype} = categories)
-      when K.and(is_binary(head), K.in(dtype, [:string, :category])),
-      do: apply_series(from_list(indexes, dtype: :string), :categorise, [categories])
+  def categorise(%Series{dtype: l_dtype} = series, [head | _] = categories)
+      when K.and(K.in(l_dtype, [:integer, :string]), is_binary(head)),
+      do: apply_series(series, :categorise, [from_list(categories, dtype: :string)])
 
   # Slice and dice
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1123,6 +1123,10 @@ defmodule Explorer.Series do
   def categorise(%Series{dtype: :integer} = series, [head | _] = categories) when is_binary(head),
     do: apply_series(series, :categorise, [from_list(categories, dtype: :string)])
 
+  def categorise(%Series{dtype: :string} = series, %Series{dtype: dtype} = categories)
+      when K.in(dtype, [:string, :category]),
+      do: apply_series(series, :categorise, [categories])
+
   # Slice and dice
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1127,6 +1127,10 @@ defmodule Explorer.Series do
       when K.in(dtype, [:string, :category]),
       do: apply_series(series, :categorise, [categories])
 
+  def categorise([head | _] = indexes, %Series{dtype: dtype} = categories)
+      when K.and(is_binary(head), K.in(dtype, [:string, :category])),
+      do: apply_series(from_list(indexes, dtype: :string), :categorise, [categories])
+
   # Slice and dice
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1071,6 +1071,10 @@ defmodule Explorer.Series do
 
     * a list of strings. The integers will be indexes into the list
 
+  This is going to essentially "copy" the source of categories from the left series
+  to the right. All members from the left that are not present in the right hand-side
+  are going to be `nil`.
+
   If you have a series of strings and you want to convert them into categories,
   invoke `cast(series, :category)` instead.
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -548,6 +548,15 @@ pub fn s_in(s: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
         DataType::Date => s.date()?.is_in(&rhs)?,
         DataType::Time => s.time()?.is_in(&rhs)?,
         DataType::Datetime(_, _) => s.datetime()?.is_in(&rhs)?,
+        DataType::Categorical(Some(mapping)) => {
+            let l_logical = s.categorical()?.logical();
+
+            let r_casted = rhs.cast(&DataType::Categorical(Some(mapping.clone())))?;
+
+            let r_logical = r_casted.categorical()?.logical().clone().into_series();
+
+            l_logical.is_in(&r_logical)?
+        }
         dt => panic!("is_in/2 not implemented for {dt:?}"),
     };
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -572,20 +572,14 @@ pub fn s_in(s: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
 
                     l_logical.is_in(&r_logical)?
                 }
-                DataType::Categorical(Some(_rhs_mapping)) => {
-                    let mut r_ids: Vec<Option<u32>> = vec![];
-                    for opt in rhs.categorical()?.iter_str() {
-                        match opt {
-                            Some(slice) => {
-                                if let Some(id) = mapping.find(slice) {
-                                    r_ids.push(Some(id));
-                                }
-                            }
-                            None => r_ids.push(None),
-                        }
+                DataType::Categorical(Some(rhs_mapping)) => {
+                    if !mapping.same_src(rhs_mapping) {
+                        return Err(ExplorerError::Other(
+                            "cannot compare categories from different sources. See Explorer.Series.categorise/2".into(),
+                        ));
                     }
 
-                    let r_logical = Series::new("r_logical", r_ids);
+                    let r_logical = rhs.categorical()?.logical().clone().into_series();
 
                     l_logical.is_in(&r_logical)?
                 }

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1259,6 +1259,26 @@ defmodule Explorer.SeriesTest do
         Series.in(s1, s2)
       end
     end
+
+    @tag :skip
+    test "compare categories with strings" do
+      s = Series.from_list(["a", "b", "c", nil, "a"], dtype: :category)
+
+      assert Series.in(s, Series.from_list(["a", "b"])) |> Series.to_list() ==
+               [true, true, false, false, true]
+
+      assert Series.in(s, ["a"]) |> Series.to_list() == [true, false, false, false, true]
+
+      assert Series.in(s, ["z"]) |> IO.inspect() |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+
+      assert Series.in(s, ["a", "z"]) |> Series.to_list() == [true, false, false, false, true]
+    end
   end
 
   describe "iotype/1" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1323,9 +1323,9 @@ defmodule Explorer.SeriesTest do
                [true, false, false, true, true]
     end
 
-    test "compare categories with categories" do
+    test "compare categories with categories that are incompatible" do
       s = Series.from_list(["a", "b", "c", "a"], dtype: :category)
-      s1 = Series.from_list(["a", "b", "z"], dtype: :category)
+      s1 = Series.from_list(["a", "b", "z"]) |> Series.categorise(s)
 
       assert Series.in(s, s1) |> Series.to_list() ==
                [true, true, false, true]
@@ -1333,15 +1333,15 @@ defmodule Explorer.SeriesTest do
 
     test "compare categories with categories and nil on left-hand side" do
       s = Series.from_list(["a", nil, "c", "a"], dtype: :category)
-      s1 = Series.from_list(["a", "b", "z"], dtype: :category)
+      s1 = Series.from_list(["a", "c"]) |> Series.categorise(s)
 
       assert Series.in(s, s1) |> Series.to_list() ==
-               [true, false, false, true]
+               [true, false, true, true]
     end
 
     test "compare categories with categories and nil on right-hand side" do
       s = Series.from_list(["a", "b", "c", "a"], dtype: :category)
-      s1 = Series.from_list(["a", "b", nil], dtype: :category)
+      s1 = Series.from_list(["a", "b", nil]) |> Series.categorise(s)
 
       assert Series.in(s, s1) |> Series.to_list() ==
                [true, true, false, true]
@@ -1349,7 +1349,7 @@ defmodule Explorer.SeriesTest do
 
     test "compare categories with categories and nil on both sides" do
       s = Series.from_list(["a", "b", "c", "a", nil], dtype: :category)
-      s1 = Series.from_list(["a", "b", nil], dtype: :category)
+      s1 = Series.from_list(["a", "b", nil]) |> Series.categorise(s)
 
       assert Series.in(s, s1) |> Series.to_list() ==
                [true, true, false, true, true]
@@ -1357,7 +1357,7 @@ defmodule Explorer.SeriesTest do
 
     test "compare categories with categories that are equivalent" do
       s = Series.from_list(["a", "b", "c", "a", nil], dtype: :category)
-      s1 = Series.from_list(["a", "b", "c", nil], dtype: :category)
+      s1 = Series.from_list(["a", "b", "c", nil]) |> Series.categorise(s)
 
       assert Series.in(s, s1) |> Series.to_list() ==
                [true, true, true, true, true]
@@ -1367,8 +1367,11 @@ defmodule Explorer.SeriesTest do
       s = Series.from_list(["a", "b", "c", "a", nil], dtype: :category)
       s1 = Series.from_list(["z"], dtype: :category)
 
-      assert Series.in(s, s1) |> Series.to_list() ==
-               [false, false, false, false, false]
+      assert_raise RuntimeError,
+                   ~s/Generic Error: cannot compare categories from different sources. See Explorer.Series.categorise\/2/,
+                   fn ->
+                     Series.in(s, s1)
+                   end
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3040,6 +3040,46 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(categorized) == ["a", "c", "b", "a", "c", nil, "b", nil, nil]
       assert Series.dtype(categorized) == :category
     end
+
+    test "takes string series and categorise with categorical series" do
+      categories = Series.from_list(["a", "b", "c"], dtype: :category)
+
+      indexes = Series.from_list(["c", "b", "a", "a", "c"])
+      categorized = Series.categorise(indexes, categories)
+
+      assert Series.to_list(categorized) == ["c", "b", "a", "a", "c"]
+      assert Series.dtype(categorized) == :category
+    end
+
+    test "takes string series containing nils and categorise with categorical series" do
+      categories = Series.from_list(["a", "b", "c"], dtype: :category)
+
+      indexes = Series.from_list(["c", "b", nil, "a", "a", "c"])
+      categorized = Series.categorise(indexes, categories)
+
+      assert Series.to_list(categorized) == ["c", "b", nil, "a", "a", "c"]
+      assert Series.dtype(categorized) == :category
+    end
+
+    test "takes string series containing more elements and categorise with categorical series" do
+      categories = Series.from_list(["a", "b", "c"], dtype: :category)
+
+      indexes = Series.from_list(["z", "c", "b", "a", "a", "c", "z"])
+      categorized = Series.categorise(indexes, categories)
+
+      assert Series.to_list(categorized) == [nil, "c", "b", "a", "a", "c", nil]
+      assert Series.dtype(categorized) == :category
+    end
+
+    test "takes string series and categorise with another string series" do
+      categories = Series.from_list(["a", "b", "c"])
+
+      indexes = Series.from_list(["c", "b", "a", "a", "c"])
+      categorized = Series.categorise(indexes, categories)
+
+      assert Series.to_list(categorized) == ["c", "b", "a", "a", "c"]
+      assert Series.dtype(categorized) == :category
+    end
   end
 
   describe "cast/2" do


### PR DESCRIPTION
This partially solves the problem reported in https://github.com/elixir-explorer/explorer/issues/698

This PR also contains a new feature to the `Series.categorise/2` function, to support string series
on the left-hand side.