### PR TITLE
Add replace/3 expressions

### DIFF
--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -795,6 +795,15 @@ pub fn expr_substring(expr: ExExpr, offset: i64, length: Option<u64>) -> ExExpr 
     let expr = expr.clone_inner();
     ExExpr::new(expr.str().str_slice(offset, length))
 }
+#[rustler::nif]
+pub fn expr_replace(expr: ExExpr, pat: String, value: String) -> ExExpr {
+    let expr = expr.clone_inner();
+    ExExpr::new(expr.str().replace_all(
+        Expr::Literal(LiteralValue::Utf8(pat)),
+        Expr::Literal(LiteralValue::Utf8(value)),
+        true,
+    ))
+}
 
 #[rustler::nif]
 pub fn expr_round(expr: ExExpr, decimals: u32) -> ExExpr {

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -795,6 +795,7 @@ pub fn expr_substring(expr: ExExpr, offset: i64, length: Option<u64>) -> ExExpr 
     let expr = expr.clone_inner();
     ExExpr::new(expr.str().str_slice(offset, length))
 }
+
 #[rustler::nif]
 pub fn expr_replace(expr: ExExpr, pat: String, value: String) -> ExExpr {
     let expr = expr.clone_inner();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -261,6 +261,7 @@ rustler::init!(
         expr_lstrip,
         expr_rstrip,
         expr_substring,
+        expr_replace,
         // float round expressions
         expr_round,
         expr_floor,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1592,6 +1592,21 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "replace characters in a string" do
+      df =
+        DF.new(a: ["2,000", "2,000,000", ","])
+
+      df1 =
+        DF.mutate(df,
+          b: replace(a, ",", "")
+        )
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: ["2,000", "2,000,000", ","],
+               b: ["2000", "2000000", ""]
+             }
+    end
+
     test "strip multiple characters from string" do
       df =
         DF.new(


### PR DESCRIPTION
This is a naive initial implementation this might not work with more complex expressions.

The api for Polars replace is a funny one, it takes expressions not strings, this is so they can do things like [passing columns as arguments](https://stackoverflow.com/questions/73427091/polars-replace-part-of-string-in-column-with-value-of-other-column)

however if i make the argument type an expression it fails due to a missing decodor in rustler::nif

If i make it an ExExpr then i get an argument error.

Any ideas on this?

links to https://github.com/elixir-explorer/explorer/issues/718
