### PR TITLE
Fix DataFrame / Series inspect with `limit: :infinity`

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -246,9 +246,14 @@ defmodule Explorer.Backend.DataFrame do
       for name <- DataFrame.names(df) do
         series = df[name]
 
+        series =
+          case inspect_opts.limit do
+            :infinity -> series
+            limit when is_integer(limit) -> Series.slice(series, 0, limit + 1)
+          end
+
         data =
           series
-          |> Series.slice(0, inspect_opts.limit + 1)
           |> Series.to_list()
           |> Explorer.Shared.to_doc(inspect_opts)
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -296,9 +296,14 @@ defmodule Explorer.Backend.Series do
 
     dtype = A.color("#{type} ", :atom, inspect_opts)
 
+    series =
+      case inspect_opts.limit do
+        :infinity -> series
+        limit when is_integer(limit) -> Series.slice(series, 0, limit + 1)
+      end
+
     data =
       series
-      |> Series.slice(0, inspect_opts.limit + 1)
       |> Series.to_list()
       |> Explorer.Shared.to_doc(inspect_opts)
 


### PR DESCRIPTION
Error before change:

```
#Inspect.Error<
  got ArithmeticError with message:

      """
      bad argument in arithmetic expression
      """

  while inspecting:

      %{
        data: #Explorer.PolarsBackend.Series<
          shape: (100,)
          Series: 'contract_current_premium' [f64]
          [
          	42107.0
          	45028.0
          	45454.0
          	42278.0
          	40060.0
          	78537.0
          	54076.0
          	90896.0
          	135032.0
          	179491.0
          	111938.0
          	86522.0
          	…
          	62514.0
          	64914.0
          	49674.0
          	50462.0
          	186467.0
          	45424.0
          	48393.0
          	86624.0
          	113737.5819
          	43980.0
          	73177.0
          	66513.0
          	49160.0
          ]
        >,
        name: "contract_current_premium",
        __struct__: Explorer.Series,
        dtype: :float
      }

  Stacktrace:

    :erlang.+(:infinity, 1)
    (explorer 0.7.1) lib/explorer/backend/series.ex:297: Explorer.Backend.Series.inspect/5
    (explorer 0.7.1) lib/explorer/series.ex:5195: Inspect.Explorer.Series.inspect/2
    (elixir 1.15.7) lib/inspect/algebra.ex:348: Inspect.Algebra.to_doc/2
    (elixir 1.15.7) lib/io.ex:458: IO.inspect/3
    (stdlib 5.1.1) erl_eval.erl:746: :erl_eval.do_apply/7
    (elixir 1.15.7) src/elixir.erl:375: :elixir.eval_forms/4
    (elixir 1.15.7) lib/module/parallel_checker.ex:112: Module.ParallelChecker.verify/1

>
```