### PR TITLE
Remove the restriction on pivot_wider dtypes

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4313,8 +4313,6 @@ defmodule Explorer.DataFrame do
   `pivot_wider/4` "widens" data, increasing the number of columns and decreasing the number of rows.
   The inverse transformation is `pivot_longer/3`.
 
-  Due to a restriction upstream, `values_from` must be a numeric type.
-
   In case the dataframe is using groups, the groups that are also in the list of columns
   to pivot will be removed from the resultant dataframe. See the examples below.
 
@@ -4536,14 +4534,6 @@ defmodule Explorer.DataFrame do
     opts = Keyword.validate!(opts, id_columns: .., names_prefix: "")
 
     [names_from | values_from] = to_existing_columns(df, [names_from | values_from])
-    dtypes = df.dtypes
-
-    for column <- values_from do
-      unless dtypes[column] in [:integer, :float, :date, :datetime, :category] do
-        raise ArgumentError,
-              "the values_from column must be numeric, but found #{dtypes[values_from]}"
-      end
-    end
 
     id_columns =
       for column_name <- to_existing_columns(df, opts[:id_columns]) -- [names_from | values_from],

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2917,6 +2917,30 @@ defmodule Explorer.DataFrameTest do
                      DF.pivot_wider(df, "variable", "value", id_columns: [:float_id])
                    end
     end
+
+    test "with a string values_from" do
+      df1 = DF.new(id: [1, 1], variable: ["a", "b"], value: ["x", "y"])
+
+      df2 = DF.pivot_wider(df1, "variable", "value")
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               id: [1],
+               a: ["x"],
+               b: ["y"]
+             }
+    end
+
+    test "with a date values_from" do
+      df1 = DF.new(id: [1, 1], variable: ["a", "b"], value: [~D[2022-01-01], ~D[2023-01-01]])
+
+      df2 = DF.pivot_wider(df1, "variable", "value")
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               id: [1],
+               a: [~D[2022-01-01]],
+               b: [~D[2023-01-01]]
+             }
+    end
   end
 
   describe "pivot_longer/3" do


### PR DESCRIPTION
The upstream restriction does not appear to be there anymore. I'll add some tests, but poking around this seems to work as expected. Closes #732.

Edit: Yep! I'm satisfied that the upstream restriction is lifted. IIRC the `first` aggregation required a numeric dtype on the Polars end in the early days. But that's long not been the case. Wish I had stumbled across this sooner.