### PR TITLE
Enables alternative correlation methods

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -203,7 +203,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback nil_count(df) :: df()
   @callback explode(df, out_df :: df(), columns :: [column_name()]) :: df()
   @callback unnest(df, out_df :: df(), columns :: [column_name()]) :: df()
-  @callback correlation(df, out_df :: df(), ddof :: integer()) :: df()
+  @callback correlation(df, out_df :: df(), ddof :: integer(), method :: String.t()) :: df()
   @callback covariance(df, out_df :: df(), ddof :: integer()) :: df()
 
   # Two or more table verbs

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -203,7 +203,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback nil_count(df) :: df()
   @callback explode(df, out_df :: df(), columns :: [column_name()]) :: df()
   @callback unnest(df, out_df :: df(), columns :: [column_name()]) :: df()
-  @callback correlation(df, out_df :: df(), ddof :: integer(), method :: String.t()) :: df()
+  @callback correlation(df, out_df :: df(), ddof :: integer(), method :: atom()) :: df()
   @callback covariance(df, out_df :: df(), ddof :: integer()) :: df()
 
   # Two or more table verbs

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -109,7 +109,7 @@ defmodule Explorer.Backend.LazySeries do
     count: 1,
     nil_count: 1,
     skew: 2,
-    correlation: 3,
+    correlation: 4,
     covariance: 3,
     all: 1,
     any: 1,
@@ -498,8 +498,8 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def correlation(%Series{} = left, %Series{} = right, ddof) do
-    args = [series_or_lazy_series!(left), series_or_lazy_series!(right), ddof]
+  def correlation(%Series{} = left, %Series{} = right, ddof, method) do
+    args = [series_or_lazy_series!(left), series_or_lazy_series!(right), ddof, method]
     data = new(:correlation, args, {:f, 64}, true)
 
     Backend.Series.new(data, {:f, 64})

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -89,7 +89,7 @@ defmodule Explorer.Backend.Series do
   @callback nil_count(s) :: number() | lazy_s()
   @callback product(s) :: float() | non_finite() | lazy_s() | nil
   @callback skew(s, bias? :: boolean()) :: float() | non_finite() | lazy_s() | nil
-  @callback correlation(s, s, ddof :: non_neg_integer()) ::
+  @callback correlation(s, s, ddof :: non_neg_integer(), method :: String.t()) ::
               float() | non_finite() | lazy_s() | nil
   @callback covariance(s, s, ddof :: non_neg_integer()) :: float() | non_finite() | lazy_s() | nil
   @callback all?(s) :: boolean() | lazy_s()

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -89,7 +89,7 @@ defmodule Explorer.Backend.Series do
   @callback nil_count(s) :: number() | lazy_s()
   @callback product(s) :: float() | non_finite() | lazy_s() | nil
   @callback skew(s, bias? :: boolean()) :: float() | non_finite() | lazy_s() | nil
-  @callback correlation(s, s, ddof :: non_neg_integer(), method :: String.t()) ::
+  @callback correlation(s, s, ddof :: non_neg_integer(), method :: atom()) ::
               float() | non_finite() | lazy_s() | nil
   @callback covariance(s, s, ddof :: non_neg_integer()) :: float() | non_finite() | lazy_s() | nil
   @callback all?(s) :: boolean() | lazy_s()

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5678,9 +5678,9 @@ defmodule Explorer.DataFrame do
   * `:column_name` - the name of the column with column names. Defaults to "names".
   * `:ddof` - the 'delta degrees of freedom' - the divisor used in the correlation
     calculation. Defaults to 1.
-  * `method` refers to the correlation method. The following methods are available:
-    - `"pearson"` : Standard correlation coefficient. (default)
-    - `"spearman"` : Spearman rank correlation.
+  * `:method` refers to the correlation method. The following methods are available:
+    - `:pearson` : Standard correlation coefficient. (default)
+    - `:spearman` : Spearman rank correlation.
 
   ## Examples
 
@@ -5701,7 +5701,7 @@ defmodule Explorer.DataFrame do
         column_name: "names",
         columns: names(df),
         ddof: 1,
-        method: "pearson"
+        method: :pearson
       )
 
     out_df = pairwised_df(df, opts)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5658,7 +5658,7 @@ defmodule Explorer.DataFrame do
   def frequencies(_df, []), do: raise(ArgumentError, "columns cannot be empty")
 
   @doc """
-  Calculates the pairwise Pearson's correlation of numeric columns.
+  Calculates the pairwise correlation of numeric columns.
 
   The returned dataframe is the correlation matrix.
 
@@ -5678,6 +5678,9 @@ defmodule Explorer.DataFrame do
   * `:column_name` - the name of the column with column names. Defaults to "names".
   * `:ddof` - the 'delta degrees of freedom' - the divisor used in the correlation
     calculation. Defaults to 1.
+  * `method` refers to the correlation method. The following methods are available:
+    - `"pearson"` : Standard correlation coefficient. (default)
+    - `"spearman"` : Spearman rank correlation.
 
   ## Examples
 
@@ -5693,9 +5696,16 @@ defmodule Explorer.DataFrame do
   @doc type: :single
   @spec correlation(df :: DataFrame.t(), opts :: Keyword.t()) :: df :: DataFrame.t()
   def correlation(df, opts \\ []) do
-    opts = Keyword.validate!(opts, column_name: "names", columns: names(df), ddof: 1)
+    opts =
+      Keyword.validate!(opts,
+        column_name: "names",
+        columns: names(df),
+        ddof: 1,
+        method: "pearson"
+      )
+
     out_df = pairwised_df(df, opts)
-    Shared.apply_impl(df, :correlation, [out_df, opts[:ddof]])
+    Shared.apply_impl(df, :correlation, [out_df, opts[:ddof], opts[:method]])
   end
 
   @doc """

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -155,7 +155,7 @@ defmodule Explorer.PolarsBackend.Expression do
     slice: 3,
     concat: 1,
     column: 1,
-    correlation: 3,
+    correlation: 4,
     covariance: 3
   ]
 
@@ -205,8 +205,8 @@ defmodule Explorer.PolarsBackend.Expression do
     Native.expr_concat(expr_list)
   end
 
-  def to_expr(%LazySeries{op: :correlation, args: [series1, series2, ddof]}) do
-    Native.expr_correlation(to_expr(series1), to_expr(series2), ddof)
+  def to_expr(%LazySeries{op: :correlation, args: [series1, series2, ddof, method]}) do
+    Native.expr_correlation(to_expr(series1), to_expr(series2), ddof, method)
   end
 
   def to_expr(%LazySeries{op: :covariance, args: [series1, series2, ddof]}) do

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -488,7 +488,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   not_available_funs = [
-    correlation: 3,
+    correlation: 4,
     covariance: 3,
     describe: 2,
     nil_count: 1,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -270,7 +270,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_cumulative_sum(_s, _reverse), do: err()
   def s_cumulative_product(_s, _reverse), do: err()
   def s_skew(_s, _bias), do: err()
-  def s_correlation(_s1, _s2, _ddof), do: err()
+  def s_correlation(_s1, _s2, _ddof, _method), do: err()
   def s_covariance(_s1, _s2, _ddof), do: err()
   def s_distinct(_s), do: err()
   def s_divide(_s, _other), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -220,8 +220,9 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(series, :s_skew, [bias?])
 
   @impl true
-  def correlation(left, right, ddof),
-    do: Shared.apply_series(matching_size!(left, right), :s_correlation, [right.data, ddof])
+  def correlation(left, right, ddof, method),
+    do:
+      Shared.apply_series(matching_size!(left, right), :s_correlation, [right.data, ddof, method])
 
   @impl true
   def covariance(left, right, ddof),

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2660,10 +2660,14 @@ defmodule Explorer.Series do
     do: dtype_error("skew/2", dtype, @numeric_dtypes)
 
   @doc """
-  Compute the Pearson's correlation between two series.
+  Compute the correlation between two series.
 
   The parameter `ddof` refers to the 'delta degrees of freedom' - the divisor
   used in the correlation calculation. Defaults to 1.
+
+  The parameter `method` refers to the correlation method. The following methods are available:
+    - `"pearson"` : Standard correlation coefficient. (default)
+    - `"spearman"` : Spearman rank correlation.
 
   ## Supported dtypes
 
@@ -2682,11 +2686,12 @@ defmodule Explorer.Series do
   @spec correlation(
           left :: Series.t() | number(),
           right :: Series.t() | number(),
-          ddof :: non_neg_integer()
+          opts :: Keyword.t()
         ) ::
           float() | non_finite() | nil
-  def correlation(left, right, ddof \\ 1) when K.and(is_integer(ddof), ddof >= 0) do
-    basic_numeric_operation(:correlation, left, right, [ddof])
+  def correlation(left, right, opts \\ []) do
+    opts = Keyword.validate!(opts, ddof: 1, method: "pearson")
+    basic_numeric_operation(:correlation, left, right, [opts[:ddof], opts[:method]])
   end
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2665,9 +2665,9 @@ defmodule Explorer.Series do
   The parameter `ddof` refers to the 'delta degrees of freedom' - the divisor
   used in the correlation calculation. Defaults to 1.
 
-  The parameter `method` refers to the correlation method. The following methods are available:
-    - `"pearson"` : Standard correlation coefficient. (default)
-    - `"spearman"` : Spearman rank correlation.
+  The parameter `:method` refers to the correlation method. The following methods are available:
+    - `:pearson` : Standard correlation coefficient. (default)
+    - `:spearman` : Spearman rank correlation.
 
   ## Supported dtypes
 
@@ -2690,7 +2690,11 @@ defmodule Explorer.Series do
         ) ::
           float() | non_finite() | nil
   def correlation(left, right, opts \\ []) do
-    opts = Keyword.validate!(opts, ddof: 1, method: "pearson")
+    opts = Keyword.validate!(opts, ddof: 1, method: :pearson)
+
+    if K.not(K.in(opts[:method], [:pearson, :spearman])),
+      do: raise(ArgumentError, "unsupported correlation method #{inspect(opts[:method])}")
+
     basic_numeric_operation(:correlation, left, right, [opts[:ddof], opts[:method]])
   end
 

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -80,6 +80,7 @@ features = [
   "peaks",
   "moment",
   "rank",
+  "propagate_nans",
 ]
 
 [dependencies.polars-ops]

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -505,6 +505,12 @@ pub enum ExParquetCompression {
     Zstd(Option<i32>),
 }
 
+#[derive(NifTaggedEnum)]
+pub enum ExCorrelationMethod {
+    Pearson,
+    Spearman,
+}
+
 impl TryFrom<ExParquetCompression> for ParquetCompression {
     type Error = ExplorerError;
 

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -5,7 +5,8 @@
 // wrapped in an Elixir struct.
 
 use polars::prelude::{
-    col, concat_str, cov, pearson_corr, when, IntoLazy, LiteralValue, SortOptions,
+    col, concat_str, cov, pearson_corr, spearman_rank_corr, when, IntoLazy, LiteralValue,
+    SortOptions,
 };
 use polars::prelude::{DataType, Expr, Literal, StrptimeOptions, TimeUnit};
 
@@ -494,10 +495,15 @@ pub fn expr_skew(data: ExExpr, bias: bool) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_correlation(left: ExExpr, right: ExExpr, ddof: u8) -> ExExpr {
+pub fn expr_correlation(left: ExExpr, right: ExExpr, ddof: u8, method: &str) -> ExExpr {
     let left_expr = left.clone_inner().cast(DataType::Float64);
     let right_expr = right.clone_inner().cast(DataType::Float64);
-    ExExpr::new(pearson_corr(left_expr, right_expr, ddof))
+
+    match method {
+        "pearson" => ExExpr::new(pearson_corr(left_expr, right_expr, ddof)),
+        "spearman" => ExExpr::new(spearman_rank_corr(left_expr, right_expr, ddof, true)),
+        &_ => todo!("not supported yet"),
+    }
 }
 
 #[rustler::nif]

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -10,7 +10,9 @@ use polars::prelude::{
 };
 use polars::prelude::{DataType, Expr, Literal, StrptimeOptions, TimeUnit};
 
-use crate::datatypes::{ExDate, ExDateTime, ExDuration, ExSeriesDtype, ExValidValue};
+use crate::datatypes::{
+    ExCorrelationMethod, ExDate, ExDateTime, ExDuration, ExSeriesDtype, ExValidValue,
+};
 use crate::series::{cast_str_to_f64, ewm_opts, rolling_opts};
 use crate::{ExDataFrame, ExExpr, ExSeries};
 
@@ -495,14 +497,20 @@ pub fn expr_skew(data: ExExpr, bias: bool) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_correlation(left: ExExpr, right: ExExpr, ddof: u8, method: &str) -> ExExpr {
+pub fn expr_correlation(
+    left: ExExpr,
+    right: ExExpr,
+    ddof: u8,
+    method: ExCorrelationMethod,
+) -> ExExpr {
     let left_expr = left.clone_inner().cast(DataType::Float64);
     let right_expr = right.clone_inner().cast(DataType::Float64);
 
     match method {
-        "pearson" => ExExpr::new(pearson_corr(left_expr, right_expr, ddof)),
-        "spearman" => ExExpr::new(spearman_rank_corr(left_expr, right_expr, ddof, true)),
-        &_ => todo!("not supported yet"),
+        ExCorrelationMethod::Pearson => ExExpr::new(pearson_corr(left_expr, right_expr, ddof)),
+        ExCorrelationMethod::Spearman => {
+            ExExpr::new(spearman_rank_corr(left_expr, right_expr, ddof, true))
+        }
     }
 }
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3868,6 +3868,17 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "spearman rank method" do
+      df = DF.new(dogs: [1, 8, 3], cats: [4, 5, 2])
+      df1 = DF.correlation(df, method: "spearman")
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               names: ["dogs", "cats"],
+               dogs: [1.0, 0.5],
+               cats: [0.5, 1.0]
+             }
+    end
+
     test "three integer columns and custom column name" do
       df = DF.new(dogs: [1, 2, 3], cats: [3, 2, 1], frogs: [7, 8, 9])
       df1 = DF.correlation(df, column_name: "variables")

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3870,7 +3870,7 @@ defmodule Explorer.DataFrameTest do
 
     test "spearman rank method" do
       df = DF.new(dogs: [1, 8, 3], cats: [4, 5, 2])
-      df1 = DF.correlation(df, method: "spearman")
+      df1 = DF.correlation(df, method: :spearman)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                names: ["dogs", "cats"],

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4164,11 +4164,11 @@ defmodule Explorer.SeriesTest do
     test "explicit pearson and spearman rank methods for correlation" do
       s1 = Series.from_list([1, 8, 3])
       s2 = Series.from_list([4, 5, 2])
-      assert abs(Series.correlation(s1, s2, method: "spearman") - 0.5) < 1.0e-4
-      assert abs(Series.correlation(s1, s2, method: "pearson") - 0.5447047794019223) < 1.0e-4
+      assert abs(Series.correlation(s1, s2, method: :spearman) - 0.5) < 1.0e-4
+      assert abs(Series.correlation(s1, s2, method: :pearson) - 0.5447047794019223) < 1.0e-4
 
-      assert_raise RuntimeError, ~r/Generic Error: method is not supported not_a_method/, fn ->
-        Series.correlation(s1, s2, method: "not_a_method")
+      assert_raise ArgumentError, ~s(unsupported correlation method :not_a_method), fn ->
+        Series.correlation(s1, s2, method: :not_a_method)
       end
     end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4161,6 +4161,17 @@ defmodule Explorer.SeriesTest do
       end
     end
 
+    test "explicit pearson and spearman rank methods for correlation" do
+      s1 = Series.from_list([1, 8, 3])
+      s2 = Series.from_list([4, 5, 2])
+      assert abs(Series.correlation(s1, s2, method: "spearman") - 0.5) < 1.0e-4
+      assert abs(Series.correlation(s1, s2, method: "pearson") - 0.5447047794019223) < 1.0e-4
+
+      assert_raise RuntimeError, ~r/Generic Error: method is not supported not_a_method/, fn ->
+        Series.correlation(s1, s2, method: "not_a_method")
+      end
+    end
+
     test "impossible correlation and covariance" do
       s1 = Series.from_list([], dtype: {:f, 64})
       s2 = Series.from_list([], dtype: {:f, 64})
@@ -4187,7 +4198,7 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list(["a", "b"])
 
       assert_raise ArgumentError,
-                   "cannot invoke Explorer.Series.correlation/3 with mismatched dtypes: {:f, 64} and :string",
+                   "cannot invoke Explorer.Series.correlation/4 with mismatched dtypes: {:f, 64} and :string",
                    fn -> Series.correlation(s1, s2) end
 
       assert_raise ArgumentError,


### PR DESCRIPTION
I'm passing the correlation method as string to follow the `Series.rank` convention but I'd suggest to use atoms instead. WDYT?