### PR TITLE
Add support for grouping into series

### DIFF
--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -380,7 +380,7 @@ defmodule Explorer.DataFrame.GroupedTest do
 
     test "with one group but no aggregation", %{df: df} do
       message = """
-      expecting summarise with an aggregation operation, but no aggregation was found in: #Explorer.Series<
+      expecting summarise with an aggregation operation or plain column, but none of which were found in: #Explorer.Series<
         LazySeries[???]
         integer (column("solid_fuel") + 50)
       >\

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3564,6 +3564,21 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "allows returning the group as a list" do
+      df =
+        DF.new(
+          letters: ~w(a b c d e f g h i j),
+          is_vowel: [true, false, false, false, true, false, false, false, false, false]
+        )
+        |> DF.group_by(:is_vowel)
+        |> DF.summarise(letters: letters)
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               is_vowel: [true, false],
+               letters: [["a", "e"], ["b", "c", "d", "f", "g", "h", "i", "j"]]
+             }
+    end
+
     test "mode/1" do
       df =
         Datasets.iris()

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3568,14 +3568,14 @@ defmodule Explorer.DataFrameTest do
       df =
         DF.new(
           letters: ~w(a b c d e f g h i j),
-          is_vowel: [true, false, false, false, true, false, false, false, false, false]
+          is_vowel: [true, false, false, false, true, false, false, false, true, false]
         )
         |> DF.group_by(:is_vowel)
         |> DF.summarise(letters: letters)
 
       assert DF.to_columns(df, atom_keys: true) == %{
                is_vowel: [true, false],
-               letters: [["a", "e"], ["b", "c", "d", "f", "g", "h", "i", "j"]]
+               letters: [["a", "e", "i"], ["b", "c", "d", "f", "g", "h", "j"]]
              }
     end
 


### PR DESCRIPTION
Hey folks!

My first intention with this PR was to implement [implode](https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.implode.html) to allow gathering all the values of a given group into a Series. Halfway through it, I noticed I was getting some double wrapping (i.e. `[[[1, 2]], [[3, 4]]]` instead of `[[1, 2], [3, 4]]`).

Then I looked a bit further and noticed there isn't really a need for `implode` to have this feature, we just need to allow plain lazy series in summarize and it _just works_, which is the approach this PR follows. I also updated the docs to reflect that.

Please let me know if there's something I'm overlooking with this PR, or if this is not a wanted feature. I'm more than happy to start this over with a different approach or just scrap it altogether 🙂 