### PR TITLE
Update Polars to v0.34.2

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3997,16 +3997,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.sample(df, 3, seed: 100)
       #Explorer.DataFrame<
         Polars[3 x 10]
-        year integer [2011, 2012, 2011]
-        country string ["SERBIA", "FALKLAND ISLANDS (MALVINAS)", "SWAZILAND"]
-        total integer [13422, 15, 286]
-        solid_fuel integer [9355, 3, 102]
-        liquid_fuel integer [2537, 12, 184]
-        gas_fuel integer [1188, 0, 0]
-        cement integer [342, 0, 0]
-        gas_flaring integer [0, 0, 0]
-        per_capita float [1.49, 5.21, 0.24]
-        bunker_fuels integer [39, 0, 1]
+        year integer [2012, 2013, 2014]
+        country string ["SYRIAN ARAB REPUBLIC", "EGYPT", "AFGHANISTAN"]
+        total integer [12198, 58198, 2675]
+        solid_fuel integer [1, 224, 1194]
+        liquid_fuel integer [7909, 26501, 1393]
+        gas_fuel integer [3265, 24672, 74]
+        cement integer [816, 6800, 14]
+        gas_flaring integer [208, 0, 0]
+        per_capita float [0.61, 0.66, 0.08]
+        bunker_fuels integer [437, 694, 9]
       >
 
   Or you can sample a proportion of rows:
@@ -4015,16 +4015,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.sample(df, 0.03, seed: 100)
       #Explorer.DataFrame<
         Polars[32 x 10]
-        year integer [2011, 2012, 2012, 2013, 2010, ...]
-        country string ["URUGUAY", "FRENCH POLYNESIA", "ICELAND", "PERU", "TUNISIA", ...]
-        total integer [2117, 222, 491, 15586, 7543, ...]
-        solid_fuel integer [1, 0, 96, 784, 15, ...]
-        liquid_fuel integer [1943, 222, 395, 7097, 3138, ...]
-        gas_fuel integer [40, 0, 0, 3238, 3176, ...]
-        cement integer [132, 0, 0, 1432, 1098, ...]
-        gas_flaring integer [0, 0, 0, 3036, 116, ...]
-        per_capita float [0.63, 0.81, 1.52, 0.51, 0.71, ...]
-        bunker_fuels integer [401, 45, 170, 617, 219, ...]
+        year integer [2013, 2012, 2014, 2011, 2011, ...]
+        country string ["BRITISH VIRGIN ISLANDS", "TAJIKISTAN", "AFGHANISTAN", "ICELAND", "SINGAPORE", ...]
+        total integer [48, 800, 2675, 513, 12332, ...]
+        solid_fuel integer [0, 192, 1194, 94, 7, ...]
+        liquid_fuel integer [48, 501, 1393, 400, 7774, ...]
+        gas_fuel integer [0, 74, 74, 0, 4551, ...]
+        cement integer [0, 34, 14, 19, 0, ...]
+        gas_flaring integer [0, 0, 0, 0, 0, ...]
+        per_capita float [1.64, 0.1, 0.08, 1.6, 2.38, ...]
+        bunker_fuels integer [0, 28, 9, 168, 41786, ...]
       >
 
   ## Grouped examples
@@ -4039,10 +4039,10 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[6 x 5]
         Groups: ["species"]
-        sepal_length float [5.3, 5.1, 5.1, 5.6, 6.2, ...]
-        sepal_width float [3.7, 3.8, 2.5, 2.7, 3.4, ...]
-        petal_length float [1.5, 1.9, 3.0, 4.2, 5.4, ...]
-        petal_width float [0.2, 0.4, 1.1, 1.3, 2.3, ...]
+        sepal_length float [4.8, 5.0, 5.5, 6.5, 7.4, ...]
+        sepal_width float [3.1, 3.6, 2.4, 2.8, 2.8, ...]
+        petal_length float [1.6, 1.4, 3.8, 4.6, 6.1, ...]
+        petal_width float [0.2, 0.2, 1.1, 1.5, 1.9, ...]
         species string ["Iris-setosa", "Iris-setosa", "Iris-versicolor", "Iris-versicolor", "Iris-virginica", ...]
       >
 
@@ -4055,10 +4055,10 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[15 x 5]
         Groups: ["species"]
-        sepal_length float [5.3, 5.1, 4.7, 5.7, 5.1, ...]
-        sepal_width float [3.7, 3.8, 3.2, 3.8, 3.5, ...]
-        petal_length float [1.5, 1.9, 1.3, 1.7, 1.4, ...]
-        petal_width float [0.2, 0.4, 0.2, 0.3, 0.3, ...]
+        sepal_length float [5.2, 5.0, 5.2, 5.0, 5.0, ...]
+        sepal_width float [3.4, 3.6, 3.5, 3.0, 3.4, ...]
+        petal_length float [1.4, 1.4, 1.5, 1.6, 1.6, ...]
+        petal_width float [0.2, 0.2, 0.2, 0.2, 0.4, ...]
         species string ["Iris-setosa", "Iris-setosa", "Iris-setosa", "Iris-setosa", "Iris-setosa", ...]
       >
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -363,7 +363,7 @@ defmodule Explorer.PolarsBackend.Series do
       do: Shared.apply_series(s, :s_clip_integer, [min, max])
 
   def clip(%Series{} = s, min, max),
-    do: Shared.apply_series(cast(s, :float), :s_clip_float, [min * 1.0, max * 1.0])
+    do: s |> cast(:float) |> Shared.apply_series(:s_clip_float, [min * 1.0, max * 1.0])
 
   # Trigonometry
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -363,7 +363,7 @@ defmodule Explorer.PolarsBackend.Series do
       do: Shared.apply_series(s, :s_clip_integer, [min, max])
 
   def clip(%Series{} = s, min, max),
-    do: Shared.apply_series(s, :s_clip_float, [min * 1.0, max * 1.0])
+    do: Shared.apply_series(cast(s, :float), :s_clip_float, [min * 1.0, max * 1.0])
 
   # Trigonometry
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1288,14 +1288,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.sample(s, 10, seed: 100)
       #Explorer.Series<
         Polars[10]
-        integer [55, 51, 33, 26, 5, 32, 62, 31, 9, 25]
+        integer [57, 9, 54, 62, 50, 77, 35, 88, 1, 69]
       >
 
       iex> s = 1..100 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.sample(s, 0.05, seed: 100)
       #Explorer.Series<
         Polars[5]
-        integer [49, 77, 96, 19, 18]
+        integer [9, 56, 79, 28, 54]
       >
 
       iex> s = 1..5 |> Enum.to_list() |> Explorer.Series.from_list()
@@ -1648,7 +1648,7 @@ defmodule Explorer.Series do
       iex> s1 = Explorer.Series.from_list([<<1>>, <<239, 191, 19>>], dtype: :binary)
       iex> s2 = Explorer.Series.from_list([<<3>>, <<4>>], dtype: :binary)
       iex> Explorer.Series.format([s1, s2])
-      ** (RuntimeError) Polars Error: External error: invalid utf-8 sequence
+      ** (RuntimeError) Polars Error: invalid utf-8 sequence
   """
   @doc type: :shape
   @spec format([Series.t() | String.t()]) :: Series.t()

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -19,14 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -103,40 +104,6 @@ checksum = "07884ea216994cdc32a2d5f8274a8bee979cfe90274b83f86f440866ee3132c7"
 dependencies = [
  "planus",
  "serde",
-]
-
-[[package]]
-name = "arrow2"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963fef509b757bcbbf9e5ffa23bcb345614d99f4f6f531f97417b27b8604d389"
-dependencies = [
- "ahash",
- "arrow-format",
- "base64",
- "bytemuck",
- "chrono",
- "dyn-clone",
- "either",
- "ethnum",
- "fallible-streaming-iterator",
- "foreign_vec",
- "futures",
- "getrandom",
- "hash_hasher",
- "hashbrown 0.14.1",
- "lexical-core",
- "lz4",
- "multiversion",
- "num-traits",
- "parquet2",
- "regex",
- "regex-syntax 0.7.5",
- "rustc_version",
- "simdutf8",
- "streaming-iterator",
- "strength_reduce",
- "zstd",
 ]
 
 [[package]]
@@ -659,12 +626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash_hasher"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +656,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "home"
@@ -1132,6 +1099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1200,8 @@ dependencies = [
  "seq-macro",
  "snap",
  "streaming-decompression",
- "zstd",
+ "xxhash-rust",
+ "zstd 0.12.4",
 ]
 
 [[package]]
@@ -1261,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3030de163b9ff2c9dac9a12dcb9be25cc0f2bc7c8e7cd2e4b2592ebed458ce6a"
+checksum = "40db657cc67a8dd9fe4b40db5b73027f5f224623545597e1930cbbb9c05b1de5"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -1277,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "polars-algo"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad136572767ebb4dd1510368880e75c2a935067b44c18a94209bf024a13f990e"
+checksum = "7e38c82e2c70b6a028225ea39a2b9bb88a38246a0386abce5083d99672604ea3"
 dependencies = [
  "polars-core",
  "polars-lazy",
@@ -1288,34 +1266,50 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35cd38a64fb389fd990e4efd433a36331c995c981d353bfef83b5de4d87f1828"
+checksum = "d1e50c63db77f846ac5119477422f0156f0a1826ceaae7d921f9a6d5ea5f7ca3"
 dependencies = [
- "arrow2",
+ "ahash",
+ "arrow-format",
+ "base64",
+ "bytemuck",
+ "chrono",
+ "dyn-clone",
+ "either",
+ "ethnum",
+ "fallible-streaming-iterator",
+ "foreign_vec",
+ "futures",
+ "getrandom",
  "hashbrown 0.14.1",
+ "lexical-core",
+ "lz4",
  "multiversion",
  "num-traits",
+ "parquet2",
  "polars-error",
- "thiserror",
- "version_check",
+ "rustc_version",
+ "simdutf8",
+ "streaming-iterator",
+ "strength_reduce",
+ "zstd 0.13.0",
 ]
 
 [[package]]
 name = "polars-core"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08367c014c07fa8f141680e024f926cab3a1fe839605a8fcf2223647eb45ca71"
+checksum = "cdfb622b8ca81b4614c64d95e7590d6e0571d7d398b5ad595c1abc4412abe714"
 dependencies = [
  "ahash",
- "arrow2",
  "bitflags 2.4.0",
+ "bytemuck",
  "chrono",
  "either",
  "hashbrown 0.14.1",
  "indexmap 2.0.2",
  "num-traits",
- "object_store",
  "once_cell",
  "polars-arrow",
  "polars-error",
@@ -1327,31 +1321,31 @@ dependencies = [
  "regex",
  "smartstring",
  "thiserror",
- "url",
  "version_check",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "polars-error"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b20a09651a299979354945819dc2ce017964b80b916954e9d2ce39002a5f949"
+checksum = "4b6480520ebde0b20935b600483b865513891e36c04942cebdd19e4f338257b4"
 dependencies = [
- "arrow2",
+ "arrow-format",
  "object_store",
+ "parquet2",
  "regex",
+ "simdutf8",
  "thiserror",
 ]
 
 [[package]]
 name = "polars-io"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf4a89c18a90ac20dfbcdfd19ab50ad4ac5a76fc7bb775d3c28bb738cf1f34"
+checksum = "666466a3b151047c76d99b4e4e5f5438895ef97848008cf49b06df8e3d2d395a"
 dependencies = [
  "ahash",
- "arrow2",
  "async-trait",
  "bytes",
  "chrono",
@@ -1359,6 +1353,7 @@ dependencies = [
  "flate2",
  "futures",
  "home",
+ "itoa",
  "lexical",
  "lexical-core",
  "memchr",
@@ -1366,6 +1361,7 @@ dependencies = [
  "num-traits",
  "object_store",
  "once_cell",
+ "percent-encoding",
  "polars-arrow",
  "polars-core",
  "polars-error",
@@ -1374,9 +1370,12 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "reqwest",
+ "ryu",
  "serde_json",
  "simd-json",
  "simdutf8",
+ "smartstring",
  "tokio",
  "tokio-util",
  "url",
@@ -1384,30 +1383,34 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d5666176d681706aef5a06a57597c83391948b3d958f9fbe9b4cf016527eb8"
+checksum = "24451d2647a9bd51283cc946509c23bac27130565daa5103a156c8507b85b5a3"
 dependencies = [
  "ahash",
- "arrow2",
+ "chrono",
  "fallible-streaming-iterator",
  "hashbrown 0.14.1",
  "indexmap 2.0.2",
+ "itoa",
  "num-traits",
  "polars-arrow",
  "polars-error",
  "polars-utils",
+ "ryu",
  "simd-json",
+ "streaming-iterator",
 ]
 
 [[package]]
 name = "polars-lazy"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5110eab438848c981cc5f541fbc5b21bb263fd707000b4715233074fb2630fcf"
+checksum = "07e1c2da1ca20106f80d9510090344e7311fd1dcfd6e6b65031e10606c0958c7"
 dependencies = [
  "ahash",
  "bitflags 2.4.0",
+ "futures",
  "glob",
  "once_cell",
  "polars-arrow",
@@ -1421,23 +1424,31 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "tokio",
  "version_check",
 ]
 
 [[package]]
 name = "polars-ops"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7740d7bc4c2ca08044f9ef599638e116fdd7d687e80d1974b698e390c6ce4252"
+checksum = "0fe2d37a6a3ef358499d43aecee80740e62dd44e6cfe7a9c4aa0b8db88de8292"
 dependencies = [
+ "ahash",
  "argminmax",
- "arrow2",
+ "bytemuck",
  "either",
+ "hashbrown 0.14.1",
  "indexmap 2.0.2",
  "memchr",
+ "num-traits",
  "polars-arrow",
  "polars-core",
+ "polars-error",
  "polars-utils",
+ "rand",
+ "rand_distr",
+ "rayon",
  "regex",
  "smartstring",
  "version_check",
@@ -1445,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f30c5e77c5594ddc958a46fe2e021da2feba9c94e767e1d798bd82ac5a33c3b"
+checksum = "f6aa050d529be01617f54bc60658149da76f97dbea9fdac3c9d60b811f64a2ba"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -1463,18 +1474,20 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "tokio",
  "version_check",
 ]
 
 [[package]]
 name = "polars-plan"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678cbeb730e29e50f0f8d844102d15454fc6113a74c667eab046c0e4a4322a9e"
+checksum = "c47e5d62d8f612aab61a6331d04c5c95c9ff301106d8b91131c8833b4ef3def6"
 dependencies = [
  "ahash",
- "arrow2",
+ "bytemuck",
  "once_cell",
+ "percent-encoding",
  "polars-arrow",
  "polars-core",
  "polars-io",
@@ -1490,25 +1503,27 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52ef8885b9d13f848839594fbab21ad79fc63f7e11c19cdc2cfe9bb03c313ac"
+checksum = "f05d6544f7d6065fcaa93bc69aac0532ce09aab4f81ec03c9a78dd901bb0c05b"
 dependencies = [
- "arrow2",
+ "polars-arrow",
  "polars-error",
  "polars-utils",
 ]
 
 [[package]]
 name = "polars-sql"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d716855267e3516f722287f68cf10e650e33f7197df83a79e680602471456fc"
+checksum = "77f65f9c8bfe7f0b2c08c38c79b92ec4ddaf213fc424d94a6272ed7b2d83987f"
 dependencies = [
  "polars-arrow",
  "polars-core",
+ "polars-error",
  "polars-lazy",
  "polars-plan",
+ "rand",
  "serde",
  "serde_json",
  "sqlparser",
@@ -1516,17 +1531,17 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb75a24f11b55a400b52dc19a2a3e949aaaa46a911f99496de4485b1127063"
+checksum = "3763af36aeeb85ef083f11c43bc28c5b6222e2aae039c5118d916bc855f2b5b9"
 dependencies = [
- "arrow2",
  "atoi",
  "chrono",
  "now",
  "once_cell",
  "polars-arrow",
  "polars-core",
+ "polars-error",
  "polars-ops",
  "polars-utils",
  "regex",
@@ -1535,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.33.2"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4a5e743509096322cad39104d56e329fe2748483a3354a0f0c354724f3cef6"
+checksum = "55d2c038ff67e4eb6019682c3f66d83f744e285de9c28e816109a61bace824cd"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1672,7 +1687,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.1",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1683,14 +1698,8 @@ checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.1",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1928,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.10.7"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ea1dfc2c400965867fc4ddd6f502572be2de2074b39f90984ed15fbdbdd8eb"
+checksum = "f0f07a84c7456b901b8dd2c1d44caca8b0fd2c2616206ee5acc9d9da61e8d9ec"
 dependencies = [
  "ahash",
  "getrandom",
@@ -2031,9 +2040,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaa1e88e78d2c2460d78b7dc3f0c08dbb606ab4222f9aff36f420d36e307d87"
+checksum = "0272b7bb0a225320170c99901b4b5fb3a4384e255a7f2cc228f61e2ba3893e75"
 dependencies = [
  "log",
 ]
@@ -2186,6 +2195,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio-macros",
@@ -2585,12 +2595,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
 
 [[package]]
+name = "zerocopy"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "zstd"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 6.0.6",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -2600,6 +2639,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -31,7 +31,7 @@ object_store = { version = "0.7", default-features = false, optional = true }
 mimalloc = { version = "*", default-features = false }
 
 [dependencies.polars]
-version = "0.33"
+version = "0.34"
 default-features = false
 features = [
   "abs",
@@ -69,15 +69,20 @@ features = [
   "round_series",
   "ewma",
   "product",
+  "peaks",
   "moment",
   "rank"
 ]
 
 [dependencies.polars-ops]
-version = "0.33"
+version = "0.34"
+features = [
+  "ewma",
+  "cum_agg"
+]
 
 [dependencies.polars-algo]
-version = "0.33"
+version = "0.34"
 
 [features]
 default = ["ndjson", "cloud", "nif_version_2_15"]

--- a/native/explorer/rust-toolchain.toml
+++ b/native/explorer/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-08-26"
+channel = "nightly-2023-10-12"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -63,7 +63,7 @@ pub fn df_from_csv(
         .truncate_ragged_lines(true)
         .with_try_parse_dates(parse_dates)
         .with_n_rows(stop_after_n_rows)
-        .with_delimiter(delimiter_as_byte)
+        .with_separator(delimiter_as_byte)
         .with_skip_rows(skip_rows)
         .with_projection(projection)
         .with_rechunk(do_rechunk)
@@ -115,7 +115,7 @@ pub fn df_to_csv(
     let mut buf_writer = BufWriter::new(file);
     CsvWriter::new(&mut buf_writer)
         .has_header(has_headers)
-        .with_delimiter(delimiter)
+        .with_separator(delimiter)
         .finish(&mut data.clone())?;
     Ok(())
 }
@@ -132,7 +132,7 @@ pub fn df_to_csv_cloud(
 
     CsvWriter::new(&mut cloud_writer)
         .has_header(has_headers)
-        .with_delimiter(delimiter)
+        .with_separator(delimiter)
         .finish(&mut data.clone())?;
     Ok(())
 }
@@ -148,7 +148,7 @@ pub fn df_dump_csv(
 
     CsvWriter::new(&mut buf)
         .has_header(has_headers)
-        .with_delimiter(delimiter)
+        .with_separator(delimiter)
         .finish(&mut data.clone())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
@@ -187,7 +187,7 @@ pub fn df_load_csv(
         .has_header(has_header)
         .with_try_parse_dates(parse_dates)
         .with_n_rows(stop_after_n_rows)
-        .with_delimiter(delimiter_as_byte)
+        .with_separator(delimiter_as_byte)
         .with_skip_rows(skip_rows)
         .with_projection(projection)
         .with_rechunk(do_rechunk)

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -430,7 +430,7 @@ fn categorical_series_to_list<'b>(
     let nil_as_c_arg = atom::nil().to_term(env).as_c_arg();
     let mut list = unsafe { list::make_list(env_as_c_arg, &[]) };
 
-    let logical = s.categorical()?.logical();
+    let logical = s.categorical()?.physical();
     let cat_size = mapping.len();
     let mut terms: Vec<NIF_TERM> = vec![nil_as_c_arg; cat_size];
 

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -174,7 +174,7 @@ pub fn lf_from_csv(
         .has_header(has_header)
         .with_try_parse_dates(parse_dates)
         .with_n_rows(stop_after_n_rows)
-        .with_delimiter(delimiter_as_byte)
+        .with_separator(delimiter_as_byte)
         .with_skip_rows(skip_rows)
         .with_rechunk(do_rechunk)
         .with_encoding(encoding)

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1357,7 +1357,7 @@ defmodule Explorer.DataFrameTest do
                a: [1, 2, 3, 4, 5],
                b: [5, 3, 2, 1, 4],
                c: [1, 3, 2, 4, 5],
-               d: [5, 1, 4, 0, 0]
+               d: [4, 2, 5, 0, 0]
              }
 
       assert df1.dtypes == %{
@@ -3424,8 +3424,8 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.sample(df, 3, seed: 100)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
-               letters: ["e", "b", "d"],
-               numbers: [5, 2, 4]
+               letters: ["j", "f", "h"],
+               numbers: [10, 6, 8]
              }
     end
 
@@ -3435,8 +3435,8 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.sample(df, 0.2, seed: 100)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
-               letters: ["j", "b"],
-               numbers: [10, 2]
+               letters: ["f", "g"],
+               numbers: [6, 7]
              }
     end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2597,7 +2597,7 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list([<<3>>, <<4>>], dtype: :binary)
 
       assert_raise RuntimeError,
-                   "Polars Error: External error: invalid utf-8 sequence",
+                   "Polars Error: invalid utf-8 sequence",
                    fn -> Series.format([s1, s2]) end
     end
 
@@ -2733,7 +2733,7 @@ defmodule Explorer.SeriesTest do
       result = Series.sample(s, 10, seed: 100)
 
       assert Series.size(result) == 10
-      assert Series.to_list(result) == [55, 51, 33, 26, 5, 32, 62, 31, 9, 25]
+      assert Series.to_list(result) == [57, 9, 54, 62, 50, 77, 35, 88, 1, 69]
     end
 
     test "sample taking 5% of elements" do
@@ -2742,7 +2742,7 @@ defmodule Explorer.SeriesTest do
       result = Series.sample(s, 0.05, seed: 100)
 
       assert Series.size(result) == 5
-      assert Series.to_list(result) == [49, 77, 96, 19, 18]
+      assert Series.to_list(result) == [9, 56, 79, 28, 54]
     end
 
     test "sample taking more than elements without replace" do
@@ -3805,13 +3805,13 @@ defmodule Explorer.SeriesTest do
     test "rank of a float series with a nan" do
       s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :nan, 3.9])
       r = Series.rank(s)
-      assert Series.to_list(r) === [2.0, 4.0, 5.0, nil, 3.0, 1.0, 8.0, 6.0]
+      assert Series.to_list(r) === [2.0, 4.0, 5.0, nil, 3.0, 1.0, 7.0, 6.0]
     end
 
     test "rank of a float series with infinity positive" do
       s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :infinity, 3.9])
       r = Series.rank(s)
-      assert Series.to_list(r) === [2.0, 4.0, 5.0, nil, 3.0, 1.0, 8.0, 6.0]
+      assert Series.to_list(r) === [2.0, 4.0, 5.0, nil, 3.0, 1.0, 7.0, 6.0]
     end
 
     test "rank of a float series with infinity negative" do
@@ -3844,22 +3844,28 @@ defmodule Explorer.SeriesTest do
   end
 
   describe "clip/3" do
-    test "With integers and floats" do
+    test "with integers" do
       s1 = Series.from_list([-50, 5, nil, 50])
       clipped1 = Series.clip(s1, 1, 10)
       assert Series.to_list(clipped1) == [1, 5, nil, 10]
       assert clipped1.dtype == :integer
+    end
 
+    test "with regular floats" do
       s2 = Series.from_list([-50, 5, nil, 50])
       clipped2 = Series.clip(s2, 1.5, 10.5)
       assert Series.to_list(clipped2) == [1.5, 5.0, nil, 10.5]
       assert clipped2.dtype == :float
+    end
 
+    test "with special floats" do
       s3 = Series.from_list([:neg_infinity, :nan, nil, :infinity])
       clipped3 = Series.clip(s3, 1.5, 10.5)
       assert Series.to_list(clipped3) == [1.5, :nan, nil, 10.5]
       assert clipped3.dtype == :float
+    end
 
+    test "errors" do
       assert_raise ArgumentError,
                    ~r"expects both the min and max bounds to be numbers",
                    fn -> Series.clip(Series.from_list([1]), 1, "a") end


### PR DESCRIPTION
What changed: https://github.com/pola-rs/polars/releases/tag/rs-0.34.0

This version, as always, contain a bunch of improvements and bug fixes. We had to update the examples from tests using "sample".

There is also a implicit casting when "clip" is using floats as min or max.