### PR TITLE
Remove arg swap hack from `Series.add`

### DIFF
--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -13,6 +13,7 @@ defmodule Explorer.PolarsBackend.Expression do
   @type t :: %__MODULE__{resource: reference()}
 
   @all_expressions [
+    add: 2,
     all_equal: 2,
     argmax: 1,
     argmin: 1,
@@ -130,7 +131,6 @@ defmodule Explorer.PolarsBackend.Expression do
   ]
 
   @custom_expressions [
-    add: 2,
     divide: 2,
     multiply: 2,
     cast: 2,
@@ -242,18 +242,6 @@ defmodule Explorer.PolarsBackend.Expression do
 
       apply(Native, unquote(expr_op), [expr | args])
     end
-  end
-
-  def to_expr(%LazySeries{op: :add, args: [left, right]}) do
-    # `duration + date` is not supported by polars for some reason.
-    # `date + duration` is, so we're swapping arguments as a work around.
-    [left, right] =
-      case [dtype(left), dtype(right)] do
-        [{:duration, _}, :date] -> [right, left]
-        _ -> [left, right]
-      end
-
-    Native.expr_add(to_expr(left), to_expr(right))
   end
 
   def to_expr(%LazySeries{op: :multiply, args: [left, right] = args}) do

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -284,19 +284,8 @@ defmodule Explorer.PolarsBackend.Series do
   # Arithmetic
 
   @impl true
-  def add(out_dtype, left, right) do
-    left = matching_size!(left, right)
-
-    # `duration + date` is not supported by polars for some reason.
-    # `date + duration` is, so we're swapping arguments as a work around.
-    [left, right] =
-      case {out_dtype, dtype(left), dtype(right)} do
-        {:date, {:duration, _}, :date} -> [right, left]
-        _ -> [left, right]
-      end
-
-    Shared.apply_series(left, :s_add, [right.data])
-  end
+  def add(_out_dtype, left, right),
+    do: Shared.apply_series(matching_size!(left, right), :s_add, [right.data])
 
   @impl true
   def subtract(_out_dtype, left, right),

--- a/test/explorer/series/duration_test.exs
+++ b/test/explorer/series/duration_test.exs
@@ -693,8 +693,8 @@ defmodule Explorer.Series.DurationTest do
       assert Series.to_list(df["ns"]) == [ns]
     end
 
-    # There is currently an issue with Polars where `duration + date` is not supported but
-    # `date + duration` is. There is a workaround in where we swap the args.
+    # There used to be an issue with Polars where `duration + date` was not supported but
+    # `date + duration` was. This test was for that workaround (which is no longer present).
     test "mutate/2 with duration + date" do
       require Explorer.DataFrame
       alias Explorer.DataFrame, as: DF

--- a/test/explorer/series/duration_test.exs
+++ b/test/explorer/series/duration_test.exs
@@ -694,7 +694,7 @@ defmodule Explorer.Series.DurationTest do
     end
 
     # There used to be an issue with Polars where `duration + date` was not supported but
-    # `date + duration` was. This test was for that workaround (which is no longer present).
+    # `date + duration` was. This test was for a workaround (longer present) to that issue.
     test "mutate/2 with duration + date" do
       require Explorer.DataFrame
       alias Explorer.DataFrame, as: DF


### PR DESCRIPTION
As part of https://github.com/elixir-explorer/explorer/pull/696, we introduced a hack where we swapped the arguments to `Series.add` since Polars only supported `date + duration` and not `duration + date`. This PR removes that hack since as of Polars `0.34`, it's no longer needed:

* Polars PR: https://github.com/pola-rs/polars/pull/11190
* Explorer Upgrade: https://github.com/elixir-explorer/explorer/pull/724