### PR TITLE
Add `Series.all?/1` and `Series.any?/1`

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -111,6 +111,8 @@ defmodule Explorer.Backend.LazySeries do
     skew: 2,
     correlation: 3,
     covariance: 3,
+    all: 1,
+    any: 1,
     # Strings
     contains: 2,
     replace: 3,
@@ -528,6 +530,24 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
+  def all?(%Series{} = s) do
+    args = [series_or_lazy_series!(s)]
+
+    data = new(:all, args, :boolean, true)
+
+    Backend.Series.new(data, :boolean)
+  end
+
+  @impl true
+  def any?(%Series{} = s) do
+    args = [series_or_lazy_series!(s)]
+
+    data = new(:any, args, :boolean, true)
+
+    Backend.Series.new(data, :boolean)
+  end
+
+  @impl true
   def coalesce(%Series{} = left, %Series{} = right) do
     args = [series_or_lazy_series!(left), series_or_lazy_series!(right)]
 
@@ -647,6 +667,8 @@ defmodule Explorer.Backend.LazySeries do
   defp dtype_for_agg_operation(op, series)
        when op in [:first, :last, :sum, :min, :max, :argmin, :argmax],
        do: series.dtype
+
+  defp dtype_for_agg_operation(op, _) when op in [:all?, :any?], do: :boolean
 
   defp dtype_for_agg_operation(_, _), do: {:f, 64}
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -92,6 +92,8 @@ defmodule Explorer.Backend.Series do
   @callback correlation(s, s, ddof :: non_neg_integer()) ::
               float() | non_finite() | lazy_s() | nil
   @callback covariance(s, s, ddof :: non_neg_integer()) :: float() | non_finite() | lazy_s() | nil
+  @callback all?(s) :: boolean() | lazy_s()
+  @callback any?(s) :: boolean() | lazy_s()
 
   # Cumulative
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -13,7 +13,9 @@ defmodule Explorer.PolarsBackend.Expression do
   @type t :: %__MODULE__{resource: reference()}
 
   @all_expressions [
+    all: 1,
     add: 2,
+    any: 1,
     all_equal: 2,
     argmax: 1,
     argmin: 1,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -248,7 +248,9 @@ defmodule Explorer.PolarsBackend.Native do
   # Series
   def s_as_str(_s), do: err()
   def s_add(_s, _other), do: err()
+  def s_all(_s), do: err()
   def s_and(_s, _s2), do: err()
+  def s_any(_s), do: err()
   def s_argmax(_s), do: err()
   def s_argmin(_s), do: err()
   def s_argsort(_s, _descending?, _nils_last?), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -227,6 +227,12 @@ defmodule Explorer.PolarsBackend.Series do
   def covariance(left, right, ddof),
     do: Shared.apply_series(matching_size!(left, right), :s_covariance, [right.data, ddof])
 
+  @impl true
+  def all?(series), do: Shared.apply_series(series, :s_all)
+
+  @impl true
+  def any?(series), do: Shared.apply_series(series, :s_any)
+
   # Cumulative
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2555,7 +2555,7 @@ defmodule Explorer.Series do
       iex> Series.all?(s)
       true
 
-  Nil values are ignored:
+  Opposite to Elixir but similar to databases, `nil` values are ignored:
 
       iex> s = Series.from_list([nil, true, true])
       iex> Series.all?(s)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2597,7 +2597,7 @@ defmodule Explorer.Series do
       iex> Series.any?(s)
       false
 
-  Nil values are ignored:
+  Opposite to Elixir but similar to databases, `nil` values are ignored:
 
       iex> s = Series.from_list([nil, true, true])
       iex> Series.any?(s)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2528,6 +2528,90 @@ defmodule Explorer.Series do
     basic_numeric_operation(:covariance, left, right, [ddof])
   end
 
+  @doc """
+  Returns if all the values in a boolean series are true.
+
+  ## Supported dtypes
+
+    * `:boolean`
+
+  ## Examples
+
+      iex> s = Series.from_list([true, true, true])
+      iex> Series.all?(s)
+      true
+
+      iex> s = Series.from_list([true, false, true])
+      iex> Series.all?(s)
+      false
+
+      iex> s = Series.from_list([1, 2, 3])
+      iex> Series.all?(s)
+      ** (ArgumentError) Explorer.Series.all?/1 not implemented for dtype :integer. Valid dtypes are [:boolean]
+
+  An empty series will always return true:
+
+      iex> s = Series.from_list([], dtype: :boolean)
+      iex> Series.all?(s)
+      true
+
+  Nil values are ignored:
+
+      iex> s = Series.from_list([nil, true, true])
+      iex> Series.all?(s)
+      true
+
+      iex> s = Series.from_list([nil, nil, nil], dtype: :boolean)
+      iex> Series.all?(s)
+      true
+  """
+  @doc type: :aggregation
+  @spec all?(series :: Series.t()) :: boolean()
+  def all?(%Series{dtype: :boolean} = series), do: apply_series(series, :all?)
+  def all?(%Series{dtype: dtype}), do: dtype_error("all?/1", dtype, [:boolean])
+
+  @doc """
+  Returns if any of the values in a boolean series are true.
+
+  ## Supported dtypes
+
+    * `:boolean`
+
+  ## Examples
+
+      iex> s = Series.from_list([true, true, true])
+      iex> Series.any?(s)
+      true
+
+      iex> s = Series.from_list([true, false, true])
+      iex> Series.any?(s)
+      true
+
+      iex> s = Series.from_list([1, 2, 3])
+      iex> Series.any?(s)
+      ** (ArgumentError) Explorer.Series.any?/1 not implemented for dtype :integer. Valid dtypes are [:boolean]
+
+  An empty series will always return `false`:
+
+      iex> s = Series.from_list([], dtype: :boolean)
+      iex> Series.any?(s)
+      false
+
+  Nil values are ignored:
+
+      iex> s = Series.from_list([nil, true, true])
+      iex> Series.any?(s)
+      true
+
+      iex> s = Series.from_list([nil, nil, nil], dtype: :boolean)
+      iex> Series.any?(s)
+      false
+  """
+  @doc type: :aggregation
+  @spec any?(series :: Series.t()) :: boolean()
+  def any?(%Series{dtype: :boolean} = series), do: apply_series(series, :any?)
+  def any?(%Series{dtype: dtype}), do: dtype_error("any?/1", dtype, [:boolean])
+
   # Cumulative
 
   @doc """

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -508,6 +508,20 @@ pub fn expr_covariance(left: ExExpr, right: ExExpr, ddof: u8) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_all(expr: ExExpr) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.all(true))
+}
+
+#[rustler::nif]
+pub fn expr_any(expr: ExExpr) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.any(true))
+}
+
+#[rustler::nif]
 pub fn expr_alias(expr: ExExpr, name: &str) -> ExExpr {
     let expr = expr.clone_inner();
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -241,6 +241,8 @@ rustler::init!(
         expr_skew,
         expr_correlation,
         expr_covariance,
+        expr_all,
+        expr_any,
         // window expressions
         expr_cumulative_max,
         expr_cumulative_min,
@@ -373,6 +375,8 @@ rustler::init!(
         s_skew,
         s_correlation,
         s_covariance,
+        s_all,
+        s_any,
         s_min,
         s_mode,
         s_multiply,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1013,6 +1013,20 @@ pub fn s_covariance(env: Env, s1: ExSeries, s2: ExSeries, ddof: u8) -> Result<Te
     Ok(term_from_optional_float(cov, env))
 }
 
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_all(s: ExSeries) -> Result<bool, ExplorerError> {
+    let s = s.clone_inner();
+
+    Ok(s.bool()?.all())
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_any(s: ExSeries) -> Result<bool, ExplorerError> {
+    let s = s.clone_inner();
+
+    Ok(s.bool()?.any())
+}
+
 fn term_from_optional_float(option: Option<f64>, env: Env<'_>) -> Term<'_> {
     match option {
         Some(float) => encoding::term_from_float64(float, env),

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3703,6 +3703,25 @@ defmodule Explorer.DataFrameTest do
                f: [2]
              }
     end
+
+    test "all?/1 and any?/1" do
+      df = DF.new([a: [true, false, true], nils: [nil, nil, nil]], dtypes: [nils: :boolean])
+
+      df1 =
+        DF.summarise(df,
+          all?: all?(a),
+          any?: any?(a),
+          all_nils?: all?(nils),
+          any_nils?: any?(nils)
+        )
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               all?: [false],
+               any?: [true],
+               all_nils?: [true],
+               any_nils?: [false]
+             }
+    end
   end
 
   describe "explode/2" do


### PR DESCRIPTION
This PR introduces two new aggregations: `Series.all?/1` and `Series.any?/1`.

The main thing to keep in mind with these functions is how to deal with `nil`. I could see three approaches:

- Ignore `nil` values (`all?([nil, nil, nil]) == all?([])`)
- Use [Kleene Logic](https://en.wikipedia.org/wiki/Three-valued_logic), treating `nil` as _unknown_, and return `nil` whenever it makes the result also unknown (`any?([nil, true]) == true` and `all?([nil, false]) == false`, but `any?([nil, false]) == nil` and `all?([nil, true]) == nil`)
  - this is how the existing `Series.and/2` and `Series.or/2` functions behave
- Treat `nil` as `false` just like in the `Enum` functions (`all?([nil, true]) == false`)

I went with the first option here as it seems to be the default behavior in Polars, but I can see the appeal for either of them. The one thing to consider about the third option above is that it doesn't have native support in Polars, so it would need to be implemented on the Explorer side (should be straightforward with a call to `fill_missing(false)` before aggregating).

Another route I can see is supporting all behaviors, and letting the caller decide through an option:

```elixir
all?(s, nils: :as_false | :ignore | :kleene)
```

Let me know what your thoughts are!