### PR TITLE
Add `Series.sort_by` and `Series.sort_with`

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1631,6 +1631,28 @@ defmodule Explorer.Series do
     |> Explorer.DataFrame.pull(:series)
   end
 
+  @doc type: :element_wise
+  defmacro arrange(series, query, opts \\ []) do
+    {direction, opts} = Keyword.pop(opts, :direction, :asc)
+
+    quote do
+      require Explorer.DataFrame
+
+      Explorer.DataFrame.new(_: unquote(series))
+      |> Explorer.DataFrame.arrange([{unquote(direction), unquote(query)}], unquote(opts))
+      |> Explorer.DataFrame.pull(:_)
+    end
+  end
+
+  @doc type: :element_wise
+  def arrange_with(%Series{} = series, fun, opts \\ []) do
+    {direction, opts} = Keyword.pop(opts, :direction, :asc)
+
+    Explorer.DataFrame.new(series: series)
+    |> Explorer.DataFrame.arrange_with(&[{direction, fun.(&1[:series])}], opts)
+    |> Explorer.DataFrame.pull(:series)
+  end
+
   @doc """
   Filters a series with a mask.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1631,7 +1631,55 @@ defmodule Explorer.Series do
     |> Explorer.DataFrame.pull(:series)
   end
 
-  @doc type: :element_wise
+  @doc """
+  Sorts the series based on an expression.
+
+  > #### Notice {: .notice}
+  >
+  > This is a macro.
+  >
+  >   * You must `require Explorer.Series` before using it.
+  >   * You must use the special `_` syntax. See the moduledoc for details.
+
+  See `sort_with/3` for the callback-based version of this function.
+
+  ## Options
+
+    * `:direction` - `:asc` or `:desc`, meaning "ascending" or "descending", respectively.
+      By default it sorts in ascending order.
+
+    * `:nils` - `:first` or `:last`.
+      By default it is `:last` if direction is `:asc`, and `:first` otherwise.
+
+    * `:stable` - `true` or `false`.
+      Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
+      Unstable sorting may be more performant.
+      By default it is `true`.
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.sort_by(s, remainder(_, 3))
+      #Explorer.Series<
+        Polars[3]
+        integer [3, 1, 2]
+      >
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.sort_by(s, remainder(_, 3), direction: :desc)
+      #Explorer.Series<
+        Polars[3]
+        integer [2, 1, 3]
+      >
+
+      iex> s = Explorer.Series.from_list([1, nil, 2, 3])
+      iex> Explorer.Series.sort_by(s, -2 * _, nils: :first)
+      #Explorer.Series<
+        Polars[4]
+        integer [nil, 3, 2, 1]
+      >
+  """
+  @doc type: :shape
   defmacro sort_by(series, query, opts \\ []) do
     {direction, opts} = Keyword.pop(opts, :direction, :asc)
 
@@ -1644,7 +1692,48 @@ defmodule Explorer.Series do
     end
   end
 
-  @doc type: :element_wise
+  @doc """
+  Sorts the series based on a callback that returns a lazy series.
+
+  See `sort_by/3` for the expression-based version of this function.
+
+  ## Options
+
+    * `:direction` - `:asc` or `:desc`, meaning "ascending" or "descending", respectively.
+      By default it sorts in ascending order.
+
+    * `:nils` - `:first` or `:last`.
+      By default it is `:last` if direction is `:asc`, and `:first` otherwise.
+
+    * `:stable` - `true` or `false`.
+      Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
+      Unstable sorting may be more performant.
+      By default it is `true`.
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.sort_with(s, &Explorer.Series.remainder(&1, 3))
+      #Explorer.Series<
+        Polars[3]
+        integer [3, 1, 2]
+      >
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.sort_with(s, &Explorer.Series.remainder(&1, 3), direction: :desc)
+      #Explorer.Series<
+        Polars[3]
+        integer [2, 1, 3]
+      >
+
+      iex> s = Explorer.Series.from_list([1, nil, 2, 3])
+      iex> Explorer.Series.sort_with(s, &Explorer.Series.multiply(-2, &1), nils: :first)
+      #Explorer.Series<
+        Polars[4]
+        integer [nil, 3, 2, 1]
+      >
+  """
+  @doc type: :shape
   def sort_with(%Series{} = series, fun, opts \\ []) do
     {direction, opts} = Keyword.pop(opts, :direction, :asc)
 
@@ -4205,6 +4294,9 @@ defmodule Explorer.Series do
   Sorts the series.
 
   Sorting is stable by default.
+
+  See `sort_by/3` for an expression-based sorting function.
+  See `sort_with/3` for a callback-based sorting function.
 
   ## Options
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1632,7 +1632,7 @@ defmodule Explorer.Series do
   end
 
   @doc type: :element_wise
-  defmacro arrange(series, query, opts \\ []) do
+  defmacro sort_by(series, query, opts \\ []) do
     {direction, opts} = Keyword.pop(opts, :direction, :asc)
 
     quote do
@@ -1645,7 +1645,7 @@ defmodule Explorer.Series do
   end
 
   @doc type: :element_wise
-  def arrange_with(%Series{} = series, fun, opts \\ []) do
+  def sort_with(%Series{} = series, fun, opts \\ []) do
     {direction, opts} = Keyword.pop(opts, :direction, :asc)
 
     Explorer.DataFrame.new(series: series)

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2853,7 +2853,7 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s1 = Series.from_list([1, 2, 3])
-      result = Series.arrange(s1, remainder(_, 3))
+      result = Series.sort_by(s1, remainder(_, 3))
       assert Series.to_list(result) == [3, 1, 2]
     end
 
@@ -2861,7 +2861,7 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s1 = Series.from_list([1, 2, 3])
-      result = Series.arrange(s1, remainder(_, 3), direction: :desc)
+      result = Series.sort_by(s1, remainder(_, 3), direction: :desc)
       assert Series.to_list(result) == [2, 1, 3]
     end
 
@@ -2869,7 +2869,7 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s1 = Series.from_list([1, nil, 2, 3])
-      result = Series.arrange(s1, remainder(_, 3))
+      result = Series.sort_by(s1, remainder(_, 3))
       assert Series.to_list(result) == [3, 1, 2, nil]
     end
 
@@ -2877,7 +2877,7 @@ defmodule Explorer.SeriesTest do
       require Explorer.Series
 
       s1 = Series.from_list([1, nil, 2, 3])
-      result = Series.arrange(s1, remainder(_, 3), nils: :first)
+      result = Series.sort_by(s1, remainder(_, 3), nils: :first)
       assert Series.to_list(result) == [nil, 3, 1, 2]
     end
   end
@@ -2885,25 +2885,25 @@ defmodule Explorer.SeriesTest do
   describe "arrange_with/2" do
     test "ascending order (default)" do
       s1 = Series.from_list([1, 2, 3])
-      result = Series.arrange_with(s1, &Series.remainder(&1, 3))
+      result = Series.sort_with(s1, &Series.remainder(&1, 3))
       assert Series.to_list(result) == [3, 1, 2]
     end
 
     test "descending order" do
       s1 = Series.from_list([1, 2, 3])
-      result = Series.arrange_with(s1, &Series.remainder(&1, 3), direction: :desc)
+      result = Series.sort_with(s1, &Series.remainder(&1, 3), direction: :desc)
       assert Series.to_list(result) == [2, 1, 3]
     end
 
     test "nils last (default)" do
       s1 = Series.from_list([1, nil, 2, 3])
-      result = Series.arrange_with(s1, &Series.remainder(&1, 3))
+      result = Series.sort_with(s1, &Series.remainder(&1, 3))
       assert Series.to_list(result) == [3, 1, 2, nil]
     end
 
     test "nils first" do
       s1 = Series.from_list([1, nil, 2, 3])
-      result = Series.arrange_with(s1, &Series.remainder(&1, 3), nils: :first)
+      result = Series.sort_with(s1, &Series.remainder(&1, 3), nils: :first)
       assert Series.to_list(result) == [nil, 3, 1, 2]
     end
   end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2882,7 +2882,7 @@ defmodule Explorer.SeriesTest do
     end
   end
 
-  describe "arrange_with/2" do
+  describe "sort_with/2" do
     test "ascending order (default)" do
       s1 = Series.from_list([1, 2, 3])
       result = Series.sort_with(s1, &Series.remainder(&1, 3))

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2848,7 +2848,7 @@ defmodule Explorer.SeriesTest do
     end
   end
 
-  describe "arrange/2" do
+  describe "sort_by/2" do
     test "ascending order (default)" do
       require Explorer.Series
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2848,6 +2848,66 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "arrange/2" do
+    test "ascending order (default)" do
+      require Explorer.Series
+
+      s1 = Series.from_list([1, 2, 3])
+      result = Series.arrange(s1, remainder(_, 3))
+      assert Series.to_list(result) == [3, 1, 2]
+    end
+
+    test "descending order" do
+      require Explorer.Series
+
+      s1 = Series.from_list([1, 2, 3])
+      result = Series.arrange(s1, remainder(_, 3), direction: :desc)
+      assert Series.to_list(result) == [2, 1, 3]
+    end
+
+    test "nils last (default)" do
+      require Explorer.Series
+
+      s1 = Series.from_list([1, nil, 2, 3])
+      result = Series.arrange(s1, remainder(_, 3))
+      assert Series.to_list(result) == [3, 1, 2, nil]
+    end
+
+    test "nils first" do
+      require Explorer.Series
+
+      s1 = Series.from_list([1, nil, 2, 3])
+      result = Series.arrange(s1, remainder(_, 3), nils: :first)
+      assert Series.to_list(result) == [nil, 3, 1, 2]
+    end
+  end
+
+  describe "arrange_with/2" do
+    test "ascending order (default)" do
+      s1 = Series.from_list([1, 2, 3])
+      result = Series.arrange_with(s1, &Series.remainder(&1, 3))
+      assert Series.to_list(result) == [3, 1, 2]
+    end
+
+    test "descending order" do
+      s1 = Series.from_list([1, 2, 3])
+      result = Series.arrange_with(s1, &Series.remainder(&1, 3), direction: :desc)
+      assert Series.to_list(result) == [2, 1, 3]
+    end
+
+    test "nils last (default)" do
+      s1 = Series.from_list([1, nil, 2, 3])
+      result = Series.arrange_with(s1, &Series.remainder(&1, 3))
+      assert Series.to_list(result) == [3, 1, 2, nil]
+    end
+
+    test "nils first" do
+      s1 = Series.from_list([1, nil, 2, 3])
+      result = Series.arrange_with(s1, &Series.remainder(&1, 3), nils: :first)
+      assert Series.to_list(result) == [nil, 3, 1, 2]
+    end
+  end
+
   describe "sample/2" do
     test "sample taking 10 elements" do
       s = 1..100 |> Enum.to_list() |> Series.from_list()


### PR DESCRIPTION
Adds:

* `Series.arrange` (macro)
* `Series.arrange_with` (function)

Closes:

* https://github.com/elixir-explorer/explorer/issues/730

I'm opening this up early. There are two decisions we need to make before I write docs:

* **Names:**
  * `Series.arrange{_with}`
  * `Series.sort{_with}` (already taken)
* **API:**
  * `Series.arrange(s, _, direction: :asc)` (matches `Series.sort`)
  * `Series.arrange(s, asc: _)` (matches `DataFrame.arrange`)