### PR TITLE
Add initial support for struct dtype

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -324,6 +324,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_from_list_binary(_name, _val), do: err()
   def s_from_list_categories(_name, _val), do: err()
   def s_from_list_of_series(_name, _val), do: err()
+  def s_from_list_of_series_as_structs(_name, _val), do: err()
   def s_from_binary_f32(_name, _val), do: err()
   def s_from_binary_f64(_name, _val), do: err()
   def s_from_binary_i32(_name, _val), do: err()

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -118,6 +118,18 @@ defmodule Explorer.PolarsBackend.Shared do
     Native.s_from_list_of_series(name, series)
   end
 
+  def from_list(list, {:struct, fields} = _dtype, name) when is_list(list) do
+    series =
+      for {column, values} <- Table.to_columns(list) do
+        column = to_string(column)
+        inner_type = Map.fetch!(fields, column)
+
+        from_list(values, inner_type, column)
+      end
+
+    Native.s_from_list_of_series_as_structs(name, series)
+  end
+
   def from_list(list, dtype, name) when is_list(list) do
     case dtype do
       :integer -> Native.s_from_list_i64(name, list)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -16,7 +16,8 @@ defmodule Explorer.Series do
     * `:time` - Time type that unwraps to `Elixir.Time`
     * `{:list, dtype}` - A recursive dtype that can store lists. Examples: `{:list, :integer}` or
       a nested list dtype like `{:list, {:list, :integer}}`.
-    * `{:struct, %{key => dtype}}` - A recursive dtype that can store structs. Examples:
+    * `{:struct, %{key => dtype}}` - A recursive dtype that can store Arrow/Polars structs (not to be
+      confused with Elixir's struct). This type unwraps to Elixir maps with string keys. Examples:
       `{:struct, %{"a" => :integer}}` or a nested struct dtype like `{:struct, %{"a" => {:struct, %{"b" => :integer}}}}`.
 
   The following data type aliases are also supported:

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -16,6 +16,8 @@ defmodule Explorer.Series do
     * `:time` - Time type that unwraps to `Elixir.Time`
     * `{:list, dtype}` - A recursive dtype that can store lists. Examples: `{:list, :integer}` or
       a nested list dtype like `{:list, {:list, :integer}}`.
+    * `{:struct, %{key => dtype}}` - A recursive dtype that can store structs. Examples:
+      `{:struct, %{"a" => :integer}}` or a nested struct dtype like `{:struct, %{"a" => {:struct, %{"b" => :integer}}}}`.
 
   The following data type aliases are also supported:
 
@@ -77,7 +79,7 @@ defmodule Explorer.Series do
   @numeric_dtypes [:integer | @float_dtypes]
   @numeric_or_temporal_dtypes @numeric_dtypes ++ @temporal_dtypes
 
-  @io_dtypes Shared.dtypes() -- [:binary, :string, {:list, :any}]
+  @io_dtypes Shared.dtypes() -- [:binary, :string, {:list, :any}, {:struct, :any}]
 
   @type dtype ::
           :binary
@@ -92,11 +94,13 @@ defmodule Explorer.Series do
           | :integer
           | :string
           | list_dtype
+          | struct_dtype
 
   @type time_unit :: :nanosecond | :microsecond | :millisecond
   @type datetime_dtype :: {:datetime, time_unit}
   @type duration_dtype :: {:duration, time_unit}
   @type list_dtype :: {:list, dtype()}
+  @type struct_dtype :: {:struct, %{String.t() => dtype()}}
 
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
@@ -2202,7 +2206,7 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-  All except `:list`.
+  All except `:list` and `:struct`.
 
   ## Examples
 
@@ -2230,7 +2234,7 @@ defmodule Explorer.Series do
   @doc type: :aggregation
   @spec mode(series :: Series.t()) :: Series.t() | nil
   def mode(%Series{dtype: {:list, _} = dtype}),
-    do: dtype_error("mode/1", dtype, Shared.dtypes() -- [{:list, :any}])
+    do: dtype_error("mode/1", dtype, Shared.dtypes() -- [{:list, :any}, {:struct, :any}])
 
   def mode(%Series{} = series),
     do: Shared.apply_impl(series, :mode)

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -309,7 +309,7 @@ defmodule Explorer.Shared do
 
   defp new_type_matches?(type, type), do: true
 
-  defp new_type_matches?(nil, _new_trpe), do: true
+  defp new_type_matches?(nil, _new_type), do: true
 
   defp new_type_matches?({:struct, types}, {:struct, new_types}) do
     Enum.all?(types, fn {key, type} ->

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -399,6 +399,7 @@ rustler::init!(
         s_from_list_binary,
         s_from_list_categories,
         s_from_list_of_series,
+        s_from_list_of_series_as_structs,
         s_from_binary_f32,
         s_from_binary_f64,
         s_from_binary_i64,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -173,6 +173,21 @@ pub fn s_from_list_of_series(name: &str, series_vec: Vec<Option<ExSeries>>) -> E
     ExSeries::new(Series::new(name, lists))
 }
 
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_of_series_as_structs(name: &str, series_vec: Vec<ExSeries>) -> ExSeries {
+    let struct_chunked = StructChunked::new(
+        name,
+        series_vec
+            .into_iter()
+            .map(|s| s.clone_inner())
+            .collect::<Vec<_>>()
+            .as_slice(),
+    )
+    .unwrap();
+
+    ExSeries::new(struct_chunked.into_series())
+}
+
 macro_rules! from_binary {
     ($name:ident, $type:ty, $bytes:expr) => {
         #[rustler::nif(schedule = "DirtyCpu")]

--- a/test/explorer/data_frame/ipc_stream_test.exs
+++ b/test/explorer/data_frame/ipc_stream_test.exs
@@ -123,6 +123,10 @@ defmodule Explorer.DataFrame.IPCStreamTest do
       assert_ipc_stream({:list, {:f, 64}}, [["100.42"]], [100.42])
       assert_ipc_stream({:list, {:f, 64}}, [["-101.51"]], [-101.51])
     end
+
+    test "struct" do
+      assert_ipc_stream({:struct, %{"a" => :integer}}, [%{a: 1}], %{"a" => 1})
+    end
   end
 
   describe "to_ipc_stream/3" do

--- a/test/explorer/data_frame/ipc_test.exs
+++ b/test/explorer/data_frame/ipc_test.exs
@@ -120,6 +120,10 @@ defmodule Explorer.DataFrame.IPCTest do
       assert_ipc({:list, {:f, 64}}, [["100.42"]], [100.42])
       assert_ipc({:list, {:f, 64}}, [["-101.51"]], [-101.51])
     end
+
+    test "struct" do
+      assert_ipc({:struct, %{"a" => :integer}}, [%{a: 1}], %{"a" => 1})
+    end
   end
 
   describe "to_ipc/3" do

--- a/test/explorer/data_frame/ndjson_test.exs
+++ b/test/explorer/data_frame/ndjson_test.exs
@@ -121,6 +121,10 @@ defmodule Explorer.DataFrame.NDJSONTest do
       assert_ndjson({:list, {:f, 64}}, [["-101.51"]], [-101.51])
     end
 
+    test "structs" do
+      assert_ndjson({:struct, %{"a" => :integer}}, [%{a: 1}], %{"a" => 1})
+    end
+
     # test "date" do
     #   assert_ndjson(:date, "19327", ~D[2022-12-01])
     #   assert_ndjson(:date, "-3623", ~D[1960-01-31])

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -223,6 +223,10 @@ defmodule Explorer.DataFrame.ParquetTest do
       assert_parquet({:list, {:f, 64}}, [["100.42"]], [100.42])
       assert_parquet({:list, {:f, 64}}, [["-101.51"]], [-101.51])
     end
+
+    test "struct" do
+      assert_parquet({:struct, %{"a" => :integer}}, [%{a: 1}], %{"a" => 1})
+    end
   end
 
   test "dump_parquet/1 without compression" do

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -109,6 +109,14 @@ defmodule Explorer.Series.StructTest do
 
       assert Series.dtype(s1) == {:struct, %{"a" => {:datetime, :microsecond}}}
     end
+
+    test "errors when casting to invalid nested types" do
+      s = Series.from_list([%{a: 1}, %{a: 2}])
+
+      assert_raise ArgumentError,
+                   ~r"Explorer.Series.cast/2 not implemented for dtype {:struct, %{\"a\" => :invalid_type}}",
+                   fn -> Series.cast(s, {:struct, %{"a" => :invalid_type}}) end
+    end
   end
 
   describe "inspect/1" do

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -61,6 +61,13 @@ defmodule Explorer.Series.StructTest do
       assert Series.to_list(series) == [%{"a" => 1.0, "b" => 2.4}, %{"a" => 1.5, "b" => 2.0}]
     end
 
+    test "allows nested lists with structs" do
+      series = Series.from_list([[%{a: 1}, %{a: 2}], [%{a: 3}]])
+
+      assert series.dtype == {:list, {:struct, %{"a" => :integer}}}
+      assert Series.to_list(series) == [[%{"a" => 1}, %{"a" => 2}], [%{"a" => 3}]]
+    end
+
     test "errors when structs have mismatched types" do
       assert_raise ArgumentError,
                    "the value %{a: \"a\"} does not match the inferred series dtype {:struct, %{\"a\" => :integer}}",
@@ -69,6 +76,10 @@ defmodule Explorer.Series.StructTest do
       assert_raise ArgumentError,
                    "the value %{b: 1} does not match the inferred series dtype {:struct, %{\"a\" => :integer}}",
                    fn -> Series.from_list([%{a: 1}, %{b: 1}]) end
+
+      assert_raise ArgumentError,
+                   "the value [%{a: \"a\"}] does not match the inferred series dtype {:list, {:struct, %{\"a\" => :integer}}}",
+                   fn -> Series.from_list([[%{a: 1}], [%{a: "a"}]]) end
     end
   end
 

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -1,0 +1,139 @@
+defmodule Explorer.Series.StructTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.Series
+
+  describe "from_list/2" do
+    test "allows struct values" do
+      s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}])
+
+      assert s.dtype == {:struct, %{"a" => :integer}}
+
+      assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+    end
+
+    test "allows structs with nil values" do
+      s =
+        Series.from_list([
+          %{a: nil, b: 2},
+          %{a: 3, b: nil},
+          %{a: 5, b: 6}
+        ])
+
+      assert s.dtype == {:struct, %{"a" => :integer, "b" => :integer}}
+
+      assert Series.to_list(s) == [
+               %{"a" => nil, "b" => 2},
+               %{"a" => 3, "b" => nil},
+               %{"a" => 5, "b" => 6}
+             ]
+    end
+
+    test "allows nested structs" do
+      s =
+        Series.from_list([
+          %{a: %{b: 1}},
+          %{a: %{b: 2}},
+          %{a: %{b: 3}}
+        ])
+
+      assert s.dtype == {:struct, %{"a" => {:struct, %{"b" => :integer}}}}
+
+      assert Series.to_list(s) == [
+               %{"a" => %{"b" => 1}},
+               %{"a" => %{"b" => 2}},
+               %{"a" => %{"b" => 3}}
+             ]
+    end
+
+    test "allows structs structs with special float values" do
+      series = Series.from_list([%{a: :nan, b: :infinity, c: :neg_infinity}])
+
+      assert series.dtype == {:struct, %{"a" => {:f, 64}, "b" => {:f, 64}, "c" => {:f, 64}}}
+      assert series[0] == %{"a" => :nan, "b" => :infinity, "c" => :neg_infinity}
+      assert Series.to_list(series) == [%{"a" => :nan, "b" => :infinity, "c" => :neg_infinity}]
+    end
+
+    test "allows structs mixing integers and floats" do
+      series = Series.from_list([%{a: 1, b: 2.4}, %{a: 1.5, b: 2}])
+
+      assert series.dtype == {:struct, %{"a" => {:f, 64}, "b" => {:f, 64}}}
+      assert Series.to_list(series) == [%{"a" => 1.0, "b" => 2.4}, %{"a" => 1.5, "b" => 2.0}]
+    end
+
+    test "errors when structs have mismatched types" do
+      assert_raise ArgumentError,
+                   "the value %{a: \"a\"} does not match the inferred series dtype {:struct, %{\"a\" => :integer}}",
+                   fn -> Series.from_list([%{a: 1}, %{a: "a"}]) end
+
+      assert_raise ArgumentError,
+                   "the value %{b: 1} does not match the inferred series dtype {:struct, %{\"a\" => :integer}}",
+                   fn -> Series.from_list([%{a: 1}, %{b: 1}]) end
+    end
+  end
+
+  describe "cast/2" do
+    test "struct with integers to struct with floats" do
+      s = Series.from_list([%{a: 1}, %{a: 2}])
+      s1 = Series.cast(s, {:struct, %{"a" => {:f, 64}}})
+
+      assert Series.to_list(s1) == [%{"a" => 1.0}, %{"a" => 2.0}]
+      assert Series.dtype(s1) == {:struct, %{"a" => {:f, 64}}}
+    end
+
+    test "nested structs with integers to nested structs with floats" do
+      s = Series.from_list([%{a: %{b: 1}}, %{a: %{b: 2}}])
+      s1 = Series.cast(s, {:struct, %{"a" => {:struct, %{"b" => {:f, 64}}}}})
+
+      assert Series.to_list(s1) == [%{"a" => %{"b" => 1.0}}, %{"a" => %{"b" => 2.0}}]
+      assert Series.dtype(s1) == {:struct, %{"a" => {:struct, %{"b" => {:f, 64}}}}}
+    end
+
+    test "structs with integers to structs with datetimes" do
+      s =
+        Series.from_list([
+          %{a: 1},
+          %{a: 2},
+          %{a: 3},
+          %{a: 1_649_883_642 * 1_000 * 1_000}
+        ])
+
+      s1 = Series.cast(s, {:struct, %{"a" => {:datetime, :microsecond}}})
+
+      assert Series.to_list(s1) == [
+               %{"a" => ~N[1970-01-01 00:00:00.000001]},
+               %{"a" => ~N[1970-01-01 00:00:00.000002]},
+               %{"a" => ~N[1970-01-01 00:00:00.000003]},
+               %{"a" => ~N[2022-04-13 21:00:42.000000]}
+             ]
+
+      assert Series.dtype(s1) == {:struct, %{"a" => {:datetime, :microsecond}}}
+    end
+  end
+
+  describe "inspect/1" do
+    test "struct with integer values" do
+      s = Series.from_list([%{a: 1}, %{a: 2}])
+
+      assert inspect(s) ==
+               """
+               #Explorer.Series<
+                 Polars[2]
+                 struct[1] [%{"a" => 1}, %{"a" => 2}]
+               >\
+               """
+    end
+  end
+
+  test "struct with nested values" do
+    s = Series.from_list([%{a: %{b: 1}, c: [2]}, %{a: %{b: 2}, c: [4]}])
+
+    assert inspect(s) ==
+             """
+             #Explorer.Series<
+               Polars[2]
+               struct[2] [%{"a" => %{"b" => 1}, "c" => [2]}, %{"a" => %{"b" => 2}, "c" => [4]}]
+             >\
+             """
+  end
+end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1,7 +1,7 @@
 defmodule Explorer.SeriesTest do
   use ExUnit.Case, async: true
 
-  # Note that for the `{:list, _}` dtype, we have a separated file for the tests.
+  # Note that for the `{:list, _}` and `{:struct, _}` dtypes, we have a separated file for the tests.
 
   alias Explorer.Series
 
@@ -4623,6 +4623,14 @@ defmodule Explorer.SeriesTest do
 
       assert_raise ArgumentError,
                    "cannot convert series of dtype {:list, :integer} into iovec",
+                   fn -> Series.to_iovec(series) end
+    end
+
+    test "struct" do
+      series = Series.from_list([%{a: 1}, %{a: 2}])
+
+      assert_raise ArgumentError,
+                   ~S'cannot convert series of dtype {:struct, %{"a" => :integer}} into iovec',
                    fn -> Series.to_iovec(series) end
     end
   end


### PR DESCRIPTION
This PR is heavily inspired by the work done [here](https://github.com/elixir-explorer/explorer/pull/725).

What works at this point:

- defining basic K/V structures
- defining nested K/V structures
- casting
- inspection
- importing/exporting from parquet/IPC/NDJSON (CSV is not supported)

The goal is to add initial support to the type now and add extra functionality (like `Series.field/2` and `DataFrame.unnest/2`) in the future.

I'm well aware that I'm opening a PR with some big changes without discussing it first, so if this is not a feature the Explorer team wants to add, or if you want to take a completely different approach than what I did, please feel free to scrape this. 🙂 