### PR TITLE
Add `filter` and `filter_with` to `Series`

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1406,6 +1406,30 @@ defmodule Explorer.Series do
   def at_every(series, every_n), do: apply_series(series, :at_every, [every_n])
 
   @doc """
+  Filters a series with a callback function.
+
+  ## Examples
+
+      iex> series = Explorer.Series.from_list([1, 2, 3])
+      iex> is_odd = fn s -> s |> Explorer.Series.remainder(2) |> Explorer.Series.equal(1) end
+      iex> Explorer.Series.filter_with(series, is_odd)
+      #Explorer.Series<
+        Polars[2]
+        integer [1, 3]
+      >
+  """
+  @doc type: :element_wise
+  @spec filter_with(
+          series :: Series.t(),
+          fun :: (Series.t() -> Series.lazy_t())
+        ) :: Series.t()
+  def filter_with(%Series{} = series, fun) when is_function(fun, 1) do
+    Explorer.DataFrame.new(series: series)
+    |> Explorer.DataFrame.filter_with(&fun.(&1[:series]))
+    |> Explorer.DataFrame.pull(:series)
+  end
+
+  @doc """
   Filters a series with a mask.
 
   ## Examples

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1486,7 +1486,7 @@ defmodule Explorer.Series do
     quote do
       require Explorer.Query
 
-      Explorer.DataFrame.new([{:_, unquote(series)}])
+      Explorer.DataFrame.new([_: unquote(series)])
       |> Explorer.DataFrame.filter_with(Explorer.Query.query(unquote(query)))
       |> Explorer.DataFrame.pull(:_)
     end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1421,6 +1421,7 @@ defmodule Explorer.Series do
 
   See `filter_with/2` for a callback version of this function without
   `Explorer.Query`.
+  See `mask/2` if you want to filter values based on another series.
 
   ## Syntax
 
@@ -1494,6 +1495,8 @@ defmodule Explorer.Series do
 
   @doc """
   Filters a series with a callback function.
+
+  See `mask/2` if you want to filter values based on another series.
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1486,7 +1486,7 @@ defmodule Explorer.Series do
     quote do
       require Explorer.Query
 
-      Explorer.DataFrame.new([_: unquote(series)])
+      Explorer.DataFrame.new(_: unquote(series))
       |> Explorer.DataFrame.filter_with(Explorer.Query.query(unquote(query)))
       |> Explorer.DataFrame.pull(:_)
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2727,6 +2727,25 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "filter_with/2" do
+    test "basic example" do
+      s = Series.from_list([1, 2, 3, 4])
+      filtered = Series.filter_with(s, &Series.greater(&1, 2))
+      assert Series.to_list(filtered) == [3, 4]
+    end
+
+    test "raise an error if the function is not returning a lazy series" do
+      s = Series.from_list([1, 2, 3, 4])
+
+      message =
+        "expecting the function to return a single or a list of boolean LazySeries, but instead it contains:\ntrue"
+
+      assert_raise ArgumentError, message, fn ->
+        Series.filter_with(s, &(&1 > 2))
+      end
+    end
+  end
+
   describe "sample/2" do
     test "sample taking 10 elements" do
       s = 1..100 |> Enum.to_list() |> Series.from_list()

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2732,7 +2732,7 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s = Series.from_list([1, 2, 3, 4])
-      filtered = Series.filter(s, n: n > 2)
+      filtered = Series.filter(s, _ > 2)
       assert Series.to_list(filtered) == [3, 4]
     end
 
@@ -2740,7 +2740,7 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s = Series.from_list([1, 2, 3, 4])
-      filtered = Series.filter(s, n: n == count(n))
+      filtered = Series.filter(s, _ == count(_))
       assert Series.to_list(filtered) == [4]
     end
 
@@ -2748,10 +2748,10 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s = Series.from_list([1, 2, 3, 4])
-      message = "could not find column name \"k\". The available entries are: [\"n\"]"
+      message = "could not find column name \"n\". The available entries are: [\"_\"]"
 
       assert_raise ArgumentError, message, fn ->
-        Series.filter(s, n: k > 2)
+        Series.filter(s, n > 2)
       end
     end
   end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2727,6 +2727,35 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "filter/2" do
+    test "basic example" do
+      require Explorer.Series
+
+      s = Series.from_list([1, 2, 3, 4])
+      filtered = Series.filter(s, n: n > 2)
+      assert Series.to_list(filtered) == [3, 4]
+    end
+
+    test "aggregation" do
+      require Explorer.Series
+
+      s = Series.from_list([1, 2, 3, 4])
+      filtered = Series.filter(s, n: n == count(n))
+      assert Series.to_list(filtered) == [4]
+    end
+
+    test "mismatched columns" do
+      require Explorer.Series
+
+      s = Series.from_list([1, 2, 3, 4])
+      message = "could not find column name \"k\". The available entries are: [\"n\"]"
+
+      assert_raise ArgumentError, message, fn ->
+        Series.filter(s, n: k > 2)
+      end
+    end
+  end
+
   describe "filter_with/2" do
     test "basic example" do
       s = Series.from_list([1, 2, 3, 4])


### PR DESCRIPTION
## Description

Adds

  * `Series.filter`
  * `Series.filter_with`

As was discussed in:

  * https://github.com/elixir-explorer/explorer/issues/726

## Support macros and `_with` variants?

If/how to include macro and `_with`-callback versions of functions is up for debate. Here's how I'm proposing it would work for `filter`:

```elixir
require Explorer.Series, as: S

series = S.from_list([1, 2, 3])

S.filter_with(series, &(&1 |> S.remainder(2) |> S.equal(1)))
# vs.
S.filter(series, n: remainder(n, 2) == 1)
```

Happy to discuss :)