### PR TITLE
Add `Series.length/1` and `Series.member?/2`

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -137,7 +137,7 @@ defmodule Explorer.Backend.LazySeries do
     # List functions
     join: 2,
     length: 1,
-    member: 2
+    member: 3
   ]
 
   @comparison_operations [:equal, :not_equal, :greater, :greater_equal, :less, :less_equal]
@@ -1000,8 +1000,8 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def member?(series, value) do
-    data = new(:member, [lazy_series!(series), value], :boolean)
+  def member?(%Series{dtype: {:list, inner_dtype}} = series, value) do
+    data = new(:member, [lazy_series!(series), value, inner_dtype], :boolean)
 
     Backend.Series.new(data, :boolean)
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -135,7 +135,9 @@ defmodule Explorer.Backend.LazySeries do
     minute: 1,
     second: 1,
     # List functions
-    join: 2
+    join: 2,
+    length: 1,
+    member: 2
   ]
 
   @comparison_operations [:equal, :not_equal, :greater, :greater_equal, :less, :less_equal]
@@ -988,6 +990,20 @@ defmodule Explorer.Backend.LazySeries do
     data = new(:join, [lazy_series!(series), separator], {:list, :string})
 
     Backend.Series.new(data, :string)
+  end
+
+  @impl true
+  def length(series) do
+    data = new(:length, [lazy_series!(series)], :integer)
+
+    Backend.Series.new(data, :integer)
+  end
+
+  @impl true
+  def member?(series, value) do
+    data = new(:member, [lazy_series!(series), value], :boolean)
+
+    Backend.Series.new(data, :boolean)
   end
 
   @remaining_non_lazy_operations [

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -136,7 +136,7 @@ defmodule Explorer.Backend.LazySeries do
     second: 1,
     # List functions
     join: 2,
-    length: 1,
+    lengths: 1,
     member: 3
   ]
 
@@ -993,8 +993,8 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def length(series) do
-    data = new(:length, [lazy_series!(series)], :integer)
+  def lengths(series) do
+    data = new(:lengths, [lazy_series!(series)], :integer)
 
     Backend.Series.new(data, :integer)
   end

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -269,7 +269,7 @@ defmodule Explorer.Backend.Series do
 
   # List
   @callback join(s, String.t()) :: s
-  @callback length(s) :: s
+  @callback lengths(s) :: s
   @callback member?(s, valid_types()) :: s
 
   # Functions

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -269,6 +269,8 @@ defmodule Explorer.Backend.Series do
 
   # List
   @callback join(s, String.t()) :: s
+  @callback length(s) :: s
+  @callback member?(s, valid_types()) :: s
 
   # Functions
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -135,7 +135,7 @@ defmodule Explorer.PolarsBackend.Expression do
 
     # Lists
     join: 2,
-    length: 1,
+    lengths: 1,
     member: 3
   ]
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -134,7 +134,9 @@ defmodule Explorer.PolarsBackend.Expression do
     split: 2,
 
     # Lists
-    join: 2
+    join: 2,
+    length: 1,
+    member: 2
   ]
 
   @custom_expressions [

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -136,7 +136,7 @@ defmodule Explorer.PolarsBackend.Expression do
     # Lists
     join: 2,
     length: 1,
-    member: 2
+    member: 3
   ]
 
   @custom_expressions [

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -402,7 +402,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   def s_join(_s, _separator), do: err()
   def s_length(_s), do: err()
-  def s_member(_s, _value), do: err()
+  def s_member(_s, _value, _inner_dtype), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -401,6 +401,8 @@ defmodule Explorer.PolarsBackend.Native do
   def s_atan(_s), do: err()
 
   def s_join(_s, _separator), do: err()
+  def s_length(_s), do: err()
+  def s_member(_s, _value), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -401,7 +401,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_atan(_s), do: err()
 
   def s_join(_s, _separator), do: err()
-  def s_length(_s), do: err()
+  def s_lengths(_s), do: err()
   def s_member(_s, _value, _inner_dtype), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -653,6 +653,14 @@ defmodule Explorer.PolarsBackend.Series do
   def join(series, separator),
     do: Shared.apply_series(series, :s_join, [separator])
 
+  @impl true
+  def length(series),
+    do: Shared.apply_series(series, :s_length)
+
+  @impl true
+  def member?(series, value),
+    do: Shared.apply_series(series, :s_member, [value])
+
   # Polars specific functions
 
   def name(series), do: Shared.apply_series(series, :s_name)

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -658,8 +658,8 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(series, :s_length)
 
   @impl true
-  def member?(series, value),
-    do: Shared.apply_series(series, :s_member, [value])
+  def member?(%Series{dtype: {:list, inner_dtype}} = series, value),
+    do: Shared.apply_series(series, :s_member, [value, inner_dtype])
 
   # Polars specific functions
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -654,8 +654,8 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(series, :s_join, [separator])
 
   @impl true
-  def length(series),
-    do: Shared.apply_series(series, :s_length)
+  def lengths(series),
+    do: Shared.apply_series(series, :s_lengths)
 
   @impl true
   def member?(%Series{dtype: {:list, inner_dtype}} = series, value),

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -57,7 +57,7 @@ defmodule Explorer.Series do
 
   """
 
-  import Kernel, except: [and: 2, not: 1, in: 2, length: 1]
+  import Kernel, except: [and: 2, not: 1, in: 2]
 
   alias __MODULE__, as: Series
   alias Kernel, as: K
@@ -3433,17 +3433,17 @@ defmodule Explorer.Series do
        do: apply_series_list(operation, [left, right | args])
 
   defp basic_numeric_operation(operation, %Series{} = left, %Series{} = right, args),
-    do: dtype_mismatch_error("#{operation}/#{K.length(args) + 2}", left, right)
+    do: dtype_mismatch_error("#{operation}/#{length(args) + 2}", left, right)
 
   defp basic_numeric_operation(operation, _, %Series{dtype: dtype}, args),
-    do: dtype_error("#{operation}/#{K.length(args) + 2}", dtype, @numeric_dtypes)
+    do: dtype_error("#{operation}/#{length(args) + 2}", dtype, @numeric_dtypes)
 
   defp basic_numeric_operation(operation, %Series{dtype: dtype}, _, args),
-    do: dtype_error("#{operation}/#{K.length(args) + 2}", dtype, @numeric_dtypes)
+    do: dtype_error("#{operation}/#{length(args) + 2}", dtype, @numeric_dtypes)
 
   defp basic_numeric_operation(operation, left, right, args)
        when K.and(is_numeric(left), is_numeric(right)),
-       do: no_series_error("#{operation}/#{K.length(args) + 2}", left, right)
+       do: no_series_error("#{operation}/#{length(args) + 2}", left, right)
 
   defp no_series_error(function, left, right) do
     raise ArgumentError,
@@ -5420,7 +5420,7 @@ defmodule Explorer.Series do
   ## Examples
 
       iex> s = Series.from_list([[1], [1, 2]])
-      iex> Series.length(s)
+      iex> Series.lengths(s)
       #Explorer.Series<
         Polars[2]
         integer [1, 2]
@@ -5428,12 +5428,12 @@ defmodule Explorer.Series do
 
   """
   @doc type: :list_wise
-  @spec length(Series.t()) :: Series.t()
-  def length(%Series{dtype: {:list, _}} = series),
-    do: apply_series(series, :length)
+  @spec lengths(Series.t()) :: Series.t()
+  def lengths(%Series{dtype: {:list, _}} = series),
+    do: apply_series(series, :lengths)
 
-  def length(%Series{dtype: dtype}),
-    do: dtype_error("length/1", dtype, [{:list, :_}])
+  def lengths(%Series{dtype: dtype}),
+    do: dtype_error("lengths/1", dtype, [{:list, :_}])
 
   @doc """
   Checks for the presence of a value in a list series.

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -433,6 +433,16 @@ pub enum ExValidValue<'a> {
     Duration(ExDuration),
 }
 
+impl<'a> ExValidValue<'a> {
+    pub fn lit_with_matching_precision(self, data_type: &DataType) -> Expr {
+        match data_type {
+            DataType::Datetime(time_unit, _) => self.lit().dt().cast_time_unit(*time_unit),
+            DataType::Duration(time_unit) => self.lit().dt().cast_time_unit(*time_unit),
+            _ => self.lit(),
+        }
+    }
+}
+
 impl<'a> Literal for &ExValidValue<'a> {
     fn lit(self) -> Expr {
         match self {

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -213,6 +213,12 @@ impl From<NaiveDate> for ExDate {
     }
 }
 
+impl Literal for ExDate {
+    fn lit(self) -> Expr {
+        NaiveDate::from(self).lit().dt().date()
+    }
+}
+
 #[derive(NifStruct, Copy, Clone, Debug)]
 #[module = "Explorer.Duration"]
 pub struct ExDuration {
@@ -223,6 +229,30 @@ pub struct ExDuration {
 impl From<ExDuration> for i64 {
     fn from(d: ExDuration) -> i64 {
         d.value
+    }
+}
+
+impl Literal for ExDuration {
+    fn lit(self) -> Expr {
+        // Note: it's tempting to use `.lit()` on a `chrono::Duration` struct in this function, but
+        // doing so will lose precision information as `chrono::Duration`s have no time units.
+        Expr::Literal(LiteralValue::Duration(
+            self.value,
+            time_unit_of_ex_duration(&self),
+        ))
+    }
+}
+
+fn time_unit_of_ex_duration(duration: &ExDuration) -> TimeUnit {
+    let precision = duration.precision;
+    if precision == atoms::millisecond() {
+        TimeUnit::Milliseconds
+    } else if precision == atoms::microsecond() {
+        TimeUnit::Microseconds
+    } else if precision == atoms::nanosecond() {
+        TimeUnit::Nanoseconds
+    } else {
+        panic!("unrecognized precision: {precision:?}")
     }
 }
 
@@ -318,6 +348,12 @@ impl From<NaiveDateTime> for ExDateTime {
     }
 }
 
+impl Literal for ExDateTime {
+    fn lit(self) -> Expr {
+        NaiveDateTime::from(self).lit()
+    }
+}
+
 #[derive(NifStruct, Copy, Clone, Debug)]
 #[module = "Time"]
 pub struct ExTime {
@@ -375,6 +411,73 @@ impl From<NaiveTime> for ExTime {
             minute: t.minute(),
             second: t.second(),
             microsecond: ex_microseconds,
+        }
+    }
+}
+
+impl Literal for ExTime {
+    fn lit(self) -> Expr {
+        Expr::Literal(LiteralValue::Time(self.into()))
+    }
+}
+
+/// Represents valid Elixir types that can be used as literals in Polars.
+pub enum ExValidValue<'a> {
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    Str(&'a str),
+    Date(ExDate),
+    Time(ExTime),
+    DateTime(ExDateTime),
+    Duration(ExDuration),
+}
+
+impl<'a> Literal for &ExValidValue<'a> {
+    fn lit(self) -> Expr {
+        match self {
+            ExValidValue::I64(v) => v.lit(),
+            ExValidValue::F64(v) => v.lit(),
+            ExValidValue::Bool(v) => v.lit(),
+            ExValidValue::Str(v) => v.lit(),
+            ExValidValue::Date(v) => v.lit(),
+            ExValidValue::Time(v) => v.lit(),
+            ExValidValue::DateTime(v) => v.lit(),
+            ExValidValue::Duration(v) => v.lit(),
+        }
+    }
+}
+
+impl<'a> rustler::Decoder<'a> for ExValidValue<'a> {
+    fn decode(term: rustler::Term<'a>) -> rustler::NifResult<Self> {
+        use rustler::*;
+
+        match term.get_type() {
+            TermType::Atom => term.decode::<bool>().map(ExValidValue::Bool),
+            TermType::Binary => term.decode::<&'a str>().map(ExValidValue::Str),
+            TermType::Number => {
+                if let Ok(i) = term.decode::<i64>() {
+                    Ok(ExValidValue::I64(i))
+                } else if let Ok(f) = term.decode::<f64>() {
+                    Ok(ExValidValue::F64(f))
+                } else {
+                    Err(rustler::Error::BadArg)
+                }
+            }
+            TermType::Map => {
+                if let Ok(date) = term.decode::<ExDate>() {
+                    Ok(ExValidValue::Date(date))
+                } else if let Ok(time) = term.decode::<ExTime>() {
+                    Ok(ExValidValue::Time(time))
+                } else if let Ok(datetime) = term.decode::<ExDateTime>() {
+                    Ok(ExValidValue::DateTime(datetime))
+                } else if let Ok(duration) = term.decode::<ExDuration>() {
+                    Ok(ExValidValue::Duration(duration))
+                } else {
+                    Err(rustler::Error::BadArg)
+                }
+            }
+            _ => Err(rustler::Error::BadArg),
         }
     }
 }

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -971,8 +971,12 @@ pub fn expr_length(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_member(expr: ExExpr, value: ExValidValue) -> ExExpr {
+pub fn expr_member(expr: ExExpr, value: ExValidValue, inner_dtype: ExSeriesDtype) -> ExExpr {
     let expr = expr.clone_inner();
+    let inner_dtype = DataType::try_from(&inner_dtype).unwrap();
 
-    ExExpr::new(expr.list().contains(value.lit()))
+    ExExpr::new(
+        expr.list()
+            .contains(value.lit_with_matching_precision(&inner_dtype)),
+    )
 }

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -4,13 +4,12 @@
 // or an expression and returns an expression that is
 // wrapped in an Elixir struct.
 
-use chrono::{NaiveDate, NaiveDateTime};
-use polars::lazy::dsl::{col, concat_str, cov, pearson_corr, when, Expr, StrptimeOptions};
-use polars::prelude::{DataType, Literal, TimeUnit};
-use polars::prelude::{IntoLazy, LiteralValue, SortOptions};
+use polars::prelude::{
+    col, concat_str, cov, pearson_corr, when, IntoLazy, LiteralValue, SortOptions,
+};
+use polars::prelude::{DataType, Expr, Literal, StrptimeOptions, TimeUnit};
 
-use crate::atoms::{microsecond, millisecond, nanosecond};
-use crate::datatypes::{ExDate, ExDateTime, ExDuration, ExSeriesDtype};
+use crate::datatypes::{ExDate, ExDateTime, ExDuration, ExSeriesDtype, ExValidValue};
 use crate::series::{cast_str_to_f64, ewm_opts, rolling_opts};
 use crate::{ExDataFrame, ExExpr, ExSeries};
 
@@ -54,38 +53,17 @@ pub fn expr_atom(atom: &str) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_date(date: ExDate) -> ExExpr {
-    let naive_date = NaiveDate::from(date);
-    let expr = naive_date.lit().dt().date();
-    ExExpr::new(expr)
+    ExExpr::new(date.lit())
 }
 
 #[rustler::nif]
 pub fn expr_datetime(datetime: ExDateTime) -> ExExpr {
-    let naive_datetime = NaiveDateTime::from(datetime);
-    let expr = naive_datetime.lit();
-    ExExpr::new(expr)
+    ExExpr::new(datetime.lit())
 }
 
 #[rustler::nif]
 pub fn expr_duration(duration: ExDuration) -> ExExpr {
-    // Note: it's tempting to use `.lit()` on a `chrono::Duration` struct in this function, but
-    // doing so will lose precision information as `chrono::Duration`s have no time units.
-    let time_unit = time_unit_of_ex_duration(duration);
-    let expr = Expr::Literal(LiteralValue::Duration(duration.value, time_unit));
-    ExExpr::new(expr)
-}
-
-fn time_unit_of_ex_duration(duration: ExDuration) -> TimeUnit {
-    let precision = duration.precision;
-    if precision == millisecond() {
-        TimeUnit::Milliseconds
-    } else if precision == microsecond() {
-        TimeUnit::Microseconds
-    } else if precision == nanosecond() {
-        TimeUnit::Nanoseconds
-    } else {
-        panic!("unrecognized precision: {precision:?}")
-    }
+    ExExpr::new(duration.lit())
 }
 
 #[rustler::nif]
@@ -976,4 +954,25 @@ pub fn expr_second(expr: ExExpr) -> ExExpr {
     let expr = expr.clone_inner();
 
     ExExpr::new(expr.dt().second().cast(DataType::Int64))
+}
+
+#[rustler::nif]
+pub fn expr_join(expr: ExExpr, sep: String) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.list().join(sep.lit()))
+}
+
+#[rustler::nif]
+pub fn expr_length(expr: ExExpr) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.list().len().cast(DataType::Int64))
+}
+
+#[rustler::nif]
+pub fn expr_member(expr: ExExpr, value: ExValidValue) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.list().contains(value.lit()))
 }

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -964,7 +964,7 @@ pub fn expr_join(expr: ExExpr, sep: String) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_length(expr: ExExpr) -> ExExpr {
+pub fn expr_lengths(expr: ExExpr) -> ExExpr {
     let expr = expr.clone_inner();
 
     ExExpr::new(expr.list().len().cast(DataType::Int64))

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -267,6 +267,10 @@ rustler::init!(
         expr_round,
         expr_floor,
         expr_ceil,
+        // list expressions
+        expr_join,
+        expr_length,
+        expr_member,
         // lazyframe
         lf_collect,
         lf_describe_plan,
@@ -446,6 +450,8 @@ rustler::init!(
         s_floor,
         s_ceil,
         s_join,
+        s_length,
+        s_member,
     ],
     load = on_load
 );

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -269,7 +269,7 @@ rustler::init!(
         expr_ceil,
         // list expressions
         expr_join,
-        expr_length,
+        expr_lengths,
         expr_member,
         // lazyframe
         lf_collect,
@@ -450,7 +450,7 @@ rustler::init!(
         s_floor,
         s_ceil,
         s_join,
-        s_length,
+        s_lengths,
         s_member,
     ],
     load = on_load

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1,6 +1,8 @@
 use crate::{
     atoms,
-    datatypes::{ExDate, ExDateTime, ExDuration, ExSeriesDtype, ExSeriesIoType, ExTime},
+    datatypes::{
+        ExDate, ExDateTime, ExDuration, ExSeriesDtype, ExSeriesIoType, ExTime, ExValidValue,
+    },
     encoding, ExDataFrame, ExSeries, ExplorerError,
 };
 
@@ -1661,6 +1663,31 @@ pub fn s_join(s1: ExSeries, separator: &str) -> Result<ExSeries, ExplorerError> 
         .list()?
         .lst_join(&ChunkedArray::new("a", &[separator]))?
         .into_series();
+
+    Ok(ExSeries::new(s2))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_length(s: ExSeries) -> Result<ExSeries, ExplorerError> {
+    let s2 = s
+        .list()?
+        .lst_lengths()
+        .into_series()
+        .cast(&DataType::Int64)?;
+
+    Ok(ExSeries::new(s2))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn s_member(s: ExSeries, value: ExValidValue) -> Result<ExSeries, ExplorerError> {
+    let s2 = s
+        .clone_inner()
+        .into_frame()
+        .lazy()
+        .select([col(s.name()).list().contains(value.lit())])
+        .collect()?
+        .column(s.name())?
+        .clone();
 
     Ok(ExSeries::new(s2))
 }

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1668,7 +1668,7 @@ pub fn s_join(s1: ExSeries, separator: &str) -> Result<ExSeries, ExplorerError> 
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_length(s: ExSeries) -> Result<ExSeries, ExplorerError> {
+pub fn s_lengths(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     let s2 = s
         .list()?
         .lst_lengths()

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1679,12 +1679,19 @@ pub fn s_length(s: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-fn s_member(s: ExSeries, value: ExValidValue) -> Result<ExSeries, ExplorerError> {
+fn s_member(
+    s: ExSeries,
+    value: ExValidValue,
+    inner_dtype: ExSeriesDtype,
+) -> Result<ExSeries, ExplorerError> {
+    let inner_dtype = DataType::try_from(&inner_dtype)?;
+    let value_expr = value.lit_with_matching_precision(&inner_dtype);
+
     let s2 = s
         .clone_inner()
         .into_frame()
         .lazy()
-        .select([col(s.name()).list().contains(value.lit())])
+        .select([col(s.name()).list().contains(value_expr)])
         .collect()?
         .column(s.name())?
         .clone();

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1864,7 +1864,7 @@ defmodule Explorer.DataFrameTest do
       df =
         DF.mutate(df,
           join: join(a, ","),
-          length: length(b),
+          lengths: lengths(b),
           member?: member?(c, ~N[2021-01-02 00:00:00])
         )
 
@@ -1876,7 +1876,7 @@ defmodule Explorer.DataFrameTest do
                  [~N[2021-01-03 00:00:00.000000], ~N[2021-01-04 00:00:00.000000]]
                ],
                join: ["a,b,c", "d,e,f"],
-               length: [3, 3],
+               lengths: [3, 3],
                member?: [true, false]
              }
     end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1851,18 +1851,30 @@ defmodule Explorer.DataFrameTest do
     end
 
     test "supports list operations" do
-      df = DF.new(a: [~w(a b c), ~w(d e f)], b: [[1, 2, 3], [4, 5, 6]])
+      df =
+        DF.new(
+          a: [~w(a b c), ~w(d e f)],
+          b: [[1, 2, 3], [4, 5, 6]],
+          c: [
+            [~N[2021-01-01 00:00:00], ~N[2021-01-02 00:00:00]],
+            [~N[2021-01-03 00:00:00], ~N[2021-01-04 00:00:00]]
+          ]
+        )
 
       df =
         DF.mutate(df,
           join: join(a, ","),
           length: length(b),
-          member?: member?(a, "a")
+          member?: member?(c, ~N[2021-01-02 00:00:00])
         )
 
       assert DF.to_columns(df, atom_keys: true) == %{
                a: [~w(a b c), ~w(d e f)],
                b: [[1, 2, 3], [4, 5, 6]],
+               c: [
+                 [~N[2021-01-01 00:00:00.000000], ~N[2021-01-02 00:00:00.000000]],
+                 [~N[2021-01-03 00:00:00.000000], ~N[2021-01-04 00:00:00.000000]]
+               ],
                join: ["a,b,c", "d,e,f"],
                length: [3, 3],
                member?: [true, false]

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1849,6 +1849,25 @@ defmodule Explorer.DataFrameTest do
       assert Series.to_list(df[:simple_result]) == ["Exceptional", "Passed", "Passed"]
       assert Series.to_list(df[:result]) == [nil, "Failed", nil]
     end
+
+    test "supports list operations" do
+      df = DF.new(a: [~w(a b c), ~w(d e f)], b: [[1, 2, 3], [4, 5, 6]])
+
+      df =
+        DF.mutate(df,
+          join: join(a, ","),
+          length: length(b),
+          member?: member?(a, "a")
+        )
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               a: [~w(a b c), ~w(d e f)],
+               b: [[1, 2, 3], [4, 5, 6]],
+               join: ["a,b,c", "d,e,f"],
+               length: [3, 3],
+               member?: [true, false]
+             }
+    end
   end
 
   describe "arrange/3" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4496,8 +4496,6 @@ defmodule Explorer.SeriesTest do
       assert series |> Series.member?(~T[00:00:01]) |> Series.to_list() == [false, true]
     end
 
-    # This test is not passing. The resulting series is [false, false] instead of [false, true].
-    @tag :skip
     test "works with datetimes" do
       series =
         Series.from_list([
@@ -4513,7 +4511,7 @@ defmodule Explorer.SeriesTest do
 
     test "works with durations" do
       series = Series.from_list([[1], [1, 2]], dtype: {:list, {:duration, :millisecond}})
-      duration = %Explorer.Duration{value: 2, precision: :millisecond}
+      duration = %Explorer.Duration{value: 2000, precision: :microsecond}
 
       assert series |> Series.member?(duration) |> Series.to_list() == [false, true]
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4449,11 +4449,11 @@ defmodule Explorer.SeriesTest do
     end
   end
 
-  describe "length/1" do
+  describe "lengths/1" do
     test "calculates the length of each list in a series" do
       series = Series.from_list([[1], [1, 2, 3], [1, 2]])
 
-      assert series |> Series.length() |> Series.to_list() == [1, 3, 2]
+      assert series |> Series.lengths() |> Series.to_list() == [1, 3, 2]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4441,11 +4441,81 @@ defmodule Explorer.SeriesTest do
     end
   end
 
-  describe "join" do
+  describe "join/2" do
     test "join/2" do
       series = Series.from_list([["1"], ["1", "2"]])
 
       assert series |> Series.join("|") |> Series.to_list() == ["1", "1|2"]
+    end
+  end
+
+  describe "length/1" do
+    test "calculates the length of each list in a series" do
+      series = Series.from_list([[1], [1, 2, 3], [1, 2]])
+
+      assert series |> Series.length() |> Series.to_list() == [1, 3, 2]
+    end
+  end
+
+  describe "member?/2" do
+    test "checks if any of the element lists contain the given value" do
+      series = Series.from_list([[1], [1, 2, 3], [1, 2]])
+
+      assert series |> Series.member?(1) |> Series.to_list() == [true, true, true]
+      assert series |> Series.member?(2) |> Series.to_list() == [false, true, true]
+      assert series |> Series.member?(3) |> Series.to_list() == [false, true, false]
+    end
+
+    test "works with floats" do
+      series = Series.from_list([[1.0], [1.0, 2.0]])
+
+      assert series |> Series.member?(2.0) |> Series.to_list() == [false, true]
+    end
+
+    test "works with booleans" do
+      series = Series.from_list([[true], [true, false]])
+
+      assert series |> Series.member?(false) |> Series.to_list() == [false, true]
+    end
+
+    test "works with strings" do
+      series = Series.from_list([["a"], ["a", "b"]])
+
+      assert series |> Series.member?("b") |> Series.to_list() == [false, true]
+    end
+
+    test "works with dates" do
+      series = Series.from_list([[~D[2021-01-01]], [~D[2021-01-01], ~D[2021-01-02]]])
+
+      assert series |> Series.member?(~D[2021-01-02]) |> Series.to_list() == [false, true]
+    end
+
+    test "works with times" do
+      series = Series.from_list([[~T[00:00:00]], [~T[00:00:00], ~T[00:00:01]]])
+
+      assert series |> Series.member?(~T[00:00:01]) |> Series.to_list() == [false, true]
+    end
+
+    # This test is not passing. The resulting series is [false, false] instead of [false, true].
+    @tag :skip
+    test "works with datetimes" do
+      series =
+        Series.from_list([
+          [~N[2021-01-01 00:00:00]],
+          [~N[2021-01-01 00:00:00], ~N[2021-01-01 00:00:01]]
+        ])
+
+      assert series |> Series.member?(~N[2021-01-01 00:00:01]) |> Series.to_list() == [
+               false,
+               true
+             ]
+    end
+
+    test "works with durations" do
+      series = Series.from_list([[1], [1, 2]], dtype: {:list, {:duration, :millisecond}})
+      duration = %Explorer.Duration{value: 2, precision: :millisecond}
+
+      assert series |> Series.member?(duration) |> Series.to_list() == [false, true]
     end
   end
 


### PR DESCRIPTION
It's me again! 💜 

This PR is adding `Series.length/1` (to calculate the length of list elements) and `Series.member?/2` (to check membership in list elements). There are a couple of things to consider:

- Function names. I'm not sure that's the pattern you want to follow (it seems like it is with `join/2`), but I also thought of something like `list_lenghts/1` and `list_member?/2`. Let me know if you have any thoughts.
- `join/2` was not being implemented for `LazySeries`, so I added a test for it in `DataFrame.mutate/2` and implemented it as well.
- I moved the conversion of struct to expression literals closer to the structs (by directly implementing the `Literal` trait. This felt cleaner/easier to re-use, but I'm more than happy to undo it if you prefer the original way.
- For the eager implementation of `member?/2`, I followed the [Python](https://github.com/pola-rs/polars/blob/38d016b61971c1ce3789fced9a7aa519983d5de9/py-polars/polars/series/list.py#L26-L27) [approach](https://github.com/pola-rs/polars/blob/38d016b61971c1ce3789fced9a7aa519983d5de9/py-polars/polars/series/utils.py#L28) (wrap the series into a frame and re-use the lazy implementation). Let me know if you have any thoughts on this.
- To make `member?/2` work with all our allowed Elixir types, I introduced an `ExValidValue` enum in the Rust code, which essentially dynamically decodes the Erlang terms into a single type, allowing us to have a single function definition in the Rust code. I think this could be re-used for functions like `fill_missing/2` that currently use a double-dispatch approach.
- `member?/2` is not working properly for `:datetime`. It doesn't error out, but it returns false when it shouldn't (I've left a skipped test with a comment to demonstrate this). My gut feeling is that it is a precision issue, but I ran out of time to continue investigating tonight. Please let me know if you have any ideas 😅 

At the same time that it feels like this PR is doing too much, the changes do seem connected, so I've decided to keep it as is instead of splitting it preemptively. Please let me know if you want me to split it up.