### PR TITLE
Drop support for RISCV 64 bits Linux target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
           - { target: aarch64-apple-darwin, os: macos-11 }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          # - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, cargo-args: "--no-default-features" }
           - { target: x86_64-apple-darwin, os: macos-11 }
           - { target: x86_64-pc-windows-gnu, os: windows-2022, rustflags: "-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma" }
           - { target: x86_64-pc-windows-gnu, os: windows-2022, variant: "legacy_cpu" }

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ rustup toolchain install nightly-2023-11-12
 You can also use [asdf](https://asdf-vm.com/):
 
 ```sh
-asdf install rust nightly-2023-07-27
+asdf install rust nightly-2023-11-12
 ```
 
 It's possible that you may need to install [`CMake`](https://cmake.org/) in order to build the project,
@@ -258,7 +258,6 @@ We support the following:
 - `aarch64-apple-darwin` - MacOS running on ARM 64 bits CPUs.
 - `aarch64-unknown-linux-gnu` - Linux running on ARM 64 bits CPUs, compiled with GCC.
 - `aarch64-unknown-linux-musl` - Linux running on ARM 64 bits CPUs, compiled with Musl.
-- `riscv64gc-unknown-linux-gnu` - Linux running on RISCV 64 bits CPUs, compiled with GCC.
 - `x86_64-apple-darwin` - MacOS running on Intel/AMD 64 bits CPUs.
 - `x86_64-pc-windows-msvc` - Windows running on Intel/AMD 64 bits CPUs, compiled with Visual C++.
 - `x86_64-pc-windows-gnu` - Windows running on Intel/AMD 64 bits CPUs, compiled with GCC.

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -37,7 +37,6 @@ defmodule Explorer.PolarsBackend.Native do
       aarch64-apple-darwin
       aarch64-unknown-linux-gnu
       aarch64-unknown-linux-musl
-      riscv64gc-unknown-linux-gnu
       x86_64-apple-darwin
       x86_64-pc-windows-msvc
       x86_64-pc-windows-gnu

--- a/native/explorer/Cross.toml
+++ b/native/explorer/Cross.toml
@@ -3,6 +3,3 @@ passthrough = [
   "RUSTLER_NIF_VERSION",
   "RUSTFLAGS"
 ]
-
-[target.riscv64gc-unknown-linux-gnu]
-pre-build = ["apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends cmake"]


### PR DESCRIPTION
Unfortunately it's been hard to maintain this target, so we decided to not support it for a while.