### PR TITLE
DF.arrange options

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -162,7 +162,13 @@ defmodule Explorer.Backend.DataFrame do
   @callback mask(df, mask :: series) :: df
   @callback filter_with(df, out_df :: df(), lazy_series()) :: df
   @callback mutate_with(df, out_df :: df(), mutations :: [{column_name(), lazy_series()}]) :: df
-  @callback arrange_with(df, out_df :: df(), directions :: [{:asc | :desc, lazy_series()}]) :: df
+  @callback arrange_with(
+              df,
+              out_df :: df(),
+              directions :: [{:asc | :desc, lazy_series()}],
+              nulls_last :: boolean(),
+              maintain_order :: boolean()
+            ) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()]) :: df
   @callback rename(df, out_df :: df(), [{old :: column_name(), new :: column_name()}]) :: df
   @callback dummies(df, out_df :: df(), columns :: [column_name()]) :: df

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -643,7 +643,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def arrange_with(%DataFrame{} = df, out_df, column_pairs) do
+  def arrange_with(%DataFrame{} = df, out_df, column_pairs, nulls_last, maintain_order) do
     {directions, expressions} =
       column_pairs
       |> Enum.map(fn {direction, lazy_series} ->
@@ -652,7 +652,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
       end)
       |> Enum.unzip()
 
-    Shared.apply_dataframe(df, out_df, :df_arrange_with, [expressions, directions, df.groups])
+    Shared.apply_dataframe(df, out_df, :df_arrange_with, [
+      expressions,
+      directions,
+      nulls_last,
+      maintain_order,
+      df.groups
+    ])
   end
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -354,17 +354,22 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def arrange_with(%DF{groups: []} = df, out_df, column_pairs) do
+  def arrange_with(%DF{groups: []} = df, out_df, column_pairs, nulls_last, maintain_order) do
     {directions, expressions} =
       column_pairs
       |> Enum.map(fn {direction, lazy_series} -> {direction == :desc, to_expr(lazy_series)} end)
       |> Enum.unzip()
 
-    Shared.apply_dataframe(df, out_df, :lf_arrange_with, [expressions, directions])
+    Shared.apply_dataframe(df, out_df, :lf_arrange_with, [
+      expressions,
+      directions,
+      nulls_last,
+      maintain_order
+    ])
   end
 
   @impl true
-  def arrange_with(_df, _out_df, _directions) do
+  def arrange_with(_df, _out_df, _directions, _nulls_last, _maintain_order) do
     raise "arrange_with/2 with groups is not supported yet for lazy frames"
   end
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -58,8 +58,11 @@ defmodule Explorer.PolarsBackend.Native do
   defstruct [:inner]
 
   def df_from_arrow_stream_pointer(_stream_ptr), do: err()
-  def df_arrange(_df, _by, _reverse, _groups), do: err()
-  def df_arrange_with(_df, _expressions, _directions, _groups), do: err()
+  def df_arrange(_df, _by, _reverse, _nulls_last, _maintain_order, _groups), do: err()
+
+  def df_arrange_with(_df, _expressions, _directions, _nulls_last, _maintain_order, _groups),
+    do: err()
+
   def df_concat_columns(_df, _others), do: err()
   def df_concat_rows(_df, _others), do: err()
   def df_distinct(_df, _subset, _selection), do: err()
@@ -229,7 +232,7 @@ defmodule Explorer.PolarsBackend.Native do
       do: err()
 
   def lf_filter_with(_df, _expression), do: err()
-  def lf_arrange_with(_df, _expressions, _directions), do: err()
+  def lf_arrange_with(_df, _expressions, _directions, _nulls_last, _maintain_order), do: err()
   def lf_distinct(_df, _subset, _selection), do: err()
   def lf_mutate_with(_df, _exprs), do: err()
   def lf_summarise_with(_df, _groups, _aggs), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -347,12 +347,24 @@ pub fn df_arrange(
     df: ExDataFrame,
     by_columns: Vec<String>,
     reverse: Vec<bool>,
+    nulls_last: bool,
+    maintain_order: bool,
     groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
-    // TODO: make maintain_order an option.
-    let maintain_order = true;
     let new_df = if groups.is_empty() {
-        df.sort(by_columns, reverse, maintain_order)?
+        // Note: we cannot use either df.sort or df.sort_with_options.
+        // df.sort does not allow a nulls_last option.
+        // df.sort_with_options only allows a single column.
+        let by_columns = df.select_series(by_columns)?;
+        let multithreaded = false;
+        df.sort_impl(
+            by_columns,
+            reverse,
+            nulls_last,
+            maintain_order,
+            None,
+            multithreaded,
+        )?
     } else {
         df.group_by_stable(groups)?
             .apply(|df| df.sort(by_columns.clone(), reverse.clone(), maintain_order))?
@@ -366,14 +378,12 @@ pub fn df_arrange_with(
     data: ExDataFrame,
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
+    nulls_last: bool,
+    maintain_order: bool,
     groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = data.clone_inner();
     let exprs = ex_expr_to_exprs(expressions);
-
-    // TODO: make these bools options
-    let nulls_last = false;
-    let maintain_order = true;
 
     let new_df = if groups.is_empty() {
         df.lazy()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -356,6 +356,7 @@ pub fn df_arrange(
         // df.sort does not allow a nulls_last option.
         // df.sort_with_options only allows a single column.
         let by_columns = df.select_series(by_columns)?;
+        // TODO: make these bools options.
         let multithreaded = false;
         df.sort_impl(
             by_columns,

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -97,11 +97,9 @@ pub fn lf_arrange_with(
     data: ExLazyFrame,
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
+    nulls_last: bool,
+    maintain_order: bool,
 ) -> Result<ExLazyFrame, ExplorerError> {
-    // Make these bools options
-    let maintain_order = true;
-    let nulls_last = false;
-
     let exprs = ex_expr_to_exprs(expressions);
     let ldf = data
         .clone_inner()

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1951,6 +1951,21 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with a simple df and nils" do
+      df = DF.new(a: [1, 2, nil, 3])
+      df1 = DF.arrange_with(df, fn ldf -> [asc: ldf["a"]] end, nils: :first)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [nil, 1, 2, 3]
+             }
+
+      df2 = DF.arrange_with(df, fn ldf -> [asc: ldf["a"]] end, nils: :last)
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               a: [1, 2, 3, nil]
+             }
+    end
+
     test "without a lazy series" do
       df = DF.new(a: [1, 2])
 


### PR DESCRIPTION
Adds the following options to `DF.arrange` and `DF.arrange_with`:

* `nils: :first | :last`
* `stable: boolean()`

This is a prerequisite for https://github.com/elixir-explorer/explorer/issues/730#issuecomment-1804577613.