### PR TITLE
Hopefully improves the description of DataFrame.arrange_with()

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3150,9 +3150,8 @@ defmodule Explorer.DataFrame do
   @doc """
   Arranges/sorts rows by columns using a callback function.
 
-  The callback receives a lazy dataframe. A lazy dataframe does
-  hold any values, instead it stores all operations in order to
-  execute all sorting performantly.
+  The callback receives a lazy dataframe. A lazy dataframe does not
+  hold values; instead it stores operations for efficient sorting.
 
   This is a callback version of `arrange/2`.
 


### PR DESCRIPTION
The prior description of DataFrame.arrange_with appears to be missing the word "not".

With less confidence, I thought the phrasing could be improved. This is less important than adding "not".

I'm offering this because one of the things that contributes to my experience with Elixir is the wonderful, quality documentation. 