### PR TITLE
Normalize sorting options

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -166,8 +166,9 @@ defmodule Explorer.Backend.DataFrame do
               df,
               out_df :: df(),
               directions :: [{:asc | :desc, lazy_series()}],
-              nulls_last :: boolean(),
-              maintain_order :: boolean()
+              maintain_order? :: boolean(),
+              multithreaded? :: boolean(),
+              nulls_last? :: boolean()
             ) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()]) :: df
   @callback rename(df, out_df :: df(), [{old :: column_name(), new :: column_name()}]) :: df

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -76,8 +76,8 @@ defmodule Explorer.Backend.LazySeries do
     # Transformation
     column: 1,
     reverse: 1,
-    argsort: 3,
-    sort: 3,
+    argsort: 5,
+    sort: 5,
     distinct: 1,
     unordered_distinct: 1,
     slice: 2,
@@ -221,16 +221,16 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def argsort(%Series{} = s, descending?, nils_last?) do
-    args = [lazy_series!(s), descending?, nils_last?]
+  def argsort(%Series{} = s, descending?, maintain_order?, multithreaded?, nulls_last?) do
+    args = [lazy_series!(s), descending?, maintain_order?, multithreaded?, nulls_last?]
     data = new(:argsort, args, :integer, aggregations?(args))
 
     Backend.Series.new(data, :integer)
   end
 
   @impl true
-  def sort(%Series{} = s, descending?, nils_last?) do
-    args = [lazy_series!(s), descending?, nils_last?]
+  def sort(%Series{} = s, descending?, maintain_order?, multithreaded?, nulls_last?) do
+    args = [lazy_series!(s), descending?, maintain_order?, multithreaded?, nulls_last?]
     data = new(:sort, args, s.dtype, aggregations?(args))
 
     Backend.Series.new(data, s.dtype)

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -158,8 +158,20 @@ defmodule Explorer.Backend.Series do
 
   # Sort
 
-  @callback sort(s, descending? :: boolean(), nils_last :: boolean()) :: s
-  @callback argsort(s, descending? :: boolean(), nils_last :: boolean()) :: s
+  @callback sort(
+              s,
+              descending? :: boolean(),
+              maintain_order? :: boolean(),
+              multithreaded? :: boolean(),
+              nulls_last? :: boolean()
+            ) :: s
+  @callback argsort(
+              s,
+              descending? :: boolean(),
+              maintain_order? :: boolean(),
+              multithreaded? :: boolean(),
+              nulls_last? :: boolean()
+            ) :: s
   @callback reverse(s) :: s
 
   # Distinct

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3057,29 +3057,15 @@ defmodule Explorer.DataFrame do
 
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
-      By default it is `false`.
+      By default it is `true`.
 
-      > #### Notice {: .notice}
-      >
-      > The `:parallel` option is applicable under one condition: all lazy series must reduce to
-      > `op: :column`. E.g.
-      >
-      > ```elixir
-      > df = Explorer.DataFrame.new(a: [1, 2, 3])
-      > Explorer.DataFrame.arrange(df, desc: a)
-      > ```
-      >
-      > If any additional computation takes place, e.g.
-      >
-      > ```elixir
-      > Explorer.DataFrame.arrange(df, desc: 1 / a)
-      > ```
-      > parallelism is not available and this option is ignored.
+      Parallel sort isn't available on certain lazy operations.
+      In those situations this option is ignored.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      By default it is `true`.
+      By default it is `false`.
 
   ## Examples
 
@@ -3182,29 +3168,15 @@ defmodule Explorer.DataFrame do
 
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
-      By default it is `false`.
+      By default it is `true`.
 
-      > #### Notice {: .notice}
-      >
-      > The `:parallel` option is applicable under one condition: all lazy series must reduce to
-      > `op: :column`. E.g.
-      >
-      > ```elixir
-      > df = Explorer.DataFrame.new(a: [1, 2, 3])
-      > Explorer.DataFrame.arrange(df, &[desc: &1["a"]])
-      > ```
-      >
-      > If any additional computation takes place, e.g.
-      >
-      > ```elixir
-      > Explorer.DataFrame.arrange(df, desc: &[desc: Explorer.Series.divide(1, &1["a"])])
-      > ```
-      > parallelism is not available and this option is ignored.
+      Parallel sort isn't available on certain lazy operations.
+      In those situations this option is ignored.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      By default it is `true`.
+      By default it is `false`.
 
   ## Examples
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3059,6 +3059,23 @@ defmodule Explorer.DataFrame do
       Whether to parallelize the sorting.
       By default it is `false`.
 
+      > #### Notice {: .notice}
+      >
+      > The `:parallel` option is applicable under one condition: all lazy series must reduce to
+      > `op: :column`. E.g.
+      >
+      > ```elixir
+      > df = Explorer.DataFrame.new(a: [1, 2, 3])
+      > Explorer.DataFrame.arrange(df, desc: a)
+      > ```
+      >
+      > If any additional computation takes place, e.g.
+      >
+      > ```elixir
+      > Explorer.DataFrame.arrange(df, desc: 1 / a)
+      > ```
+      > parallelism is not available and this option is ignored.
+
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
@@ -3166,6 +3183,23 @@ defmodule Explorer.DataFrame do
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
       By default it is `false`.
+
+      > #### Notice {: .notice}
+      >
+      > The `:parallel` option is applicable under one condition: all lazy series must reduce to
+      > `op: :column`. E.g.
+      >
+      > ```elixir
+      > df = Explorer.DataFrame.new(a: [1, 2, 3])
+      > Explorer.DataFrame.arrange(df, &[desc: &1["a"]])
+      > ```
+      >
+      > If any additional computation takes place, e.g.
+      >
+      > ```elixir
+      > Explorer.DataFrame.arrange(df, desc: &[desc: Explorer.Series.divide(1, &1["a"])])
+      > ```
+      > parallelism is not available and this option is ignored.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3052,14 +3052,17 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `:nils` - `:first | :last`.
-      Determines if `nil`s get sorted first or last in the result.
-      Default is `:last`.
+    * `:nils` - `:first` or `:last`.
+      By default it is `:last` if direction is `:asc`, and `:first` otherwise.
 
-    * `:stable` - `boolean()`.
+    * `:parallel` - boolean.
+      Whether to parallelize the sorting.
+      By default it is `false`.
+
+    * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      Default is `true`.
+      By default it is `true`.
 
   ## Examples
 
@@ -3157,14 +3160,17 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `:nils` - `:first | :last`.
-      Determines if `nil`s get sorted first or last in the result.
-      Default is `:last`.
+    * `:nils` - `:first` or `:last`.
+      By default it is `:last` if direction is `:asc`, and `:first` otherwise.
 
-    * `:stable` - `boolean()`.
+    * `:parallel` - boolean.
+      Whether to parallelize the sorting.
+      By default it is `false`.
+
+    * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      Default is `true`.
+      By default it is `true`.
 
   ## Examples
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3230,7 +3230,7 @@ defmodule Explorer.DataFrame do
           opts :: [nils: :first | :last, stable: boolean()]
         ) :: DataFrame.t()
   def arrange_with(%DataFrame{} = df, fun, opts \\ []) when is_function(fun, 1) do
-    [_direction | opts] = Shared.validate_sort_options!(opts)
+    [_descending? | opts] = Shared.validate_sort_options!(opts)
 
     ldf = Explorer.Backend.LazyFrame.new(df)
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3230,21 +3230,7 @@ defmodule Explorer.DataFrame do
           opts :: [nils: :first | :last, stable: boolean()]
         ) :: DataFrame.t()
   def arrange_with(%DataFrame{} = df, fun, opts \\ []) when is_function(fun, 1) do
-    opts = Keyword.validate!(opts, nils: :last, stable: true)
-
-    nulls_last =
-      case opts[:nils] do
-        :first -> false
-        :last -> true
-        _ -> raise ArgumentError, "`nils` must be `:first` or `:last`"
-      end
-
-    maintain_order =
-      case opts[:stable] do
-        true -> true
-        false -> false
-        _ -> raise ArgumentError, "`stable` must be `true` or `false`"
-      end
+    [_direction | opts] = Shared.validate_sort_options!(opts)
 
     ldf = Explorer.Backend.LazyFrame.new(df)
 
@@ -3270,12 +3256,7 @@ defmodule Explorer.DataFrame do
           raise "not a valid lazy series or arrange instruction: #{inspect(other)}"
       end)
 
-    Shared.apply_impl(df, :arrange_with, [
-      df,
-      dir_and_lazy_series_pairs,
-      nulls_last,
-      maintain_order
-    ])
+    Shared.apply_impl(df, :arrange_with, [df, dir_and_lazy_series_pairs] ++ opts)
   end
 
   @doc """

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -677,7 +677,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
         expressions,
         directions,
         maintain_order?,
-        multithreaded?,
         nulls_last?,
         df.groups
       ])

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -643,7 +643,16 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def arrange_with(%DataFrame{} = df, out_df, column_pairs, nulls_last, maintain_order) do
+  def arrange_with(
+        %DataFrame{} = df,
+        out_df,
+        column_pairs,
+        maintain_order?,
+        multithreaded?,
+        nulls_last?
+      )
+      when is_boolean(maintain_order?) and is_boolean(multithreaded?) and
+             is_boolean(nulls_last?) do
     {directions, expressions} =
       column_pairs
       |> Enum.map(fn {direction, lazy_series} ->
@@ -655,8 +664,9 @@ defmodule Explorer.PolarsBackend.DataFrame do
     Shared.apply_dataframe(df, out_df, :df_arrange_with, [
       expressions,
       directions,
-      nulls_last,
-      maintain_order,
+      maintain_order?,
+      multithreaded?,
+      nulls_last?,
       df.groups
     ])
   end

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -82,8 +82,8 @@ defmodule Explorer.PolarsBackend.Expression do
 
   @first_only_expressions [
     quantile: 2,
-    argsort: 3,
-    sort: 3,
+    argsort: 5,
+    sort: 5,
     head: 2,
     tail: 2,
     peaks: 2,

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -373,7 +373,6 @@ defmodule Explorer.PolarsBackend.LazyFrame do
       expressions,
       directions,
       maintain_order?,
-      multithreaded?,
       nulls_last?
     ])
   end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -354,7 +354,16 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def arrange_with(%DF{groups: []} = df, out_df, column_pairs, nulls_last, maintain_order) do
+  def arrange_with(
+        %DF{groups: []} = df,
+        out_df,
+        column_pairs,
+        maintain_order?,
+        multithreaded?,
+        nulls_last?
+      )
+      when is_boolean(maintain_order?) and is_boolean(multithreaded?) and
+             is_boolean(nulls_last?) do
     {directions, expressions} =
       column_pairs
       |> Enum.map(fn {direction, lazy_series} -> {direction == :desc, to_expr(lazy_series)} end)
@@ -363,13 +372,14 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     Shared.apply_dataframe(df, out_df, :lf_arrange_with, [
       expressions,
       directions,
-      nulls_last,
-      maintain_order
+      maintain_order?,
+      multithreaded?,
+      nulls_last?
     ])
   end
 
   @impl true
-  def arrange_with(_df, _out_df, _directions, _nulls_last, _maintain_order) do
+  def arrange_with(_df, _out_df, _directions, _maintain_order?, _multithreaded?, _nulls_last?) do
     raise "arrange_with/2 with groups is not supported yet for lazy frames"
   end
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -58,10 +58,20 @@ defmodule Explorer.PolarsBackend.Native do
   defstruct [:inner]
 
   def df_from_arrow_stream_pointer(_stream_ptr), do: err()
-  def df_arrange(_df, _by, _reverse, _nulls_last, _maintain_order, _groups), do: err()
 
-  def df_arrange_with(_df, _expressions, _directions, _nulls_last, _maintain_order, _groups),
+  def df_arrange(_df, _by, _reverse, _maintain_order?, _multithreaded?, _nulls_last?, _groups),
     do: err()
+
+  def df_arrange_with(
+        _df,
+        _expressions,
+        _directions,
+        _maintain_order?,
+        _multithreaded?,
+        _nulls_last?,
+        _groups
+      ),
+      do: err()
 
   def df_concat_columns(_df, _others), do: err()
   def df_concat_rows(_df, _others), do: err()
@@ -236,7 +246,17 @@ defmodule Explorer.PolarsBackend.Native do
       do: err()
 
   def lf_filter_with(_df, _expression), do: err()
-  def lf_arrange_with(_df, _expressions, _directions, _nulls_last, _maintain_order), do: err()
+
+  def lf_arrange_with(
+        _df,
+        _expressions,
+        _directions,
+        _maintain_order?,
+        _multithreaded?,
+        _nulls_last?
+      ),
+      do: err()
+
   def lf_distinct(_df, _subset, _selection), do: err()
   def lf_mutate_with(_df, _exprs), do: err()
   def lf_summarise_with(_df, _groups, _aggs), do: err()
@@ -258,7 +278,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_any(_s), do: err()
   def s_argmax(_s), do: err()
   def s_argmin(_s), do: err()
-  def s_argsort(_s, _descending?, _nils_last?), do: err()
+  def s_argsort(_s, _descending?, _maintain_order?, _multithreaded?, _nulls_last?), do: err()
   def s_cast(_s, _dtype), do: err()
   def s_categories(_s), do: err()
   def s_categorise(_s, _s_categories), do: err()
@@ -361,7 +381,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_slice(_s, _offset, _length), do: err()
   def s_slice_by_indices(_s, _indices), do: err()
   def s_slice_by_series(_s, _series), do: err()
-  def s_sort(_s, _descending?, _nils_last?), do: err()
+  def s_sort(_s, _descending?, _maintain_order?, _multithreaded?, _nulls_last?), do: err()
   def s_standard_deviation(_s, _ddof), do: err()
   def s_strip(_s, _string), do: err()
   def s_subtract(_s, _other), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -67,7 +67,6 @@ defmodule Explorer.PolarsBackend.Native do
         _expressions,
         _directions,
         _maintain_order?,
-        _multithreaded?,
         _nulls_last?,
         _groups
       ),
@@ -252,7 +251,6 @@ defmodule Explorer.PolarsBackend.Native do
         _expressions,
         _directions,
         _maintain_order?,
-        _multithreaded?,
         _nulls_last?
       ),
       do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -406,15 +406,27 @@ defmodule Explorer.PolarsBackend.Series do
   # Sort
 
   @impl true
-  def sort(series, descending?, nils_last?)
-      when is_boolean(descending?) and is_boolean(nils_last?) do
-    Shared.apply_series(series, :s_sort, [descending?, nils_last?])
+  def sort(series, descending?, maintain_order?, multithreaded?, nulls_last?)
+      when is_boolean(descending?) and is_boolean(maintain_order?) and is_boolean(multithreaded?) and
+             is_boolean(nulls_last?) do
+    Shared.apply_series(series, :s_sort, [
+      descending?,
+      maintain_order?,
+      multithreaded?,
+      nulls_last?
+    ])
   end
 
   @impl true
-  def argsort(series, descending?, nils_last?)
-      when is_boolean(descending?) and is_boolean(nils_last?) do
-    Shared.apply_series(series, :s_argsort, [descending?, nils_last?])
+  def argsort(series, descending?, maintain_order?, multithreaded?, nulls_last?)
+      when is_boolean(descending?) and is_boolean(maintain_order?) and is_boolean(multithreaded?) and
+             is_boolean(nulls_last?) do
+    Shared.apply_series(series, :s_argsort, [
+      descending?,
+      maintain_order?,
+      multithreaded?,
+      nulls_last?
+    ])
   end
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -4325,11 +4325,7 @@ defmodule Explorer.Series do
   """
   @doc type: :shape
   def sort(series, opts \\ []) do
-    opts = Keyword.validate!(opts, [:nils, direction: :asc])
-    descending? = opts[:direction] == :desc
-    nils_last? = if nils = opts[:nils], do: nils == :last, else: K.not(descending?)
-
-    apply_series(series, :sort, [descending?, nils_last?])
+    apply_series(series, :sort, Shared.validate_sort_options!(opts))
   end
 
   @doc """
@@ -4362,11 +4358,7 @@ defmodule Explorer.Series do
   """
   @doc type: :shape
   def argsort(series, opts \\ []) do
-    opts = Keyword.validate!(opts, [:nils, direction: :asc])
-    descending? = opts[:direction] == :desc
-    nils_last? = if nils = opts[:nils], do: nils == :last, else: K.not(descending?)
-
-    apply_series(series, :argsort, [descending?, nils_last?])
+    apply_series(series, :argsort, Shared.validate_sort_options!(opts))
   end
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1651,7 +1651,11 @@ defmodule Explorer.Series do
     * `:nils` - `:first` or `:last`.
       By default it is `:last` if direction is `:asc`, and `:first` otherwise.
 
-    * `:stable` - `true` or `false`.
+    * `:parallel` - boolean.
+      Whether to parallelize the sorting.
+      By default it is `false`.
+
+    * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
       By default it is `true`.
@@ -1705,7 +1709,11 @@ defmodule Explorer.Series do
     * `:nils` - `:first` or `:last`.
       By default it is `:last` if direction is `:asc`, and `:first` otherwise.
 
-    * `:stable` - `true` or `false`.
+    * `:parallel` - boolean.
+      Whether to parallelize the sorting.
+      By default it is `false`.
+
+    * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
       By default it is `true`.
@@ -4303,8 +4311,17 @@ defmodule Explorer.Series do
     * `:direction` - `:asc` or `:desc`, meaning "ascending" or "descending", respectively.
       By default it sorts in ascending order.
 
-    * `:nils` - `:first` or `:last`. By default it is `:last` if direction is `:asc`, and
-      `:first` otherwise.
+    * `:nils` - `:first` or `:last`.
+      By default it is `:last` if direction is `:asc`, and `:first` otherwise.
+
+    * `:parallel` - boolean.
+      Whether to parallelize the sorting.
+      By default it is `false`.
+
+    * `:stable` - boolean.
+      Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
+      Unstable sorting may be more performant.
+      By default it is `true`.
 
   ## Examples
 
@@ -4336,8 +4353,17 @@ defmodule Explorer.Series do
     * `:direction` - `:asc` or `:desc`, meaning "ascending" or "descending", respectively.
       By default it sorts in ascending order.
 
-    * `:nils` - `:first` or `:last`. By default it is `:last` if direction is `:asc`, and
-      `:first` otherwise.
+    * `:nils` - `:first` or `:last`.
+      By default it is `:last` if direction is `:asc`, and `:first` otherwise.
+
+    * `:parallel` - boolean.
+      Whether to parallelize the sorting.
+      By default it is `false`.
+
+    * `:stable` - boolean.
+      Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
+      Unstable sorting may be more performant.
+      By default it is `true`.
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1653,12 +1653,15 @@ defmodule Explorer.Series do
 
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
-      By default it is `false`.
+      By default it is `true`.
+
+      Parallel sort isn't available on certain lazy operations.
+      In those situations this option is ignored.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      By default it is `true`.
+      By default it is `false`.
 
   ## Examples
 
@@ -1711,12 +1714,15 @@ defmodule Explorer.Series do
 
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
-      By default it is `false`.
+      By default it is `true`.
+
+      Parallel sort isn't available on certain lazy operations.
+      In those situations this option is ignored.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      By default it is `true`.
+      By default it is `false`.
 
   ## Examples
 
@@ -4301,8 +4307,6 @@ defmodule Explorer.Series do
   @doc """
   Sorts the series.
 
-  Sorting is stable by default.
-
   See `sort_by/3` for an expression-based sorting function.
   See `sort_with/3` for a callback-based sorting function.
 
@@ -4316,12 +4320,12 @@ defmodule Explorer.Series do
 
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
-      By default it is `false`.
+      By default it is `true`.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      By default it is `true`.
+      By default it is `false`.
 
   ## Examples
 
@@ -4358,12 +4362,12 @@ defmodule Explorer.Series do
 
     * `:parallel` - boolean.
       Whether to parallelize the sorting.
-      By default it is `false`.
+      By default it is `true`.
 
     * `:stable` - boolean.
       Determines if the sorting is stable (ties are guaranteed to maintain their order) or not.
       Unstable sorting may be more performant.
-      By default it is `true`.
+      By default it is `false`.
 
   ## Examples
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -480,7 +480,7 @@ defmodule Explorer.Shared do
   Validate options to be used for the various sorting functions.
   """
   def validate_sort_options!(opts) do
-    opts = Keyword.validate!(opts, [:direction, :nils, parallel: false, stable: true])
+    opts = Keyword.validate!(opts, [:direction, :nils, parallel: true, stable: false])
 
     direction =
       case Keyword.fetch(opts, :direction) do

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -475,4 +475,58 @@ defmodule Explorer.Shared do
     |> Enum.sort(&(elem(&1, 1) <= elem(&2, 1)))
     |> Enum.map(fn {_, key} -> ["      * ", inspect(key), ?\n] end)
   end
+
+  @doc """
+  Validate options to be used for the various sorting functions.
+  """
+  def validate_sort_options!(opts) do
+    opts = Keyword.validate!(opts, [:direction, :nils, parallel: false, stable: true])
+
+    direction =
+      case Keyword.fetch(opts, :direction) do
+        {:ok, d} when d in [:asc, :desc] ->
+          d
+
+        :error ->
+          :not_provided
+
+        {:ok, x} ->
+          raise ArgumentError, "`:direction` must be `:asc` or `:desc`, found: #{inspect(x)}."
+      end
+
+    nils =
+      case Keyword.fetch(opts, :nils) do
+        {:ok, n} when n in [:first, :last] ->
+          n
+
+        :error ->
+          case direction do
+            :asc -> :last
+            :desc -> :first
+            :not_provided -> :last
+          end
+
+        {:ok, x} ->
+          raise ArgumentError, "`:nils` must be `:first` or `:last`, found: #{inspect(x)}."
+      end
+
+    parallel =
+      case Keyword.fetch!(opts, :parallel) do
+        b when is_boolean(b) -> b
+        x -> raise ArgumentError, "`:parallel` must be `true` or `false`, found: #{inspect(x)}."
+      end
+
+    stable =
+      case Keyword.fetch!(opts, :stable) do
+        b when is_boolean(b) -> b
+        x -> raise ArgumentError, "`:stable` must be `true` or `false`, found: #{inspect(x)}."
+      end
+
+    descending? = direction == :desc
+    maintain_order? = stable == true
+    multithreaded? = parallel == true
+    nulls_last? = nils == :last
+
+    [descending?, maintain_order?, multithreaded?, nulls_last?]
+  end
 end

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -347,8 +347,9 @@ pub fn df_arrange(
     df: ExDataFrame,
     by_columns: Vec<String>,
     reverse: Vec<bool>,
-    nulls_last: bool,
     maintain_order: bool,
+    multithreaded: bool,
+    nulls_last: bool,
     groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let new_df = if groups.is_empty() {
@@ -356,8 +357,6 @@ pub fn df_arrange(
         // df.sort does not allow a nulls_last option.
         // df.sort_with_options only allows a single column.
         let by_columns = df.select_series(by_columns)?;
-        // TODO: make these bools options.
-        let multithreaded = false;
         df.sort_impl(
             by_columns,
             reverse,
@@ -379,8 +378,9 @@ pub fn df_arrange_with(
     data: ExDataFrame,
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
-    nulls_last: bool,
     maintain_order: bool,
+    _multithreaded: bool,
+    nulls_last: bool,
     groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = data.clone_inner();

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -379,7 +379,6 @@ pub fn df_arrange_with(
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
     maintain_order: bool,
-    _multithreaded: bool,
     nulls_last: bool,
     groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -688,36 +688,40 @@ pub fn expr_reverse(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_sort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr {
+pub fn expr_sort(
+    expr: ExExpr,
+    descending: bool,
+    maintain_order: bool,
+    multithreaded: bool,
+    nulls_last: bool,
+) -> ExExpr {
     let expr = expr.clone_inner();
-
-    // TODO: make these bools options.
-    let multithreaded = false;
-    let maintain_order = true;
 
     let opts = SortOptions {
         descending,
-        nulls_last,
-        multithreaded,
         maintain_order,
+        multithreaded,
+        nulls_last,
     };
 
     ExExpr::new(expr.sort_with(opts))
 }
 
 #[rustler::nif]
-pub fn expr_argsort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr {
+pub fn expr_argsort(
+    expr: ExExpr,
+    descending: bool,
+    maintain_order: bool,
+    multithreaded: bool,
+    nulls_last: bool,
+) -> ExExpr {
     let expr = expr.clone_inner();
-
-    // TODO: make these bools options.
-    let multithreaded = false;
-    let maintain_order = true;
 
     let opts = SortOptions {
         descending,
-        nulls_last,
-        multithreaded,
         maintain_order,
+        multithreaded,
+        nulls_last,
     };
 
     ExExpr::new(expr.arg_sort(opts).cast(DataType::Int64))

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -110,7 +110,6 @@ pub fn lf_arrange_with(
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
     maintain_order: bool,
-    _multithreaded: bool,
     nulls_last: bool,
 ) -> Result<ExLazyFrame, ExplorerError> {
     let exprs = ex_expr_to_exprs(expressions);

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -109,8 +109,9 @@ pub fn lf_arrange_with(
     data: ExLazyFrame,
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
-    nulls_last: bool,
     maintain_order: bool,
+    _multithreaded: bool,
+    nulls_last: bool,
 ) -> Result<ExLazyFrame, ExplorerError> {
     let exprs = ex_expr_to_exprs(expressions);
     let ldf = data

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -349,17 +349,15 @@ pub fn s_shift(series: ExSeries, offset: i64) -> Result<ExSeries, ExplorerError>
 pub fn s_sort(
     series: ExSeries,
     descending: bool,
+    maintain_order: bool,
+    multithreaded: bool,
     nulls_last: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    // TODO: Make this an option
-    let maintain_order = true;
-    let multithreaded = false;
-
     let opts = SortOptions {
         descending,
-        nulls_last,
         maintain_order,
         multithreaded,
+        nulls_last,
     };
     Ok(ExSeries::new(series.sort_with(opts)))
 }
@@ -368,17 +366,15 @@ pub fn s_sort(
 pub fn s_argsort(
     series: ExSeries,
     descending: bool,
+    maintain_order: bool,
+    multithreaded: bool,
     nulls_last: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    // TODO: Make this an option
-    let maintain_order = true;
-    let multithreaded = false;
-
     let opts = SortOptions {
         descending,
-        nulls_last,
         maintain_order,
         multithreaded,
+        nulls_last,
     };
     let indices = series.arg_sort(opts).cast(&DataType::Int64)?;
     Ok(ExSeries::new(indices))


### PR DESCRIPTION
Closes:

* https://github.com/elixir-explorer/explorer/issues/765

Each of these options are now available on all the sorting functions:

* `direction: :asc | :desc`
  * This takes the form of keys in the first arg on the DF functions
* `nils: :first | :last`
* `parallel: true | false`
  * This isn't available on the lazy functions
* `stable: true | false`