### PR TITLE
Introduce `cond/1` support in queries

### DIFF
--- a/lib/explorer/query.ex
+++ b/lib/explorer/query.ex
@@ -79,7 +79,7 @@ defmodule Explorer.Query do
         unusual nums integer [3]
       >
 
-  ## Special operations
+  ## Conditionals
 
   `cond/1` can be used to write multi-clause conditions:
 

--- a/lib/explorer/query.ex
+++ b/lib/explorer/query.ex
@@ -79,6 +79,25 @@ defmodule Explorer.Query do
         unusual nums integer [3]
       >
 
+  ## Special operations
+
+  `cond/1` can be used to write multi-clause conditions:
+
+      iex> df = DF.new(a: [10, 4, 6])
+      iex> DF.mutate(df,
+      ...>   b:
+      ...>     cond do
+      ...>       a > 9 -> "Exceptional"
+      ...>       a > 5 -> "Passed"
+      ...>       true -> "Failed"
+      ...>     end
+      ...> )
+      #Explorer.DataFrame<
+        Polars[3 x 2]
+        a integer [10, 4, 6]
+        b string ["Exceptional", "Failed", "Passed"]
+      >
+
   ## Across and comprehensions
 
   `Explorer.Query` leverages the power behind Elixir for-comprehensions

--- a/lib/explorer/query.ex
+++ b/lib/explorer/query.ex
@@ -599,5 +599,30 @@ defmodule Explorer.Query do
     |> Enum.map(&%{Explorer.Shared.apply_impl(df, :pull, [&1]) | name: &1})
   end
 
+  defmacro select(do: clauses) do
+    conditions =
+      clauses
+      |> Enum.map(fn {:->, _, [[condition], on_true]} -> [condition, on_true] end)
+
+    quote do
+      import Explorer.Query
+
+      unquote(conditions)
+      |> Enum.reverse()
+      |> Enum.reduce(nil, fn [condition, truthy], acc ->
+        predicate = Explorer.Shared.lazy_series!(condition)
+        on_true = Explorer.Shared.lazy_series!(truthy)
+
+        on_false =
+          case acc do
+            nil -> Explorer.Backend.LazySeries.from_list([nil], on_true.dtype)
+            _ -> Explorer.Shared.lazy_series!(acc)
+          end
+
+        Explorer.Backend.LazySeries.select(predicate, on_true, on_false)
+      end)
+    end
+  end
+
   defp df_var(), do: quote(do: var!(df, Explorer.Query))
 end

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -161,6 +161,13 @@ defmodule Explorer.Shared do
             "#{inspect(struct1)} and #{inspect(struct2)}"
   end
 
+  def lazy_series!(val) when is_struct(val, Explorer.Series), do: val
+
+  def lazy_series!(list) when is_list(list),
+    do: Explorer.Backend.LazySeries.from_list(list, check_types!(list))
+
+  def lazy_series!(val), do: lazy_series!([val])
+
   @doc """
   Gets the `dtype` of a list or raise error if not possible.
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1782,12 +1782,12 @@ defmodule Explorer.DataFrameTest do
       df =
         DF.mutate(df,
           simple_result:
-            select do
+            cond do
               grade > 9 -> "Exceptional"
               grade > 5 -> "Passed"
             end,
           result:
-            select do
+            cond do
               grade > 9 -> "Exceptional"
               grade > 5 -> "Passed"
               true -> cast(grade, :string)

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1775,6 +1775,28 @@ defmodule Explorer.DataFrameTest do
 
       assert Series.to_list(df7[:x]) == [~D[2023-01-15], ~D[2023-01-01], ~D[2023-01-01]]
     end
+
+    test "support select/1 macro" do
+      df = DF.new(%{names: ["Alice", "Bob", "John"], grade: [10, 4, 6]})
+
+      df =
+        DF.mutate(df,
+          simple_result:
+            select do
+              grade > 9 -> "Exceptional"
+              grade > 5 -> "Passed"
+            end,
+          result:
+            select do
+              grade > 9 -> "Exceptional"
+              grade > 5 -> "Passed"
+              true -> cast(grade, :string)
+            end
+        )
+
+      assert Series.to_list(df[:simple_result]) == ["Exceptional", nil, "Passed"]
+      assert Series.to_list(df[:result]) == ["Exceptional", "4", "Passed"]
+    end
   end
 
   describe "arrange/3" do


### PR DESCRIPTION
Referring to https://github.com/elixir-explorer/explorer/issues/515, this PR introduces multi-clause select as a macro, which in-turn expand to nested `Series.select/3` queries. This makes nested selects easy to write in a flat structure and improves readability.

Below are the list of assumptions made in this PR
- Each clause will be prioritised by top-down by their order of definition
- If none of the clauses match, it will be calculated to `nil`

Creating the PR for initial feedback, will add the docs if the approach is good.