### PR TITLE
Rename `:integer` dtype to `{:s, 64}`

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -225,9 +225,9 @@ defmodule Explorer.Backend.LazySeries do
   @impl true
   def argsort(%Series{} = s, descending?, maintain_order?, multithreaded?, nulls_last?) do
     args = [lazy_series!(s), descending?, maintain_order?, multithreaded?, nulls_last?]
-    data = new(:argsort, args, :integer, aggregations?(args))
+    data = new(:argsort, args, {:s, 64}, aggregations?(args))
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
@@ -554,7 +554,7 @@ defmodule Explorer.Backend.LazySeries do
     args = [series_or_lazy_series!(left), series_or_lazy_series!(right)]
 
     dtype =
-      if left.dtype in [{:f, 32}, {:f, 64}, :integer] do
+      if left.dtype in Explorer.Shared.numeric_types() do
         resolve_numeric_dtype([left, right])
       else
         left.dtype
@@ -570,7 +570,7 @@ defmodule Explorer.Backend.LazySeries do
     args = [series_or_lazy_series!(predicate) | binary_args(on_true, on_false)]
 
     dtype =
-      if dtype in [{:f, 32}, {:f, 64}, :integer] do
+      if dtype in Explorer.Shared.numeric_types() do
         resolve_numeric_dtype([on_true, on_false])
       else
         dtype
@@ -599,58 +599,58 @@ defmodule Explorer.Backend.LazySeries do
 
   @impl true
   def day_of_week(%Series{} = s) do
-    data = new(:day_of_week, [lazy_series!(s)], :integer)
+    data = new(:day_of_week, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def day_of_year(%Series{} = s) do
-    data = new(:day_of_year, [lazy_series!(s)], :integer)
+    data = new(:day_of_year, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def week_of_year(%Series{} = s) do
-    data = new(:week_of_year, [lazy_series!(s)], :integer)
+    data = new(:week_of_year, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def month(%Series{} = s) do
-    data = new(:month, [lazy_series!(s)], :integer)
+    data = new(:month, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def year(%Series{} = s) do
-    data = new(:year, [lazy_series!(s)], :integer)
+    data = new(:year, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def hour(%Series{} = s) do
-    data = new(:hour, [lazy_series!(s)], :integer)
+    data = new(:hour, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def minute(%Series{} = s) do
-    data = new(:minute, [lazy_series!(s)], :integer)
+    data = new(:minute, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
   def second(%Series{} = s) do
-    data = new(:second, [lazy_series!(s)], :integer)
+    data = new(:second, [lazy_series!(s)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true
@@ -686,7 +686,8 @@ defmodule Explorer.Backend.LazySeries do
     Backend.Series.new(data, {:f, 64})
   end
 
-  defp dtype_for_agg_operation(op, _) when op in [:count, :nil_count, :n_distinct], do: :integer
+  # TODO: consider using `{:u, 64}` here.
+  defp dtype_for_agg_operation(op, _) when op in [:count, :nil_count, :n_distinct], do: {:s, 64}
 
   defp dtype_for_agg_operation(op, series)
        when op in [:first, :last, :sum, :min, :max, :argmin, :argmax],
@@ -705,9 +706,18 @@ defmodule Explorer.Backend.LazySeries do
         end
       end
 
+    numeric_dtypes = Explorer.Shared.integer_types() ++ Explorer.Shared.float_types()
+
     case dtypes do
-      [dtype] when dtype in [:integer, {:f, 32}, {:f, 64}] -> dtype
-      [_, _] -> {:f, 64}
+      [dtype] ->
+        if dtype in numeric_dtypes do
+          dtype
+        else
+          raise "invalid dtype for numeric items: #{inspect(dtype)}"
+        end
+
+      [_, _] ->
+        {:f, 64}
     end
   end
 
@@ -811,11 +821,11 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def clip(%Series{dtype: :integer} = series, min, max)
+  def clip(%Series{dtype: {:s, 64}} = series, min, max)
       when is_integer(min) and is_integer(max) do
-    data = new(:clip_integer, [lazy_series!(series), min, max], :integer)
+    data = new(:clip_integer, [lazy_series!(series), min, max], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   def clip(%Series{} = series, min, max) do
@@ -1045,9 +1055,9 @@ defmodule Explorer.Backend.LazySeries do
 
   @impl true
   def lengths(series) do
-    data = new(:lengths, [lazy_series!(series)], :integer)
+    data = new(:lengths, [lazy_series!(series)], {:s, 64})
 
-    Backend.Series.new(data, :integer)
+    Backend.Series.new(data, {:s, 64})
   end
 
   @impl true

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -706,11 +706,9 @@ defmodule Explorer.Backend.LazySeries do
         end
       end
 
-    numeric_dtypes = Explorer.Shared.integer_types() ++ Explorer.Shared.float_types()
-
     case dtypes do
       [dtype] ->
-        if dtype in numeric_dtypes do
+        if dtype in Explorer.Shared.numeric_types() do
           dtype
         else
           raise "invalid dtype for numeric items: #{inspect(dtype)}"

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5687,9 +5687,8 @@ defmodule Explorer.DataFrame do
 
   Only columns with the following dtypes are taken into account.
 
-  * `:integer`
-  * `{:f, 32}`
-  * `{:f, 64}`
+  * floats: #{Shared.inspect_dtypes(Shared.float_types(), backsticks: true)}
+  * integers: #{Shared.inspect_dtypes(Shared.integer_types(), backsticks: true)}
 
   The resultant columns are always `{:f, 64}`.
 
@@ -5738,9 +5737,8 @@ defmodule Explorer.DataFrame do
 
   Only columns with the following dtypes are taken into account.
 
-  * `:integer`
-  * `{:f, 32}`
-  * `{:f, 64}`
+  * floats: #{Shared.inspect_dtypes(Shared.float_types(), backsticks: true)}
+  * integers: #{Shared.inspect_dtypes(Shared.integer_types(), backsticks: true)}
 
   The resultant columns are always `{:f, 64}`.
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5063,9 +5063,8 @@ defmodule Explorer.DataFrame do
   end
 
   defp types_are_numeric_compatible?(types, name, type) do
-    # TODO: consider a moduletag
-    numeric_types = Explorer.Shared.integer_types() ++ Explorer.Shared.float_types()
-    types[name] != type and types[name] in numeric_types and type in numeric_types
+    types[name] != type and types[name] in Shared.numeric_types() and
+      type in Shared.numeric_types()
   end
 
   defp cast_numeric_columns_to_float(dfs, changed_types) do
@@ -5781,7 +5780,7 @@ defmodule Explorer.DataFrame do
   end
 
   defp numeric_column?(df, name) do
-    Series.dtype(df[name]) in (Explorer.Shared.integer_types() ++ Explorer.Shared.float_types())
+    Series.dtype(df[name]) in Explorer.Shared.numeric_types()
   end
 
   defp pairwised_df(df, opts) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -34,7 +34,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         a string ["a", "b"]
-        b integer [1, 2]
+        b s64 [1, 2]
       >
 
   Or with a list of maps:
@@ -43,7 +43,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         col1 string ["a", "b"]
-        col2 integer [1, 2]
+        col2 s64 [1, 2]
       >
 
   ## Verbs
@@ -136,7 +136,7 @@ defmodule Explorer.DataFrame do
       iex> df["class"]
       #Explorer.Series<
         Polars[178]
-        integer [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...]
+        s64 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...]
       >
 
   Accessing the dataframe with a column name either as a string or an atom, will return
@@ -146,7 +146,7 @@ defmodule Explorer.DataFrame do
       iex> df[0]
       #Explorer.Series<
         Polars[178]
-        integer [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...]
+        s64 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...]
       >
 
   You can also pass a list, a range, or a regex to return a dataframe matching
@@ -156,7 +156,7 @@ defmodule Explorer.DataFrame do
       iex> df[["class", "hue"]]
       #Explorer.DataFrame<
         Polars[178 x 2]
-        class integer [1, 1, 1, 1, 1, ...]
+        class s64 [1, 1, 1, 1, 1, ...]
         hue f64 [1.04, 1.05, 1.03, 0.86, 1.04, ...]
       >
 
@@ -166,7 +166,7 @@ defmodule Explorer.DataFrame do
       iex> df[0..2]
       #Explorer.DataFrame<
         Polars[178 x 3]
-        class integer [1, 1, 1, 1, 1, ...]
+        class s64 [1, 1, 1, 1, 1, ...]
         alcohol f64 [14.23, 13.2, 13.16, 14.37, 13.24, ...]
         malic_acid f64 [1.71, 1.78, 2.36, 1.95, 2.59, ...]
       >
@@ -177,7 +177,7 @@ defmodule Explorer.DataFrame do
       iex> df[~r/(class|hue)/]
       #Explorer.DataFrame<
         Polars[178 x 2]
-        class integer [1, 1, 1, 1, 1, ...]
+        class s64 [1, 1, 1, 1, 1, ...]
         hue f64 [1.04, 1.05, 1.03, 0.86, 1.04, ...]
       >
 
@@ -1569,7 +1569,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.load_ndjson!(contents)
       #Explorer.DataFrame<
         Polars[2 x 2]
-        col_a integer [1, 2]
+        col_a s64 [1, 2]
         col_b f64 [5.1, 5.2]
       >
 
@@ -1657,7 +1657,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         floats f64 [1.0, 2.0]
-        ints integer [1, nil]
+        ints s64 [1, nil]
       >
 
   ### From tensors
@@ -1672,9 +1672,9 @@ defmodule Explorer.DataFrame do
       ...> ]))
       #Explorer.DataFrame<
         Polars[2 x 3]
-        x1 integer [1, 4]
-        x2 integer [2, 5]
-        x3 integer [3, 6]
+        x1 s64 [1, 4]
+        x2 s64 [2, 5]
+        x3 s64 [3, 6]
       >
 
   Explorer expects tensors to have certain types, so you may need to cast
@@ -1689,7 +1689,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         floats f64 [1.0, 2.0]
-        ints integer [3, 4]
+        ints s64 [3, 4]
       >
 
   Use dtypes to force a particular representation:
@@ -1713,26 +1713,26 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         floats f64 [1.0, 2.0]
-        ints integer [1, nil]
+        ints s64 [1, nil]
       >
 
       iex> Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, nil])
       #Explorer.DataFrame<
         Polars[2 x 2]
         floats f64 [1.0, 2.0]
-        ints integer [1, nil]
+        ints s64 [1, nil]
       >
 
       iex> Explorer.DataFrame.new([floats: [1.0, 2.0], ints: [1, nil], binaries: [<<239, 191, 19>>, nil]], dtypes: [{:binaries, :binary}])
       #Explorer.DataFrame<
         Polars[2 x 3]
         floats f64 [1.0, 2.0]
-        ints integer [1, nil]
+        ints s64 [1, nil]
         binaries binary [<<239, 191, 19>>, nil]
       >
 
       iex> Explorer.DataFrame.new(%{floats: [1.0, 2.0], ints: [1, "wrong"]})
-      ** (ArgumentError) cannot create series "ints": the value "wrong" does not match the inferred series dtype :integer
+      ** (ArgumentError) cannot create series "ints": the value "wrong" does not match the inferred series dtype {:s, 64}
 
   From row data:
 
@@ -1740,7 +1740,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.new(rows)
       #Explorer.DataFrame<
         Polars[3 x 2]
-        id integer [1, 2, 3]
+        id s64 [1, 2, 3]
         name string ["José", "Christopher", "Cristine"]
       >
 
@@ -1748,7 +1748,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.new(rows)
       #Explorer.DataFrame<
         Polars[3 x 2]
-        id integer [1, 2, 3]
+        id s64 [1, 2, 3]
         name string ["José", "Christopher", "Cristine"]
       >
   """
@@ -1995,7 +1995,7 @@ defmodule Explorer.DataFrame do
 
       iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, 2])
       iex> Explorer.DataFrame.dtypes(df)
-      %{"floats" => {:f, 64}, "ints" => :integer}
+      %{"floats" => {:f, 64}, "ints" => {:s, 64}}
   """
   @doc type: :introspection
   @spec dtypes(df :: DataFrame.t()) :: %{String.t() => atom()}
@@ -2082,32 +2082,32 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.head(df)
       #Explorer.DataFrame<
         Polars[5 x 10]
-        year integer [2010, 2010, 2010, 2010, 2010]
+        year s64 [2010, 2010, 2010, 2010, 2010]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA"]
-        total integer [2308, 1254, 32500, 141, 7924]
-        solid_fuel integer [627, 117, 332, 0, 0]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649]
-        gas_fuel integer [74, 7, 14565, 0, 374]
-        cement integer [5, 177, 2598, 0, 204]
-        gas_flaring integer [0, 0, 2623, 0, 3697]
+        total s64 [2308, 1254, 32500, 141, 7924]
+        solid_fuel s64 [627, 117, 332, 0, 0]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649]
+        gas_fuel s64 [74, 7, 14565, 0, 374]
+        cement s64 [5, 177, 2598, 0, 204]
+        gas_flaring s64 [0, 0, 2623, 0, 3697]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37]
-        bunker_fuels integer [9, 7, 663, 0, 321]
+        bunker_fuels s64 [9, 7, 663, 0, 321]
       >
 
       iex> df = Explorer.Datasets.fossil_fuels()
       iex> Explorer.DataFrame.head(df, 2)
       #Explorer.DataFrame<
         Polars[2 x 10]
-        year integer [2010, 2010]
+        year s64 [2010, 2010]
         country string ["AFGHANISTAN", "ALBANIA"]
-        total integer [2308, 1254]
-        solid_fuel integer [627, 117]
-        liquid_fuel integer [1601, 953]
-        gas_fuel integer [74, 7]
-        cement integer [5, 177]
-        gas_flaring integer [0, 0]
+        total s64 [2308, 1254]
+        solid_fuel s64 [627, 117]
+        liquid_fuel s64 [1601, 953]
+        gas_fuel s64 [74, 7]
+        cement s64 [5, 177]
+        gas_flaring s64 [0, 0]
         per_capita f64 [0.08, 0.43]
-        bunker_fuels integer [9, 7]
+        bunker_fuels s64 [9, 7]
       >
 
   ## Grouped examples
@@ -2147,32 +2147,32 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.tail(df)
       #Explorer.DataFrame<
         Polars[5 x 10]
-        year integer [2014, 2014, 2014, 2014, 2014]
+        year s64 [2014, 2014, 2014, 2014, 2014]
         country string ["VIET NAM", "WALLIS AND FUTUNA ISLANDS", "YEMEN", "ZAMBIA", "ZIMBABWE"]
-        total integer [45517, 6, 6190, 1228, 3278]
-        solid_fuel integer [19246, 0, 137, 132, 2097]
-        liquid_fuel integer [12694, 6, 5090, 797, 1005]
-        gas_fuel integer [5349, 0, 581, 0, 0]
-        cement integer [8229, 0, 381, 299, 177]
-        gas_flaring integer [0, 0, 0, 0, 0]
+        total s64 [45517, 6, 6190, 1228, 3278]
+        solid_fuel s64 [19246, 0, 137, 132, 2097]
+        liquid_fuel s64 [12694, 6, 5090, 797, 1005]
+        gas_fuel s64 [5349, 0, 581, 0, 0]
+        cement s64 [8229, 0, 381, 299, 177]
+        gas_flaring s64 [0, 0, 0, 0, 0]
         per_capita f64 [0.49, 0.44, 0.24, 0.08, 0.22]
-        bunker_fuels integer [761, 1, 153, 33, 9]
+        bunker_fuels s64 [761, 1, 153, 33, 9]
       >
 
       iex> df = Explorer.Datasets.fossil_fuels()
       iex> Explorer.DataFrame.tail(df, 2)
       #Explorer.DataFrame<
         Polars[2 x 10]
-        year integer [2014, 2014]
+        year s64 [2014, 2014]
         country string ["ZAMBIA", "ZIMBABWE"]
-        total integer [1228, 3278]
-        solid_fuel integer [132, 2097]
-        liquid_fuel integer [797, 1005]
-        gas_fuel integer [0, 0]
-        cement integer [299, 177]
-        gas_flaring integer [0, 0]
+        total s64 [1228, 3278]
+        solid_fuel s64 [132, 2097]
+        liquid_fuel s64 [797, 1005]
+        gas_fuel s64 [0, 0]
+        cement s64 [299, 177]
+        gas_flaring s64 [0, 0]
         per_capita f64 [0.08, 0.22]
-        bunker_fuels integer [33, 9]
+        bunker_fuels s64 [33, 9]
       >
 
   ## Grouped examples
@@ -2231,7 +2231,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["a", "b", "c"]
-        b integer [1, 2, 3]
+        b s64 [1, 2, 3]
       >
 
       iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
@@ -2239,7 +2239,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["a", "b", "c"]
-        b integer [1, 2, 3]
+        b s64 [1, 2, 3]
       >
 
   Or you can use a callback function that takes the dataframe's names as its first argument:
@@ -2248,7 +2248,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.select(df, &String.starts_with?(&1, "b"))
       #Explorer.DataFrame<
         Polars[3 x 1]
-        b integer [1, 2, 3]
+        b s64 [1, 2, 3]
       >
 
   Or, if you prefer, a regex:
@@ -2257,16 +2257,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.select(df, ~r/^b$/)
       #Explorer.DataFrame<
         Polars[3 x 1]
-        b integer [1, 2, 3]
+        b s64 [1, 2, 3]
       >
 
   Or a callback function that takes names and types:
 
       iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
-      iex> Explorer.DataFrame.select(df, fn _name, type -> type == :integer end)
+      iex> Explorer.DataFrame.select(df, fn _name, type -> type == {:s, 64} end)
       #Explorer.DataFrame<
         Polars[3 x 1]
-        b integer [1, 2, 3]
+        b s64 [1, 2, 3]
       >
 
   ## Grouped examples
@@ -2319,7 +2319,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.discard(df, ["a", "b"])
       #Explorer.DataFrame<
         Polars[3 x 1]
-        c integer [4, 5, 6]
+        c s64 [4, 5, 6]
       >
 
   Ranges, regexes, and functions are also accepted in column names, as in `select/2`.
@@ -2371,7 +2371,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1 x 2]
         col1 string ["b"]
-        col2 integer [2]
+        col2 s64 [2]
       >
 
   You must avoid using masks when the masks themselves are computed from
@@ -2382,7 +2382,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         col1 string ["b", "c"]
-        col2 integer [2, 3]
+        col2 s64 [2, 3]
       >
 
   Instead, do this:
@@ -2392,7 +2392,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         col1 string ["b", "c"]
-        col2 integer [2, 3]
+        col2 s64 [2, 3]
       >
 
   The `filter_with/2` version is much more efficient because it doesn't need
@@ -2444,7 +2444,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1 x 2]
         col1 string ["c"]
-        col2 integer [3]
+        col2 s64 [3]
       >
 
       iex> df = Explorer.DataFrame.new(col1: ["a", "b", "c"], col2: [1, 2, 3])
@@ -2452,22 +2452,22 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1 x 2]
         col1 string ["b"]
-        col2 integer [2]
+        col2 s64 [2]
       >
 
       iex> df = Explorer.DataFrame.new(col1: [5, 4, 3], col2: [1, 2, 3])
       iex> Explorer.DataFrame.filter(df, [col1 > 3, col2 < 3])
       #Explorer.DataFrame<
         Polars[2 x 2]
-        col1 integer [5, 4]
-        col2 integer [1, 2]
+        col1 s64 [5, 4]
+        col2 s64 [1, 2]
       >
 
   Returning a non-boolean expression errors:
 
       iex> df = Explorer.DataFrame.new(col1: ["a", "b", "c"], col2: [1, 2, 3])
       iex> Explorer.DataFrame.filter(df, cumulative_max(col2))
-      ** (ArgumentError) expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type :integer
+      ** (ArgumentError) expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type {:s, 64}
 
   Which can be addressed by converting it to boolean:
 
@@ -2476,7 +2476,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1 x 2]
         col1 string ["a"]
-        col2 integer [1]
+        col2 s64 [1]
       >
 
   ## Grouped examples
@@ -2524,7 +2524,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1 x 2]
         col1 string ["c"]
-        col2 integer [3]
+        col2 s64 [3]
       >
 
       iex> df = Explorer.DataFrame.new(col1: ["a", "b", "c"], col2: [1, 2, 3])
@@ -2532,7 +2532,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1 x 2]
         col1 string ["b"]
-        col2 integer [2]
+        col2 s64 [2]
       >
 
   ## Grouped examples
@@ -2626,8 +2626,8 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 3]
         a string ["a", "b", "c"]
-        b integer [1, 2, 3]
-        c integer [2, 3, 4]
+        b s64 [1, 2, 3]
+        c s64 [2, 3, 4]
       >
 
   It's also possible to overwrite existing columns:
@@ -2636,8 +2636,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.mutate(df, a: b * 2)
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [2, 4, 6]
-        b integer [1, 2, 3]
+        a s64 [2, 4, 6]
+        b s64 [1, 2, 3]
       >
 
   Scalar values are repeated to fill the series:
@@ -2646,8 +2646,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.mutate(df, a: 4)
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [4, 4, 4]
-        b integer [1, 2, 3]
+        a s64 [4, 4, 4]
+        b s64 [1, 2, 3]
       >
 
   It's also possible to use functions from the Series module, like `Explorer.Series.window_sum/3`:
@@ -2656,8 +2656,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.mutate(df, b: window_sum(a, 2))
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [1, 2, 3]
-        b integer [1, 3, 5]
+        a s64 [1, 2, 3]
+        b s64 [1, 3, 5]
       >
 
   Alternatively, all of the above works with a map instead of a keyword list:
@@ -2667,7 +2667,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 3]
         a string ["a", "b", "c"]
-        b integer [1, 2, 3]
+        b s64 [1, 2, 3]
         c f64 [1.0, 2.0, 3.0]
       >
 
@@ -2686,8 +2686,8 @@ defmodule Explorer.DataFrame do
         Polars[3 x 3]
         Groups: ["id"]
         id string ["a", "a", "b"]
-        b integer [1, 2, 3]
-        count integer [2, 2, 1]
+        b s64 [1, 2, 3]
+        count s64 [2, 2, 1]
       >
 
   In case we want to get the average size of the petal length from the Iris dataset, we can:
@@ -2734,9 +2734,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.mutate_with(df, &[c: Explorer.Series.add(&1["a"], &1["b"])])
       #Explorer.DataFrame<
         Polars[3 x 3]
-        a integer [4, 5, 6]
-        b integer [1, 2, 3]
-        c integer [5, 7, 9]
+        a s64 [4, 5, 6]
+        b s64 [1, 2, 3]
+        c s64 [5, 7, 9]
       >
 
   You can overwrite existing columns as well:
@@ -2758,10 +2758,10 @@ defmodule Explorer.DataFrame do
       iex> end)
       #Explorer.DataFrame<
         Polars[3 x 4]
-        a integer [4, 5, 6]
-        b integer [1, 2, 3]
-        c integer [5, 7, 9]
-        d integer [5, 12, 16]
+        a s64 [4, 5, 6]
+        b s64 [1, 2, 3]
+        c s64 [5, 7, 9]
+        d s64 [5, 12, 16]
       >
 
   ## Grouped examples
@@ -2777,8 +2777,8 @@ defmodule Explorer.DataFrame do
         Polars[3 x 3]
         Groups: ["id"]
         id string ["a", "a", "b"]
-        b integer [1, 2, 3]
-        count integer [2, 2, 1]
+        b s64 [1, 2, 3]
+        count s64 [2, 2, 1]
       >
 
   """
@@ -2884,16 +2884,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.put(df, :b, Explorer.Series.transform(df[:a], fn n -> n * 2 end))
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [1, 2, 3]
-        b integer [2, 4, 6]
+        a s64 [1, 2, 3]
+        b s64 [2, 4, 6]
       >
 
       iex> df = Explorer.DataFrame.new(a: [1, 2, 3])
       iex> Explorer.DataFrame.put(df, :b, Explorer.Series.from_list([4, 5, 6]))
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [1, 2, 3]
-        b integer [4, 5, 6]
+        a s64 [1, 2, 3]
+        b s64 [4, 5, 6]
       >
 
   ## Grouped examples
@@ -2908,8 +2908,8 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         Groups: ["a"]
-        a integer [1, 2, 3]
-        b integer [9, 8, 7]
+        a s64 [1, 2, 3]
+        b s64 [9, 8, 7]
       >
 
   ## Tensor examples
@@ -2920,7 +2920,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.put(df, :a, Nx.tensor([1, 2, 3]))
       #Explorer.DataFrame<
         Polars[3 x 1]
-        a integer [1, 2, 3]
+        a s64 [1, 2, 3]
       >
 
   You can specify which dtype the tensor represents.
@@ -2963,7 +2963,7 @@ defmodule Explorer.DataFrame do
 
       iex> df = Explorer.DataFrame.new(a: [1, 2, 3])
       iex> Explorer.DataFrame.put(df, :a, Nx.tensor(1.0, type: :f64))
-      ** (ArgumentError) dtype integer expects a tensor of type {:s, 64} but got type {:f, 64}
+      ** (ArgumentError) dtype {:s, 64} expects a tensor of type {:s, 64} but got type {:f, 64}
 
       iex> df = Explorer.DataFrame.new(a: [1, 2, 3])
       iex> Explorer.DataFrame.put(df, :a, Nx.tensor(1.0, type: :f64), dtype: {:f, 64})
@@ -2987,7 +2987,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.put(df, :a, [1, 2, 3])
       #Explorer.DataFrame<
         Polars[3 x 1]
-        a integer [1, 2, 3]
+        a s64 [1, 2, 3]
       >
 
   The same considerations as above apply.
@@ -3089,7 +3089,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["a", "b", "c"]
-        b integer [3, 1, 2]
+        b s64 [3, 1, 2]
       >
 
   You can also sort descending:
@@ -3099,7 +3099,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["c", "b", "a"]
-        b integer [2, 1, 3]
+        b s64 [2, 1, 3]
       >
 
   You can specify how `nil`s are sorted:
@@ -3117,16 +3117,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.sort_by(df, asc: total, desc: country)
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        year integer [2010, 2010, 2011, 2011, 2012, ...]
+        year s64 [2010, 2010, 2011, 2011, 2012, ...]
         country string ["NIUE", "TUVALU", "TUVALU", "NIUE", "NIUE", ...]
-        total integer [1, 2, 2, 2, 2, ...]
-        solid_fuel integer [0, 0, 0, 0, 0, ...]
-        liquid_fuel integer [1, 2, 2, 2, 2, ...]
-        gas_fuel integer [0, 0, 0, 0, 0, ...]
-        cement integer [0, 0, 0, 0, 0, ...]
-        gas_flaring integer [0, 0, 0, 0, 0, ...]
+        total s64 [1, 2, 2, 2, 2, ...]
+        solid_fuel s64 [0, 0, 0, 0, 0, ...]
+        liquid_fuel s64 [1, 2, 2, 2, 2, ...]
+        gas_fuel s64 [0, 0, 0, 0, 0, ...]
+        cement s64 [0, 0, 0, 0, 0, ...]
+        gas_flaring s64 [0, 0, 0, 0, 0, ...]
         per_capita f64 [0.52, 0.0, 0.0, 1.04, 1.04, ...]
-        bunker_fuels integer [0, 0, 0, 0, 0, ...]
+        bunker_fuels s64 [0, 0, 0, 0, 0, ...]
       >
 
   ## Grouped examples
@@ -3208,7 +3208,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["a", "b", "c"]
-        b integer [3, 1, 2]
+        b s64 [3, 1, 2]
       >
 
   You can also sort descending:
@@ -3218,7 +3218,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["c", "b", "a"]
-        b integer [2, 1, 3]
+        b s64 [2, 1, 3]
       >
 
   You can specify how `nil`s are sorted:
@@ -3236,8 +3236,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.sort_with(df, &[desc: &1["a"], asc: &1["b"]])
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [3, 3, 1]
-        b integer [2, 3, 1]
+        a s64 [3, 3, 1]
+        b s64 [2, 3, 1]
       >
 
   ## Grouped examples
@@ -3314,7 +3314,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.distinct(df, ["year", "country"])
       #Explorer.DataFrame<
         Polars[1094 x 2]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
       >
 
@@ -3325,16 +3325,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.distinct(df, ["year", "country"], keep_all: true)
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   A callback on the dataframe's names can be passed instead of a list (like `select/2`):
@@ -3343,7 +3343,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.distinct(df, &String.starts_with?(&1, "x"))
       #Explorer.DataFrame<
         Polars[2 x 2]
-        x1 integer [1, 3]
+        x1 s64 [1, 3]
         x2 string ["a", "c"]
       >
 
@@ -3355,7 +3355,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 2]
         Groups: ["x1"]
-        x1 integer [1, 3]
+        x1 s64 [1, 3]
         x2 string ["a", "c"]
       >
 
@@ -3398,8 +3398,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.drop_nil(df)
       #Explorer.DataFrame<
         Polars[1 x 2]
-        a integer [1]
-        b integer [1]
+        a s64 [1]
+        b s64 [1]
       >
 
    To drop nils on a single column:
@@ -3408,8 +3408,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.drop_nil(df, :a)
       #Explorer.DataFrame<
         Polars[2 x 2]
-        a integer [1, 2]
-        b integer [1, nil]
+        a s64 [1, 2]
+        b s64 [1, nil]
       >
 
   To drop some columns:
@@ -3418,9 +3418,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.drop_nil(df, [:a, :c])
       #Explorer.DataFrame<
         Polars[1 x 3]
-        a integer [2]
-        b integer [nil]
-        c integer [5]
+        a s64 [2]
+        b s64 [nil]
+        c s64 [5]
       >
 
   Ranges, regexes, and functions are also accepted in column names, as in `select/2`.
@@ -3461,8 +3461,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.relocate(df, "a", after: "c")
       #Explorer.DataFrame<
         Polars[3 x 3]
-        b integer [1, 3, 1]
-        c integer [nil, 5, 6]
+        b s64 [1, 3, 1]
+        c s64 [nil, 5, 6]
         a string ["a", "b", "a"]
       >
 
@@ -3474,8 +3474,8 @@ defmodule Explorer.DataFrame do
         Polars[2 x 4]
         d string ["yes", "no"]
         b f64 [5.1, 5.2]
-        a integer [1, 2]
-        c integer [4, 5]
+        a s64 [1, 2]
+        c s64 [4, 5]
       >
 
   Relocate before another column
@@ -3484,8 +3484,8 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.relocate(df, ["a", "c"], before: "b")
       #Explorer.DataFrame<
         Polars[2 x 4]
-        a integer [1, 2]
-        c integer [4, 5]
+        a s64 [1, 2]
+        c s64 [4, 5]
         b f64 [5.1, 5.2]
         d string ["yes", "no"]
       >
@@ -3562,7 +3562,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         c string ["a", "b", "a"]
-        d integer [1, 3, 1]
+        d s64 [1, 3, 1]
       >
 
   Or you can rename individual columns using keyword args:
@@ -3572,7 +3572,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         first string ["a", "b", "a"]
-        b integer [1, 3, 1]
+        b s64 [1, 3, 1]
       >
 
   Or you can rename individual columns using a map:
@@ -3582,7 +3582,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         first string ["a", "b", "a"]
-        b integer [1, 3, 1]
+        b s64 [1, 3, 1]
       >
 
   """
@@ -3653,16 +3653,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.rename_with(df, &String.upcase/1)
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        YEAR integer [2010, 2010, 2010, 2010, 2010, ...]
+        YEAR s64 [2010, 2010, 2010, 2010, 2010, ...]
         COUNTRY string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        TOTAL integer [2308, 1254, 32500, 141, 7924, ...]
-        SOLID_FUEL integer [627, 117, 332, 0, 0, ...]
-        LIQUID_FUEL integer [1601, 953, 12381, 141, 3649, ...]
-        GAS_FUEL integer [74, 7, 14565, 0, 374, ...]
-        CEMENT integer [5, 177, 2598, 0, 204, ...]
-        GAS_FLARING integer [0, 0, 2623, 0, 3697, ...]
+        TOTAL s64 [2308, 1254, 32500, 141, 7924, ...]
+        SOLID_FUEL s64 [627, 117, 332, 0, 0, ...]
+        LIQUID_FUEL s64 [1601, 953, 12381, 141, 3649, ...]
+        GAS_FUEL s64 [74, 7, 14565, 0, 374, ...]
+        CEMENT s64 [5, 177, 2598, 0, 204, ...]
+        GAS_FLARING s64 [0, 0, 2623, 0, 3697, ...]
         PER_CAPITA f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        BUNKER_FUELS integer [9, 7, 663, 0, 321, ...]
+        BUNKER_FUELS s64 [9, 7, 663, 0, 321, ...]
       >
 
   A callback can be used to filter the column names that will be renamed, similarly to `select/2`:
@@ -3671,16 +3671,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.rename_with(df, &String.ends_with?(&1, "_fuel"), &String.trim_trailing(&1, "_fuel"))
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid integer [627, 117, 332, 0, 0, ...]
-        liquid integer [1601, 953, 12381, 141, 3649, ...]
-        gas integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid s64 [627, 117, 332, 0, 0, ...]
+        liquid s64 [1601, 953, 12381, 141, 3649, ...]
+        gas s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Or you can just pass in the list of column names you'd like to apply the function to:
@@ -3689,16 +3689,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.rename_with(df, ["total", "cement"], &String.upcase/1)
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        TOTAL integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        CEMENT integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        TOTAL s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        CEMENT s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Ranges, regexes, and functions are also accepted in column names, as in `select/2`.
@@ -3733,9 +3733,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.dummies(df, "col_x")
       #Explorer.DataFrame<
         Polars[4 x 3]
-        col_x_a integer [1, 0, 1, 0]
-        col_x_b integer [0, 1, 0, 0]
-        col_x_c integer [0, 0, 0, 1]
+        col_x_a s64 [1, 0, 1, 0]
+        col_x_b s64 [0, 1, 0, 0]
+        col_x_c s64 [0, 0, 0, 1]
       >
 
   Or multiple columns:
@@ -3744,12 +3744,12 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.dummies(df, ["col_x", "col_y"])
       #Explorer.DataFrame<
         Polars[4 x 6]
-        col_x_a integer [1, 0, 1, 0]
-        col_x_b integer [0, 1, 0, 0]
-        col_x_c integer [0, 0, 0, 1]
-        col_y_b integer [1, 0, 1, 0]
-        col_y_a integer [0, 1, 0, 0]
-        col_y_d integer [0, 0, 0, 1]
+        col_x_a s64 [1, 0, 1, 0]
+        col_x_b s64 [0, 1, 0, 0]
+        col_x_c s64 [0, 0, 0, 1]
+        col_y_b s64 [1, 0, 1, 0]
+        col_y_a s64 [0, 1, 0, 0]
+        col_y_d s64 [0, 0, 0, 1]
       >
 
   Or all string columns:
@@ -3758,9 +3758,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.dummies(df, fn _name, type -> type == :string end)
       #Explorer.DataFrame<
         Polars[4 x 3]
-        col_y_b integer [1, 0, 1, 0]
-        col_y_a integer [0, 1, 0, 0]
-        col_y_d integer [0, 0, 0, 1]
+        col_y_b s64 [1, 0, 1, 0]
+        col_y_a s64 [0, 1, 0, 0]
+        col_y_d s64 [0, 0, 0, 1]
       >
 
   Ranges, regexes, and functions are also accepted in column names, as in `select/2`.
@@ -3798,14 +3798,14 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.pull(df, "total")
       #Explorer.Series<
         Polars[1094]
-        integer [2308, 1254, 32500, 141, 7924, 41, 143, 51246, 1150, 684, 106589, 18408, 8366, 451, 7981, 16345, 403, 17192, 30222, 147, 1388, 166, 133, 5802, 1278, 114468, 47, 2237, 12030, 535, 58, 1367, 145806, 152, 152, 72, 141, 19703, 2393248, 20773, 44, 540, 19, 2064, 1900, 5501, 10465, 2102, 30428, 18122, ...]
+        s64 [2308, 1254, 32500, 141, 7924, 41, 143, 51246, 1150, 684, 106589, 18408, 8366, 451, 7981, 16345, 403, 17192, 30222, 147, 1388, 166, 133, 5802, 1278, 114468, 47, 2237, 12030, 535, 58, 1367, 145806, 152, 152, 72, 141, 19703, 2393248, 20773, 44, 540, 19, 2064, 1900, 5501, 10465, 2102, 30428, 18122, ...]
       >
 
       iex> df = Explorer.Datasets.fossil_fuels()
       iex> Explorer.DataFrame.pull(df, 2)
       #Explorer.Series<
         Polars[1094]
-        integer [2308, 1254, 32500, 141, 7924, 41, 143, 51246, 1150, 684, 106589, 18408, 8366, 451, 7981, 16345, 403, 17192, 30222, 147, 1388, 166, 133, 5802, 1278, 114468, 47, 2237, 12030, 535, 58, 1367, 145806, 152, 152, 72, 141, 19703, 2393248, 20773, 44, 540, 19, 2064, 1900, 5501, 10465, 2102, 30428, 18122, ...]
+        s64 [2308, 1254, 32500, 141, 7924, 41, 143, 51246, 1150, 684, 106589, 18408, 8366, 451, 7981, 16345, 403, 17192, 30222, 147, 1388, 166, 133, 5802, 1278, 114468, 47, 2237, 12030, 535, 58, 1367, 145806, 152, 152, 72, 141, 19703, 2393248, 20773, 44, 540, 19, 2064, 1900, 5501, 10465, 2102, 30428, 18122, ...]
       >
   """
   @doc type: :single
@@ -3829,16 +3829,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, 1, 2)
       #Explorer.DataFrame<
         Polars[2 x 10]
-        year integer [2010, 2010]
+        year s64 [2010, 2010]
         country string ["ALBANIA", "ALGERIA"]
-        total integer [1254, 32500]
-        solid_fuel integer [117, 332]
-        liquid_fuel integer [953, 12381]
-        gas_fuel integer [7, 14565]
-        cement integer [177, 2598]
-        gas_flaring integer [0, 2623]
+        total s64 [1254, 32500]
+        solid_fuel s64 [117, 332]
+        liquid_fuel s64 [953, 12381]
+        gas_fuel s64 [7, 14565]
+        cement s64 [177, 2598]
+        gas_flaring s64 [0, 2623]
         per_capita f64 [0.43, 0.9]
-        bunker_fuels integer [7, 663]
+        bunker_fuels s64 [7, 663]
       >
 
   Negative offsets count from the end of the series:
@@ -3847,16 +3847,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, -10, 2)
       #Explorer.DataFrame<
         Polars[2 x 10]
-        year integer [2014, 2014]
+        year s64 [2014, 2014]
         country string ["UNITED STATES OF AMERICA", "URUGUAY"]
-        total integer [1432855, 1840]
-        solid_fuel integer [450047, 2]
-        liquid_fuel integer [576531, 1700]
-        gas_fuel integer [390719, 25]
-        cement integer [11314, 112]
-        gas_flaring integer [4244, 0]
+        total s64 [1432855, 1840]
+        solid_fuel s64 [450047, 2]
+        liquid_fuel s64 [576531, 1700]
+        gas_fuel s64 [390719, 25]
+        cement s64 [11314, 112]
+        gas_flaring s64 [4244, 0]
         per_capita f64 [4.43, 0.54]
-        bunker_fuels integer [30722, 251]
+        bunker_fuels s64 [30722, 251]
       >
 
   If the length would run past the end of the dataframe, the result may be shorter than the length:
@@ -3865,16 +3865,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, -10, 20)
       #Explorer.DataFrame<
         Polars[10 x 10]
-        year integer [2014, 2014, 2014, 2014, 2014, ...]
+        year s64 [2014, 2014, 2014, 2014, 2014, ...]
         country string ["UNITED STATES OF AMERICA", "URUGUAY", "UZBEKISTAN", "VANUATU", "VENEZUELA", ...]
-        total integer [1432855, 1840, 28692, 42, 50510, ...]
-        solid_fuel integer [450047, 2, 1677, 0, 204, ...]
-        liquid_fuel integer [576531, 1700, 2086, 42, 28445, ...]
-        gas_fuel integer [390719, 25, 23929, 0, 12731, ...]
-        cement integer [11314, 112, 1000, 0, 1088, ...]
-        gas_flaring integer [4244, 0, 0, 0, 8042, ...]
+        total s64 [1432855, 1840, 28692, 42, 50510, ...]
+        solid_fuel s64 [450047, 2, 1677, 0, 204, ...]
+        liquid_fuel s64 [576531, 1700, 2086, 42, 28445, ...]
+        gas_fuel s64 [390719, 25, 23929, 0, 12731, ...]
+        cement s64 [11314, 112, 1000, 0, 1088, ...]
+        gas_flaring s64 [4244, 0, 0, 0, 8042, ...]
         per_capita f64 [4.43, 0.54, 0.97, 0.16, 1.65, ...]
-        bunker_fuels integer [30722, 251, 0, 10, 1256, ...]
+        bunker_fuels s64 [30722, 251, 0, 10, 1256, ...]
       >
 
   ## Grouped examples
@@ -3935,7 +3935,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, [0, 2])
       #Explorer.DataFrame<
         Polars[2 x 2]
-        a integer [1, 3]
+        a s64 [1, 3]
         b string ["a", "c"]
       >
 
@@ -3945,7 +3945,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, Explorer.Series.from_list([0, 2]))
       #Explorer.DataFrame<
         Polars[2 x 2]
-        a integer [1, 3]
+        a s64 [1, 3]
         b string ["a", "c"]
       >
 
@@ -3955,7 +3955,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, 1..2)
       #Explorer.DataFrame<
         Polars[2 x 2]
-        a integer [2, 3]
+        a s64 [2, 3]
         b string ["b", "c"]
       >
 
@@ -3965,7 +3965,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.slice(df, -2..-1)
       #Explorer.DataFrame<
         Polars[2 x 2]
-        a integer [2, 3]
+        a s64 [2, 3]
         b string ["b", "c"]
       >
 
@@ -4080,16 +4080,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.sample(df, 3, seed: 100)
       #Explorer.DataFrame<
         Polars[3 x 10]
-        year integer [2012, 2013, 2014]
+        year s64 [2012, 2013, 2014]
         country string ["SYRIAN ARAB REPUBLIC", "EGYPT", "AFGHANISTAN"]
-        total integer [12198, 58198, 2675]
-        solid_fuel integer [1, 224, 1194]
-        liquid_fuel integer [7909, 26501, 1393]
-        gas_fuel integer [3265, 24672, 74]
-        cement integer [816, 6800, 14]
-        gas_flaring integer [208, 0, 0]
+        total s64 [12198, 58198, 2675]
+        solid_fuel s64 [1, 224, 1194]
+        liquid_fuel s64 [7909, 26501, 1393]
+        gas_fuel s64 [3265, 24672, 74]
+        cement s64 [816, 6800, 14]
+        gas_flaring s64 [208, 0, 0]
         per_capita f64 [0.61, 0.66, 0.08]
-        bunker_fuels integer [437, 694, 9]
+        bunker_fuels s64 [437, 694, 9]
       >
 
   Or you can sample a proportion of rows:
@@ -4098,16 +4098,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.sample(df, 0.03, seed: 100)
       #Explorer.DataFrame<
         Polars[32 x 10]
-        year integer [2013, 2012, 2014, 2011, 2011, ...]
+        year s64 [2013, 2012, 2014, 2011, 2011, ...]
         country string ["BRITISH VIRGIN ISLANDS", "TAJIKISTAN", "AFGHANISTAN", "ICELAND", "SINGAPORE", ...]
-        total integer [48, 800, 2675, 513, 12332, ...]
-        solid_fuel integer [0, 192, 1194, 94, 7, ...]
-        liquid_fuel integer [48, 501, 1393, 400, 7774, ...]
-        gas_fuel integer [0, 74, 74, 0, 4551, ...]
-        cement integer [0, 34, 14, 19, 0, ...]
-        gas_flaring integer [0, 0, 0, 0, 0, ...]
+        total s64 [48, 800, 2675, 513, 12332, ...]
+        solid_fuel s64 [0, 192, 1194, 94, 7, ...]
+        liquid_fuel s64 [48, 501, 1393, 400, 7774, ...]
+        gas_fuel s64 [0, 74, 74, 0, 4551, ...]
+        cement s64 [0, 34, 14, 19, 0, ...]
+        gas_flaring s64 [0, 0, 0, 0, 0, ...]
         per_capita f64 [1.64, 0.1, 0.08, 1.6, 2.38, ...]
-        bunker_fuels integer [0, 28, 9, 168, 41786, ...]
+        bunker_fuels s64 [0, 28, 9, 168, 41786, ...]
       >
 
   ## Grouped examples
@@ -4183,16 +4183,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.shuffle(df, seed: 100)
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        year integer [2014, 2014, 2014, 2012, 2010, ...]
+        year s64 [2014, 2014, 2014, 2012, 2010, ...]
         country string ["ISRAEL", "ARGENTINA", "NETHERLANDS", "YEMEN", "GRENADA", ...]
-        total integer [17617, 55638, 45624, 5091, 71, ...]
-        solid_fuel integer [6775, 1588, 9070, 129, 0, ...]
-        liquid_fuel integer [6013, 25685, 18272, 4173, 71, ...]
-        gas_fuel integer [3930, 26368, 18010, 414, 0, ...]
-        cement integer [898, 1551, 272, 375, 0, ...]
-        gas_flaring integer [0, 446, 0, 0, 0, ...]
+        total s64 [17617, 55638, 45624, 5091, 71, ...]
+        solid_fuel s64 [6775, 1588, 9070, 129, 0, ...]
+        liquid_fuel s64 [6013, 25685, 18272, 4173, 71, ...]
+        gas_fuel s64 [3930, 26368, 18010, 414, 0, ...]
+        cement s64 [898, 1551, 272, 375, 0, ...]
+        gas_flaring s64 [0, 446, 0, 0, 0, ...]
         per_capita f64 [2.22, 1.29, 2.7, 0.2, 0.68, ...]
-        bunker_fuels integer [1011, 2079, 14210, 111, 4, ...]
+        bunker_fuels s64 [1011, 2079, 14210, 111, 4, ...]
       >
 
   """
@@ -4242,34 +4242,34 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.pivot_longer(df, &String.ends_with?(&1, "fuel"))
       #Explorer.DataFrame<
         Polars[3282 x 9]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
         variable string ["solid_fuel", "solid_fuel", "solid_fuel", "solid_fuel", "solid_fuel", ...]
-        value integer [627, 117, 332, 0, 0, ...]
+        value s64 [627, 117, 332, 0, 0, ...]
       >
 
       iex> df = Explorer.Datasets.fossil_fuels()
       iex> Explorer.DataFrame.pivot_longer(df, &String.ends_with?(&1, "fuel"), select: ["year", "country"])
       #Explorer.DataFrame<
         Polars[3282 x 4]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
         variable string ["solid_fuel", "solid_fuel", "solid_fuel", "solid_fuel", "solid_fuel", ...]
-        value integer [627, 117, 332, 0, 0, ...]
+        value s64 [627, 117, 332, 0, 0, ...]
       >
 
       iex> df = Explorer.Datasets.fossil_fuels()
       iex> Explorer.DataFrame.pivot_longer(df, ["total"], select: ["year", "country"], discard: ["country"])
       #Explorer.DataFrame<
         Polars[1094 x 3]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         variable string ["total", "total", "total", "total", "total", ...]
-        value integer [2308, 1254, 32500, 141, 7924, ...]
+        value s64 [2308, 1254, 32500, 141, 7924, ...]
       >
 
       iex> df = Explorer.Datasets.fossil_fuels()
@@ -4277,7 +4277,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1094 x 2]
         my_var string ["total", "total", "total", "total", "total", ...]
-        my_value integer [2308, 1254, 32500, 141, 7924, ...]
+        my_value s64 [2308, 1254, 32500, 141, 7924, ...]
       >
 
   ## Grouped examples
@@ -4472,11 +4472,11 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 6]
         team string ["A", "B", "C"]
-        Monday integer [10, nil, 15]
-        Tuesday integer [14, 9, nil]
-        Wednesday integer [nil, 16, 10]
-        Thursday integer [10, nil, 14]
-        Friday integer [16, 11, nil]
+        Monday s64 [10, nil, 15]
+        Tuesday s64 [14, 9, nil]
+        Wednesday s64 [nil, 16, 10]
+        Thursday s64 [10, nil, 14]
+        Friday s64 [16, 11, nil]
       >
 
   Now if we print that same dataframe with `print/2`, we get a better picture of the schedule:
@@ -4505,11 +4505,11 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.pivot_wider(df, "property", "property_value")
       #Explorer.DataFrame<
         Polars[2 x 5]
-        product_id integer [1, 2]
-        product_id_1 integer [1, 2]
-        width_cm integer [42, 35]
-        height_cm integer [40, 20]
-        length_cm integer [64, 40]
+        product_id s64 [1, 2]
+        product_id_1 s64 [1, 2]
+        width_cm s64 [42, 35]
+        height_cm s64 [40, 20]
+        length_cm s64 [64, 40]
       >
 
   But if the option `:names_prefix` is used, that suffix is not added:
@@ -4522,11 +4522,11 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.pivot_wider(df, "property", "property_value", names_prefix: "col_")
       #Explorer.DataFrame<
         Polars[2 x 5]
-        product_id integer [1, 2]
-        col_product_id integer [1, 2]
-        col_width_cm integer [42, 35]
-        col_height_cm integer [40, 20]
-        col_length_cm integer [64, 40]
+        product_id s64 [1, 2]
+        col_product_id s64 [1, 2]
+        col_width_cm s64 [42, 35]
+        col_height_cm s64 [40, 20]
+        col_length_cm s64 [64, 40]
       >
 
   Multiple columns are accepted for the `values_from` parameter, but the behaviour is slightly
@@ -4543,15 +4543,15 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.pivot_wider(df, "property", ["property_value", "another_value"])
       #Explorer.DataFrame<
         Polars[2 x 9]
-        product_id integer [1, 2]
-        property_value_property_product_id integer [1, 2]
-        property_value_property_width_cm integer [42, 35]
-        property_value_property_height_cm integer [40, 20]
-        property_value_property_length_cm integer [64, 40]
-        another_value_property_product_id integer [1, 2]
-        another_value_property_width_cm integer [43, 36]
-        another_value_property_height_cm integer [41, 21]
-        another_value_property_length_cm integer [65, 42]
+        product_id s64 [1, 2]
+        property_value_property_product_id s64 [1, 2]
+        property_value_property_width_cm s64 [42, 35]
+        property_value_property_height_cm s64 [40, 20]
+        property_value_property_length_cm s64 [64, 40]
+        another_value_property_product_id s64 [1, 2]
+        another_value_property_width_cm s64 [43, 36]
+        another_value_property_height_cm s64 [41, 21]
+        another_value_property_length_cm s64 [65, 42]
       >
 
   ## Grouped examples
@@ -4570,11 +4570,11 @@ defmodule Explorer.DataFrame do
         Polars[3 x 6]
         Groups: ["team"]
         team string ["A", "B", "C"]
-        Monday integer [10, nil, 15]
-        Tuesday integer [14, 9, nil]
-        Wednesday integer [nil, 16, 10]
-        Thursday integer [10, nil, 14]
-        Friday integer [16, 11, nil]
+        Monday s64 [10, nil, 15]
+        Tuesday s64 [14, 9, nil]
+        Wednesday s64 [nil, 16, 10]
+        Thursday s64 [10, nil, 14]
+        Friday s64 [16, 11, nil]
       >
 
   In the following example the group "weekday" is going to be removed, because the column is going
@@ -4590,11 +4590,11 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 6]
         team string ["A", "B", "C"]
-        Monday integer [10, nil, 15]
-        Tuesday integer [14, 9, nil]
-        Wednesday integer [nil, 16, 10]
-        Thursday integer [10, nil, 14]
-        Friday integer [16, 11, nil]
+        Monday s64 [10, nil, 15]
+        Tuesday s64 [14, 9, nil]
+        Wednesday s64 [nil, 16, 10]
+        Thursday s64 [10, nil, 14]
+        Friday s64 [16, 11, nil]
       >
 
   """
@@ -4669,7 +4669,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.join(left, right)
       #Explorer.DataFrame<
         Polars[3 x 3]
-        a integer [1, 2, 2]
+        a s64 [1, 2, 2]
         b string ["a", "b", "b"]
         c string ["d", "e", "f"]
       >
@@ -4681,7 +4681,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.join(left, right, how: :left)
       #Explorer.DataFrame<
         Polars[4 x 3]
-        a integer [1, 2, 2, 3]
+        a s64 [1, 2, 2, 3]
         b string ["a", "b", "b", "c"]
         c string ["d", "e", "f", nil]
       >
@@ -4693,7 +4693,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.join(left, right, how: :right)
       #Explorer.DataFrame<
         Polars[3 x 3]
-        a integer [1, 2, 4]
+        a s64 [1, 2, 4]
         c string ["d", "e", "f"]
         b string ["a", "b", nil]
       >
@@ -4705,7 +4705,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.join(left, right, how: :outer)
       #Explorer.DataFrame<
         Polars[4 x 3]
-        a integer [1, 2, 4, 3]
+        a s64 [1, 2, 4, 3]
         b string ["a", "b", nil, "c"]
         c string ["d", "e", "f", nil]
       >
@@ -4717,9 +4717,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.join(left, right, how: :cross)
       #Explorer.DataFrame<
         Polars[9 x 4]
-        a integer [1, 1, 1, 2, 2, ...]
+        a s64 [1, 1, 1, 2, 2, ...]
         b string ["a", "a", "a", "b", "b", ...]
-        a_right integer [1, 2, 4, 1, 2, ...]
+        a_right s64 [1, 2, 4, 1, 2, ...]
         c string ["d", "e", "f", "d", "e", ...]
       >
 
@@ -4730,7 +4730,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.join(left, right, on: [{"a", "d"}])
       #Explorer.DataFrame<
         Polars[3 x 3]
-        a integer [1, 2, 2]
+        a s64 [1, 2, 2]
         b string ["a", "b", "b"]
         c string ["d", "e", "f"]
       >
@@ -4750,7 +4750,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 3]
         Groups: ["b"]
-        a integer [1, 2, 2]
+        a s64 [1, 2, 2]
         b string ["a", "b", "b"]
         c string ["d", "e", "f"]
       >
@@ -4765,7 +4765,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[4 x 3]
         Groups: ["b"]
-        a integer [1, 2, 2, 3]
+        a s64 [1, 2, 2, 3]
         b string ["a", "b", "b", "c"]
         c string ["d", "e", "f", nil]
       >
@@ -4780,7 +4780,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 3]
         Groups: ["c"]
-        a integer [1, 2, 4]
+        a s64 [1, 2, 4]
         c string ["d", "e", "f"]
         b string ["a", "b", nil]
       >
@@ -4795,7 +4795,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[4 x 3]
         Groups: ["b"]
-        a integer [1, 2, 4, 3]
+        a s64 [1, 2, 4, 3]
         b string ["a", "b", nil, "c"]
         c string ["d", "e", "f", nil]
       >
@@ -4810,9 +4810,9 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[9 x 4]
         Groups: ["b"]
-        a integer [1, 1, 1, 2, 2, ...]
+        a s64 [1, 1, 1, 2, 2, ...]
         b string ["a", "a", "a", "b", "b", ...]
-        a_right integer [1, 2, 4, 1, 2, ...]
+        a_right s64 [1, 2, 4, 1, 2, ...]
         c string ["d", "e", "f", "d", "e", ...]
       >
 
@@ -4930,9 +4930,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.concat_columns([df1, df2])
       #Explorer.DataFrame<
         Polars[3 x 4]
-        x integer [1, 2, 3]
+        x s64 [1, 2, 3]
         y string ["a", "b", "c"]
-        z integer [4, 5, 6]
+        z s64 [4, 5, 6]
         a string ["d", "e", "f"]
       >
 
@@ -4943,9 +4943,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.concat_columns([df1, df2])
       #Explorer.DataFrame<
         Polars[3 x 4]
-        x integer [1, 2, 3]
+        x s64 [1, 2, 3]
         y string ["a", "b", "c"]
-        x_1 integer [4, 5, 6]
+        x_1 s64 [4, 5, 6]
         a string ["d", "e", "f"]
       >
 
@@ -5004,7 +5004,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.concat_rows([df1, df2])
       #Explorer.DataFrame<
         Polars[6 x 2]
-        x integer [1, 2, 3, 4, 5, ...]
+        x s64 [1, 2, 3, 4, 5, ...]
         y string ["a", "b", "c", "d", "e", ...]
       >
 
@@ -5117,16 +5117,16 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1094 x 10]
         Groups: ["country"]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Or you can group by multiple columns in a given list:
@@ -5136,16 +5136,16 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1094 x 10]
         Groups: ["country", "year"]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Or by a range:
@@ -5155,16 +5155,16 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1094 x 10]
         Groups: ["year", "country"]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Regexes and functions are also accepted in column names, as in `select/2`.
@@ -5195,16 +5195,16 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.ungroup(df)
       #Explorer.DataFrame<
         Polars[1094 x 10]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Ungrouping a single column:
@@ -5215,16 +5215,16 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1094 x 10]
         Groups: ["year"]
-        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        year s64 [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-        total integer [2308, 1254, 32500, 141, 7924, ...]
-        solid_fuel integer [627, 117, 332, 0, 0, ...]
-        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-        gas_fuel integer [74, 7, 14565, 0, 374, ...]
-        cement integer [5, 177, 2598, 0, 204, ...]
-        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        total s64 [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel s64 [627, 117, 332, 0, 0, ...]
+        liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+        cement s64 [5, 177, 2598, 0, 204, ...]
+        gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
         per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+        bunker_fuels s64 [9, 7, 663, 0, 321, ...]
       >
 
   Lists, ranges, regexes, and functions are also accepted in column names, as in `select/2`.
@@ -5284,9 +5284,9 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.summarise(grouped_df, total_max: max(total), total_min: min(total))
       #Explorer.DataFrame<
         Polars[5 x 3]
-        year integer [2010, 2011, 2012, 2013, 2014]
-        total_max integer [2393248, 2654360, 2734817, 2797384, 2806634]
-        total_min integer [1, 2, 2, 2, 3]
+        year s64 [2010, 2011, 2012, 2013, 2014]
+        total_max s64 [2393248, 2654360, 2734817, 2797384, 2806634]
+        total_min s64 [1, 2, 2, 2, 3]
       >
 
   Suppose you want to get the mean petal length of each Iris species. You could do something
@@ -5337,9 +5337,9 @@ defmodule Explorer.DataFrame do
       iex> DataFrame.summarise_with(df, &[total_max: Series.max(&1["total"]), countries: Series.n_distinct(&1["country"])])
       #Explorer.DataFrame<
         Polars[5 x 3]
-        year integer [2010, 2011, 2012, 2013, 2014]
-        total_max integer [2393248, 2654360, 2734817, 2797384, 2806634]
-        countries integer [217, 217, 220, 220, 220]
+        year s64 [2010, 2011, 2012, 2013, 2014]
+        total_max s64 [2393248, 2654360, 2734817, 2797384, 2806634]
+        countries s64 [217, 217, 220, 220, 220]
       >
 
       iex> alias Explorer.{DataFrame, Series}
@@ -5347,8 +5347,8 @@ defmodule Explorer.DataFrame do
       iex> DataFrame.summarise_with(df, &[total_max: Series.max(&1["total"]), countries: Series.n_distinct(&1["country"])])
       #Explorer.DataFrame<
         Polars[1 x 2]
-        total_max integer [2806634]
-        countries integer [222]
+        total_max s64 [2806634]
+        countries s64 [222]
       >
 
   """
@@ -5412,15 +5412,15 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.explode(df, :a)
       #Explorer.DataFrame<
         Polars[4 x 3]
-        a integer [1, 2, 3, 4]
-        b list[integer] [[5, 6], [5, 6], [7, 8], [7, ...]]
+        a s64 [1, 2, 3, 4]
+        b list[s64] [[5, 6], [5, 6], [7, 8], [7, ...]]
         c string ["a", "a", "b", "b"]
       >
       iex> Explorer.DataFrame.explode(df, [:a, :b])
       #Explorer.DataFrame<
         Polars[4 x 3]
-        a integer [1, 2, 3, 4]
-        b integer [5, 6, 7, 8]
+        a s64 [1, 2, 3, 4]
+        b s64 [5, 6, 7, 8]
         c string ["a", "a", "b", "b"]
       >
 
@@ -5432,15 +5432,15 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 3]
         c string ["a", "b"]
-        a list[integer] [[1, 2], [3, 4]]
-        b list[integer] [[5, 6], [7, 8]]
+        a list[s64] [[1, 2], [3, 4]]
+        b list[s64] [[5, 6], [7, 8]]
       >
       iex> Explorer.DataFrame.explode(df, [:a, :b]) # we are back where we started
       #Explorer.DataFrame<
         Polars[4 x 3]
         c string ["a", "a", "b", "b"]
-        a integer [1, 2, 3, 4]
-        b integer [5, 6, 7, 8]
+        a s64 [1, 2, 3, 4]
+        b s64 [5, 6, 7, 8]
       >
 
   If you want to perform the cartesian product of two list columns, you must
@@ -5450,8 +5450,8 @@ defmodule Explorer.DataFrame do
       iex> df |> Explorer.DataFrame.explode(:a) |> Explorer.DataFrame.explode(:b)
       #Explorer.DataFrame<
         Polars[8 x 3]
-        a integer [1, 1, 2, 2, 3, ...]
-        b integer [5, 6, 5, 6, 7, ...]
+        a s64 [1, 1, 2, 2, 3, ...]
+        b s64 [5, 6, 5, 6, 7, ...]
         c string ["a", "a", "a", "a", "b", ...]
       >
   """
@@ -5489,19 +5489,19 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.unnest(df, :struct)
       #Explorer.DataFrame<
         Polars[2 x 4]
-        before integer [1, 2]
-        x integer [1, 3]
-        y integer [2, 4]
-        after integer [3, 4]
+        before s64 [1, 2]
+        x s64 [1, 3]
+        y s64 [2, 4]
+        after s64 [3, 4]
       >
 
       iex> df = Explorer.DataFrame.new(struct1: [%{x: 1, y: 2}, %{x: 3, y: 4}], struct2: [%{z: 5}, %{z: 6}])
       iex> Explorer.DataFrame.unnest(df, [:struct1, :struct2])
       #Explorer.DataFrame<
         Polars[2 x 3]
-        x integer [1, 3]
-        y integer [2, 4]
-        z integer [5, 6]
+        x s64 [1, 3]
+        y s64 [2, 4]
+        z s64 [5, 6]
       >
   """
   @doc type: :single
@@ -5663,8 +5663,8 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[2 x 3]
         a string ["a", "b"]
-        b integer [1, nil]
-        counts integer [2, 1]
+        b s64 [1, nil]
+        counts s64 [2, 1]
       >
   """
   @doc type: :single

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3019,13 +3019,7 @@ defmodule Explorer.DataFrame do
   defp put(%DataFrame{} = df, column_name, fun, arg, opts) when is_column_name(column_name) do
     opts = Keyword.validate!(opts, [:dtype])
     name = to_column_name(column_name)
-
-    dtype =
-      if opts[:dtype] in [nil, :infer] do
-        opts[:dtype]
-      else
-        Shared.normalise_dtype!(opts[:dtype])
-      end
+    dtype = opts[:dtype]
 
     if dtype == nil and is_map_key(df.dtypes, name) do
       put(df, name, Series.replace(pull(df, name), arg), [])
@@ -3036,7 +3030,7 @@ defmodule Explorer.DataFrame do
         if dtype == nil or dtype == :infer do
           [backend: backend]
         else
-          [dtype: dtype, backend: backend]
+          [dtype: Shared.normalise_dtype!(dtype), backend: backend]
         end
 
       put(df, name, apply(Series, fun, [arg, opts]), [])

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -726,7 +726,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def slice(%DataFrame{} = df, %Series{dtype: :integer} = row_indices) do
+  def slice(%DataFrame{} = df, %Series{dtype: {:s, 64}} = row_indices) do
     Shared.apply_dataframe(df, df, :df_slice_by_series, [row_indices.data, df.groups])
   end
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -14,6 +14,17 @@ defmodule Explorer.PolarsBackend.Series do
   defguardp is_non_finite(n) when n in [:nan, :infinity, :neg_infinity]
   defguardp is_numeric(n) when is_number(n) or is_non_finite(n)
 
+  @integer_types [
+    {:s, 8},
+    {:s, 16},
+    {:s, 32},
+    {:s, 64},
+    {:u, 8},
+    {:u, 16},
+    {:u, 32},
+    {:u, 64}
+  ]
+
   # Conversion
 
   @impl true
@@ -66,8 +77,8 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(series, :s_categories)
 
   @impl true
-  def categorise(%Series{dtype: :integer} = series, %Series{dtype: dtype} = categories)
-      when dtype in [:string, :category],
+  def categorise(%Series{dtype: {integer_type, _}} = series, %Series{dtype: dtype} = categories)
+      when dtype in [:string, :category] and integer_type in [:s, :u],
       do: Shared.apply_series(series, :s_categorise, [categories.data])
 
   @impl true
@@ -324,8 +335,8 @@ defmodule Explorer.PolarsBackend.Series do
   def abs(%Series{} = s), do: Shared.apply_series(s, :s_abs, [])
 
   @impl true
-  def clip(%Series{dtype: :integer} = s, min, max)
-      when is_integer(min) and is_integer(max),
+  def clip(%Series{dtype: dtype} = s, min, max)
+      when dtype in @integer_types and is_integer(min) and is_integer(max),
       do: Shared.apply_series(s, :s_clip_integer, [min, max])
 
   def clip(%Series{} = s, min, max),

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -132,7 +132,6 @@ defmodule Explorer.PolarsBackend.Shared do
 
   def from_list(list, dtype, name) when is_list(list) do
     case dtype do
-      :integer -> Native.s_from_list_i64(name, list)
       # Signed integers
       {:s, 8} -> Native.s_from_list_i8(name, list)
       {:s, 16} -> Native.s_from_list_i16(name, list)
@@ -157,6 +156,7 @@ defmodule Explorer.PolarsBackend.Shared do
     end
   end
 
+  # TODO: add more integer dtypes support
   def from_binary(binary, dtype, name \\ "") when is_binary(binary) do
     case dtype do
       :boolean ->
@@ -186,7 +186,7 @@ defmodule Explorer.PolarsBackend.Shared do
       {:duration, :nanosecond} ->
         Native.s_from_binary_i64(name, binary) |> Native.s_cast(dtype) |> ok()
 
-      :integer ->
+      {:s, 64} ->
         Native.s_from_binary_i64(name, binary)
 
       {:f, 32} ->

--- a/lib/explorer/query.ex
+++ b/lib/explorer/query.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Query do
       #Explorer.DataFrame<
         Polars[1 x 2]
         strs string ["c"]
-        nums integer [3]
+        nums s64 [3]
       >
 
   If a column has unusual format, you can either rename it before-hand,
@@ -32,7 +32,7 @@ defmodule Explorer.Query do
       iex> DF.filter(df, col("unusual nums") > 2)
       #Explorer.DataFrame<
         Polars[1 x 1]
-        unusual nums integer [3]
+        unusual nums s64 [3]
       >
 
   All operations from `Explorer.Series` are imported inside queries.
@@ -59,7 +59,7 @@ defmodule Explorer.Query do
       #Explorer.DataFrame<
         Polars[1 x 2]
         strs string ["c"]
-        nums integer [3]
+        nums s64 [3]
       >
 
       iex> min = 2
@@ -68,7 +68,7 @@ defmodule Explorer.Query do
       #Explorer.DataFrame<
         Polars[3 x 2]
         strs string ["a", "b", "c"]
-        nums integer [1, 2, 3]
+        nums s64 [1, 2, 3]
       >
 
   `^` can be used with `col` to access columns dynamically:
@@ -78,7 +78,7 @@ defmodule Explorer.Query do
       iex> DF.filter(df, col(^name) > 2)
       #Explorer.DataFrame<
         Polars[1 x 1]
-        unusual nums integer [3]
+        unusual nums s64 [3]
       >
 
   ## Conditionals
@@ -98,7 +98,7 @@ defmodule Explorer.Query do
       ...> )
       #Explorer.DataFrame<
         Polars[3 x 2]
-        a integer [10, 4, 6]
+        a s64 [10, 4, 6]
         b string ["Exceptional", "Failed", "Passed"]
       >
 
@@ -691,7 +691,7 @@ defmodule Explorer.Query do
       iex> Explorer.DataFrame.filter(df, col("unusual nums") > 2)
       #Explorer.DataFrame<
         Polars[1 x 1]
-        unusual nums integer [3]
+        unusual nums s64 [3]
       >
 
   `name` must be an atom, a string, or an integer.
@@ -705,7 +705,7 @@ defmodule Explorer.Query do
       iex> Explorer.DataFrame.filter(df, col(^name) > 2)
       #Explorer.DataFrame<
         Polars[1 x 1]
-        nums integer [3]
+        nums s64 [3]
       >
 
   For traversing multiple columns programatically,

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -246,7 +246,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.from_list([1, 2, 3])
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
 
   Series are nullable, so you may also include nils:
@@ -298,7 +298,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.from_list([nil, nil], dtype: :integer)
       #Explorer.Series<
         Polars[2]
-        integer [nil, nil]
+        s64 [nil, nil]
       >
 
       iex> Explorer.Series.from_list([1, nil], dtype: :string)
@@ -363,7 +363,7 @@ defmodule Explorer.Series do
   Mixing non-numeric data types will raise an ArgumentError:
 
       iex> Explorer.Series.from_list([1, "a"])
-      ** (ArgumentError) the value "a" does not match the inferred series dtype :integer
+      ** (ArgumentError) the value "a" does not match the inferred series dtype {:s, 64}
   """
   @doc type: :conversion
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()
@@ -415,7 +415,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.from_binary(<<-1::signed-64-native, 1::signed-64-native>>, :integer)
       #Explorer.Series<
         Polars[2]
-        integer [-1, 1]
+        s64 [-1, 1]
       >
 
   Booleans are unsigned integers:
@@ -504,7 +504,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.from_tensor(tensor)
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
 
       iex> tensor = Nx.tensor([1.0, 2.0, 3.0], type: :f64)
@@ -560,7 +560,7 @@ defmodule Explorer.Series do
 
     if Shared.dtype_to_iotype!(dtype) != type do
       raise ArgumentError,
-            "dtype #{dtype} expects a tensor of type #{inspect(Shared.dtype_to_iotype!(dtype))} " <>
+            "dtype #{inspect(dtype)} expects a tensor of type #{inspect(Shared.dtype_to_iotype!(dtype))} " <>
               "but got type #{inspect(type)}"
     end
 
@@ -581,7 +581,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.replace(s, Nx.tensor([1, 2, 3]))
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
 
   This is particularly useful for categorical columns:
@@ -601,7 +601,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.replace(s, [1, 2, 3, 4, 5])
       #Explorer.Series<
         Polars[5]
-        integer [1, 2, 3, 4, 5]
+        s64 [1, 2, 3, 4, 5]
       >
 
   The same considerations as above apply.
@@ -895,7 +895,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.cast(s, :integer)
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
   """
   @doc type: :element_wise
@@ -982,7 +982,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.clip(s, 1, 10)
       #Explorer.Series<
         Polars[4]
-        integer [1, 5, nil, 10]
+        s64 [1, 5, nil, 10]
       >
 
       iex> s = Explorer.Series.from_list([-50, 5, nil, 50])
@@ -1744,21 +1744,21 @@ defmodule Explorer.Series do
       iex> Explorer.Series.sort_with(s, &Explorer.Series.remainder(&1, 3))
       #Explorer.Series<
         Polars[3]
-        integer [3, 1, 2]
+        s64 [3, 1, 2]
       >
 
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.sort_with(s, &Explorer.Series.remainder(&1, 3), direction: :desc)
       #Explorer.Series<
         Polars[3]
-        integer [2, 1, 3]
+        s64 [2, 1, 3]
       >
 
       iex> s = Explorer.Series.from_list([1, nil, 2, 3])
       iex> Explorer.Series.sort_with(s, &Explorer.Series.multiply(-2, &1), nils: :first)
       #Explorer.Series<
         Polars[4]
-        integer [nil, 3, 2, 1]
+        s64 [nil, 3, 2, 1]
       >
   """
   @doc type: :shape
@@ -2132,7 +2132,7 @@ defmodule Explorer.Series do
       iex> s1 = Explorer.Series.from_list(["foo", nil, "bar", nil])
       iex> s2 = Explorer.Series.from_list([1, 2, nil, 4])
       iex> Explorer.Series.coalesce(s1, s2)
-      ** (ArgumentError) cannot invoke Explorer.Series.coalesce/2 with mismatched dtypes: :string and :integer
+      ** (ArgumentError) cannot invoke Explorer.Series.coalesce/2 with mismatched dtypes: :string and {:s, 64}
   """
   @doc type: :element_wise
   @spec coalesce(s1 :: Series.t(), s2 :: Series.t()) :: Series.t()
@@ -2169,7 +2169,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~D[2021-01-01], ~D[1999-12-31]])
       iex> Explorer.Series.sum(s)
-      ** (ArgumentError) Explorer.Series.sum/1 not implemented for dtype :date. Valid dtypes are [:boolean, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.sum/1 not implemented for dtype :date. Valid dtypes are :boolean, {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec sum(series :: Series.t()) :: number() | non_finite() | nil
@@ -2216,7 +2216,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.min(s)
-      ** (ArgumentError) Explorer.Series.min/1 not implemented for dtype :string. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}, :time, :date, {:datetime, :nanosecond}, {:datetime, :microsecond}, {:datetime, :millisecond}, {:duration, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}]
+      ** (ArgumentError) Explorer.Series.min/1 not implemented for dtype :string. Valid dtypes are :date, :time, {:datetime, :microsecond}, {:datetime, :millisecond}, {:datetime, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}, {:duration, :nanosecond}, {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec min(series :: Series.t()) ::
@@ -2263,7 +2263,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.max(s)
-      ** (ArgumentError) Explorer.Series.max/1 not implemented for dtype :string. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}, :time, :date, {:datetime, :nanosecond}, {:datetime, :microsecond}, {:datetime, :millisecond}, {:duration, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}]
+      ** (ArgumentError) Explorer.Series.max/1 not implemented for dtype :string. Valid dtypes are :date, :time, {:datetime, :microsecond}, {:datetime, :millisecond}, {:datetime, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}, {:duration, :nanosecond}, {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec max(series :: Series.t()) ::
@@ -2314,7 +2314,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.argmax(s)
-      ** (ArgumentError) Explorer.Series.argmax/1 not implemented for dtype :string. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}, :time, :date, {:datetime, :nanosecond}, {:datetime, :microsecond}, {:datetime, :millisecond}, {:duration, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}]
+      ** (ArgumentError) Explorer.Series.argmax/1 not implemented for dtype :string. Valid dtypes are :date, :time, {:datetime, :microsecond}, {:datetime, :millisecond}, {:datetime, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}, {:duration, :nanosecond}, {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec argmax(series :: Series.t()) :: number() | non_finite() | nil
@@ -2373,7 +2373,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.argmin(s)
-      ** (ArgumentError) Explorer.Series.argmin/1 not implemented for dtype :string. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}, :time, :date, {:datetime, :nanosecond}, {:datetime, :microsecond}, {:datetime, :millisecond}, {:duration, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}]
+      ** (ArgumentError) Explorer.Series.argmin/1 not implemented for dtype :string. Valid dtypes are :date, :time, {:datetime, :microsecond}, {:datetime, :millisecond}, {:datetime, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}, {:duration, :nanosecond}, {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec argmin(series :: Series.t()) :: number() | non_finite() | nil
@@ -2404,7 +2404,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~D[2021-01-01], ~D[1999-12-31]])
       iex> Explorer.Series.mean(s)
-      ** (ArgumentError) Explorer.Series.mean/1 not implemented for dtype :date. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.mean/1 not implemented for dtype :date. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec mean(series :: Series.t()) :: float() | non_finite() | nil
@@ -2475,7 +2475,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~D[2021-01-01], ~D[1999-12-31]])
       iex> Explorer.Series.median(s)
-      ** (ArgumentError) Explorer.Series.median/1 not implemented for dtype :date. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.median/1 not implemented for dtype :date. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec median(series :: Series.t()) :: float() | non_finite() | nil
@@ -2510,7 +2510,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.variance(s)
-      ** (ArgumentError) Explorer.Series.variance/1 not implemented for dtype {:datetime, :microsecond}. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.variance/1 not implemented for dtype {:datetime, :microsecond}. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec variance(series :: Series.t(), ddof :: non_neg_integer()) :: float() | non_finite() | nil
@@ -2546,7 +2546,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.standard_deviation(s)
-      ** (ArgumentError) Explorer.Series.standard_deviation/1 not implemented for dtype :string. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.standard_deviation/1 not implemented for dtype :string. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec standard_deviation(series :: Series.t(), ddof :: non_neg_integer()) ::
@@ -2583,7 +2583,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([true, false, true])
       iex> Explorer.Series.product(s)
-      ** (ArgumentError) Explorer.Series.product/1 not implemented for dtype :boolean. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.product/1 not implemented for dtype :boolean. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec product(series :: Series.t()) :: float() | non_finite() | nil
@@ -2630,7 +2630,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([true, false, true])
       iex> Explorer.Series.quantile(s, 0.5)
-      ** (ArgumentError) Explorer.Series.quantile/2 not implemented for dtype :boolean. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}, :time, :date, {:datetime, :nanosecond}, {:datetime, :microsecond}, {:datetime, :millisecond}, {:duration, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}]
+      ** (ArgumentError) Explorer.Series.quantile/2 not implemented for dtype :boolean. Valid dtypes are :date, :time, {:datetime, :microsecond}, {:datetime, :millisecond}, {:datetime, :nanosecond}, {:duration, :microsecond}, {:duration, :millisecond}, {:duration, :nanosecond}, {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec quantile(series :: Series.t(), quantile :: float()) :: any()
@@ -2676,7 +2676,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([true, false, true])
       iex> Explorer.Series.skew(s, false)
-      ** (ArgumentError) Explorer.Series.skew/2 not implemented for dtype :boolean. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.skew/2 not implemented for dtype :boolean. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :aggregation
   @spec skew(series :: Series.t(), opts :: Keyword.t()) :: float() | non_finite() | nil
@@ -2775,7 +2775,7 @@ defmodule Explorer.Series do
 
       iex> s = Series.from_list([1, 2, 3])
       iex> Series.all?(s)
-      ** (ArgumentError) Explorer.Series.all?/1 not implemented for dtype :integer. Valid dtypes are [:boolean]
+      ** (ArgumentError) Explorer.Series.all?/1 not implemented for dtype {:s, 64}. Valid dtype is :boolean
 
   An empty series will always return true:
 
@@ -2817,7 +2817,7 @@ defmodule Explorer.Series do
 
       iex> s = Series.from_list([1, 2, 3])
       iex> Series.any?(s)
-      ** (ArgumentError) Explorer.Series.any?/1 not implemented for dtype :integer. Valid dtypes are [:boolean]
+      ** (ArgumentError) Explorer.Series.any?/1 not implemented for dtype {:s, 64}. Valid dtype is :boolean
 
   An empty series will always return `false`:
 
@@ -5175,7 +5175,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.abs(s)
-      ** (ArgumentError) Explorer.Series.abs/1 not implemented for dtype :string. Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, {:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]
+      ** (ArgumentError) Explorer.Series.abs/1 not implemented for dtype :string. Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}
   """
   @doc type: :element_wise
   @spec abs(series :: Series.t()) :: Series.t()
@@ -5888,7 +5888,7 @@ defmodule Explorer.Series do
       iex> Series.lengths(s)
       #Explorer.Series<
         Polars[2]
-        integer [1, 2]
+        s64 [1, 2]
       >
 
   """
@@ -5950,7 +5950,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.transform(s, &String.length/1)
       #Explorer.Series<
         Polars[3]
-        integer [4, 2, 5]
+        s64 [4, 2, 5]
       >
   """
   @doc type: :element_wise

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -971,9 +971,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   Clipping other dtypes are possible using `select/3`.
 
@@ -2149,9 +2148,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:boolean`
 
   ## Examples
@@ -2185,9 +2183,9 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2232,9 +2230,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2279,9 +2276,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2334,9 +2330,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2389,9 +2384,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2460,9 +2454,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2495,9 +2488,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2531,9 +2523,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2568,9 +2559,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2599,9 +2589,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2653,9 +2642,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2703,9 +2691,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2735,9 +2722,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -2852,9 +2838,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2905,9 +2890,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -2958,9 +2942,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:boolean`
 
   ## Examples
@@ -3001,9 +2984,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3041,9 +3023,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -3117,9 +3098,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3185,9 +3165,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3254,9 +3233,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3312,9 +3290,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3384,9 +3361,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3437,9 +3413,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3462,9 +3437,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -3503,7 +3477,7 @@ defmodule Explorer.Series do
 
   ## Supported dtype
 
-    * `:integer`
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   Returns `nil` if there is a zero in the right-hand side.
 
@@ -3553,7 +3527,7 @@ defmodule Explorer.Series do
 
   ## Supported dtype
 
-    * `:integer`
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   Returns `nil` if there is a zero in the right-hand side.
 
@@ -3938,9 +3912,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -3978,9 +3951,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -4018,9 +3990,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -4058,9 +4029,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
     * `:date`
     * `:time`
     * `:datetime`
@@ -5147,9 +5117,8 @@ defmodule Explorer.Series do
 
   ## Supported dtypes
 
-    * `:integer`
-    * `{:f, 32}`
-    * `{:f, 64}`
+    * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
+    * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
 
   ## Examples
 
@@ -6003,7 +5972,7 @@ defmodule Explorer.Series do
     raise(
       ArgumentError,
       "Explorer.Series.#{function} not implemented for dtype #{inspect(dtype)}. " <>
-        "Valid " <> Explorer.Shared.inspect_dtypes(valid_dtypes, with_prefix: true)
+        "Valid " <> Shared.inspect_dtypes(valid_dtypes, with_prefix: true)
     )
   end
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -13,19 +13,29 @@ defmodule Explorer.Series do
     * `{:f, size}` - a 64-bit or 32-bit floating point number
     * `{:s, size}` - a 8-bit or 16-bit or 32-bit or 64-bit signed integer number.
     * `{:u, size}` - a 8-bit or 16-bit or 32-bit or 64-bit unsigned integer number.
-    * `:integer` - 64-bit signed integer
     * `:string` - UTF-8 encoded binary
     * `:time` - Time type that unwraps to `Elixir.Time`
-    * `{:list, dtype}` - A recursive dtype that can store lists. Examples: `{:list, :integer}` or
-      a nested list dtype like `{:list, {:list, :integer}}`.
+    * `{:list, dtype}` - A recursive dtype that can store lists. Examples: `{:list, :boolean}` or
+      a nested list dtype like `{:list, {:list, :boolean}}`.
     * `{:struct, %{key => dtype}}` - A recursive dtype that can store Arrow/Polars structs (not to be
       confused with Elixir's struct). This type unwraps to Elixir maps with string keys. Examples:
-      `{:struct, %{"a" => :integer}}` or a nested struct dtype like `{:struct, %{"a" => {:struct, %{"b" => :integer}}}}`.
+      `{:struct, %{"a" => :string}}` or a nested struct dtype like `{:struct, %{"a" => {:struct, %{"b" => :string}}}}`.
 
   The following data type aliases are also supported:
 
     * The atom `:float` as an alias for `{:f, 64}` to mirror Elixir's floats
     * The atoms `:f32` and `:f64` as aliases to `{:f, 32}` and `{:f, 64}` for Nx compabitility
+    * The atom `:integer` as an alias for `{:s, 64}` to mirror Elixir's integers
+    * There are serveral atoms to represent integer dtypes, and they also follow Nx naming for compatibility.
+      They are the following:
+      * `i8` as alias to `{:s, 8}`
+      * `i16` as alias to `{:s, 16}`
+      * `i32` as alias to `{:s, 32}`
+      * `i64` as alias to `{:s, 64}`
+      * `u8` as alias to `{:u, 8}`
+      * `u16` as alias to `{:u, 16}`
+      * `u32` as alias to `{:u, 32}`
+      * `u64` as alias to `{:u, 64}`
 
   A series must consist of a single data type only. Series may have `nil` values in them.
   The series `dtype` can be retrieved via the `dtype/1` function or directly accessed as
@@ -46,7 +56,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.from_list([1, 2, 3])
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
 
   Series are nullable, so you may also include nils:
@@ -74,7 +84,7 @@ defmodule Explorer.Series do
       iex> Explorer.DataFrame.filter(df, col_name > 2)
       #Explorer.DataFrame<
         Polars[1 x 1]
-        col_name integer [3]
+        col_name s64 [3]
       >
 
   Series have no named columns.
@@ -86,7 +96,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.filter(s, _ > 2)
       #Explorer.Series<
         Polars[1]
-        integer [3]
+        s64 [3]
       >
 
   """
@@ -128,7 +138,6 @@ defmodule Explorer.Series do
           | {:u, 16}
           | {:u, 32}
           | {:u, 64}
-          | :integer
           | :string
           | list_dtype
           | struct_dtype
@@ -461,8 +470,11 @@ defmodule Explorer.Series do
         ) ::
           Series.t()
   def from_binary(binary, dtype, opts \\ []) when K.and(is_binary(binary), is_list(opts)) do
+    # TODO: fix the typespecs to consider multiple integer dtypes.
     opts = Keyword.validate!(opts, [:backend])
-    {_type, alignment} = dtype |> Shared.normalise_dtype!() |> Shared.dtype_to_iotype!()
+    dtype = Shared.normalise_dtype!(dtype)
+
+    {_type, alignment} = dtype |> Shared.dtype_to_iotype!()
 
     if rem(bit_size(binary), alignment) != 0 do
       raise ArgumentError, "binary for dtype #{dtype} is expected to be #{alignment}-bit aligned"
@@ -614,7 +626,7 @@ defmodule Explorer.Series do
     case series.dtype do
       :category ->
         Series
-        |> apply(fun, [arg, [dtype: :integer, backend: backend]])
+        |> apply(fun, [arg, [dtype: {:s, 64}, backend: backend]])
         |> categorise(series)
 
       dtype ->
@@ -888,11 +900,13 @@ defmodule Explorer.Series do
   """
   @doc type: :element_wise
   @spec cast(series :: Series.t(), dtype :: dtype()) :: Series.t()
-  def cast(%Series{dtype: dtype} = series, dtype), do: series
-
-  def cast(series, dtype) do
+  def cast(%Series{dtype: original_dtype} = series, dtype) do
     if normalised = Shared.normalise_dtype(dtype) do
-      apply_series(series, :cast, [normalised])
+      if normalised == original_dtype do
+        series
+      else
+        apply_series(series, :cast, [normalised])
+      end
     else
       dtype_error("cast/2", dtype, Shared.dtypes())
     end
@@ -1008,7 +1022,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.dtype(s)
-      :integer
+      {:s, 64}
 
       iex> s = Explorer.Series.from_list(["a", nil, "b", "c"])
       iex> Explorer.Series.dtype(s)
@@ -1195,11 +1209,11 @@ defmodule Explorer.Series do
   """
   @doc type: :element_wise
   def categorise(%Series{dtype: l_dtype} = series, %Series{dtype: dtype} = categories)
-      when K.and(K.in(l_dtype, [:integer, :string]), K.in(dtype, [:string, :category])),
+      when K.and(K.in(l_dtype, [{:s, 64}, :string]), K.in(dtype, [:string, :category])),
       do: apply_series(series, :categorise, [categories])
 
   def categorise(%Series{dtype: l_dtype} = series, [head | _] = categories)
-      when K.and(K.in(l_dtype, [:integer, :string]), is_binary(head)),
+      when K.and(K.in(l_dtype, [{:s, 64}, :string]), is_binary(head)),
       do: apply_series(series, :categorise, [from_list(categories, dtype: :string)])
 
   # Slice and dice
@@ -1213,7 +1227,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.head(s)
       #Explorer.Series<
         Polars[10]
-        integer [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        s64 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       >
   """
   @doc type: :shape
@@ -1229,7 +1243,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.tail(s)
       #Explorer.Series<
         Polars[10]
-        integer [91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
+        s64 [91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
       >
   """
   @doc type: :shape
@@ -1273,14 +1287,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.shift(s, 2)
       #Explorer.Series<
         Polars[5]
-        integer [nil, nil, 1, 2, 3]
+        s64 [nil, nil, 1, 2, 3]
       >
 
       iex> s = 1..5 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.shift(s, -2)
       #Explorer.Series<
         Polars[5]
-        integer [3, 4, 5, nil, nil]
+        s64 [3, 4, 5, nil, nil]
       >
   """
   @doc type: :shape
@@ -1352,42 +1366,42 @@ defmodule Explorer.Series do
       iex> Explorer.Series.sample(s, 10, seed: 100)
       #Explorer.Series<
         Polars[10]
-        integer [57, 9, 54, 62, 50, 77, 35, 88, 1, 69]
+        s64 [57, 9, 54, 62, 50, 77, 35, 88, 1, 69]
       >
 
       iex> s = 1..100 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.sample(s, 0.05, seed: 100)
       #Explorer.Series<
         Polars[5]
-        integer [9, 56, 79, 28, 54]
+        s64 [9, 56, 79, 28, 54]
       >
 
       iex> s = 1..5 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.sample(s, 7, seed: 100, replace: true)
       #Explorer.Series<
         Polars[7]
-        integer [4, 1, 3, 4, 3, 4, 2]
+        s64 [4, 1, 3, 4, 3, 4, 2]
       >
 
       iex> s = 1..5 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.sample(s, 1.2, seed: 100, replace: true)
       #Explorer.Series<
         Polars[6]
-        integer [4, 1, 3, 4, 3, 4]
+        s64 [4, 1, 3, 4, 3, 4]
       >
 
       iex> s = 0..9 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.sample(s, 1.0, seed: 100, shuffle: false)
       #Explorer.Series<
         Polars[10]
-        integer [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        s64 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       >
 
       iex> s = 0..9 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.sample(s, 1.0, seed: 100, shuffle: true)
       #Explorer.Series<
         Polars[10]
-        integer [7, 9, 2, 0, 4, 1, 3, 8, 5, 6]
+        s64 [7, 9, 2, 0, 4, 1, 3, 8, 5, 6]
       >
 
   """
@@ -1430,7 +1444,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.shuffle(s, seed: 100)
       #Explorer.Series<
         Polars[10]
-        integer [8, 10, 3, 1, 5, 2, 4, 9, 6, 7]
+        s64 [8, 10, 3, 1, 5, 2, 4, 9, 6, 7]
       >
 
   """
@@ -1453,7 +1467,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.at_every(s, 2)
       #Explorer.Series<
         Polars[5]
-        integer [1, 3, 5, 7, 9]
+        s64 [1, 3, 5, 7, 9]
       >
 
   If *n* is bigger than the size of the series, the result is a new series with only the first value of the supplied series.
@@ -1462,7 +1476,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.at_every(s, 20)
       #Explorer.Series<
         Polars[1]
-        integer [1]
+        s64 [1]
       >
   """
   @doc type: :shape
@@ -1505,14 +1519,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.filter(s, remainder(_, 2) == 1)
       #Explorer.Series<
         Polars[2]
-        integer [1, 3]
+        s64 [1, 3]
       >
 
   Returning a non-boolean expression errors:
 
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.filter(s, cumulative_max(_))
-      ** (ArgumentError) expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type :integer
+      ** (ArgumentError) expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type {:s, 64}
 
   Which can be addressed by converting it to boolean:
 
@@ -1520,7 +1534,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.filter(s, cumulative_max(_) == 1)
       #Explorer.Series<
         Polars[1]
-        integer [1]
+        s64 [1]
       >
   """
   @doc type: :element_wise
@@ -1546,7 +1560,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.filter_with(series, is_odd)
       #Explorer.Series<
         Polars[2]
-        integer [1, 3]
+        s64 [1, 3]
       >
   """
   @doc type: :element_wise
@@ -1585,7 +1599,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.map(s, _ * 2)
       #Explorer.Series<
         Polars[3]
-        integer [2, 4, 6]
+        s64 [2, 4, 6]
       >
 
   You can also use window functions and aggregations:
@@ -1594,7 +1608,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.map(s, _ - min(_))
       #Explorer.Series<
         Polars[3]
-        integer [0, 1, 2]
+        s64 [0, 1, 2]
       >
   """
   @doc type: :element_wise
@@ -1621,7 +1635,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.map_with(series, shift_left)
       #Explorer.Series<
         Polars[3]
-        integer [0, 1, 2]
+        s64 [0, 1, 2]
       >
   """
   @doc type: :element_wise
@@ -1669,21 +1683,21 @@ defmodule Explorer.Series do
       iex> Explorer.Series.sort_by(s, remainder(_, 3))
       #Explorer.Series<
         Polars[3]
-        integer [3, 1, 2]
+        s64 [3, 1, 2]
       >
 
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.sort_by(s, remainder(_, 3), direction: :desc)
       #Explorer.Series<
         Polars[3]
-        integer [2, 1, 3]
+        s64 [2, 1, 3]
       >
 
       iex> s = Explorer.Series.from_list([1, nil, 2, 3])
       iex> Explorer.Series.sort_by(s, -2 * _, nils: :first)
       #Explorer.Series<
         Polars[4]
-        integer [nil, 3, 2, 1]
+        s64 [nil, 3, 2, 1]
       >
   """
   @doc type: :shape
@@ -1766,7 +1780,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.mask(s1, s2)
       #Explorer.Series<
         Polars[2]
-        integer [1, 3]
+        s64 [1, 3]
       >
   """
   @doc type: :element_wise
@@ -1801,7 +1815,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.rank(s, method: :ordinal)
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
 
       iex> s = Explorer.Series.from_list([ ~N[2022-07-07 17:44:13.020548], ~N[2022-07-07 17:43:08.473561], ~N[2022-07-07 17:45:00.116337] ])
@@ -1815,14 +1829,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.rank(s, method: :min)
       #Explorer.Series<
         Polars[5]
-        integer [3, 4, 1, 1, 4]
+        s64 [3, 4, 1, 1, 4]
       >
 
       iex> s = Explorer.Series.from_list([3, 6, 1, 1, 6])
       iex> Explorer.Series.rank(s, method: :dense)
       #Explorer.Series<
         Polars[5]
-        integer [2, 3, 1, 1, 3]
+        s64 [2, 3, 1, 1, 3]
       >
 
 
@@ -1830,7 +1844,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.rank(s, method: :random, seed: 42)
       #Explorer.Series<
         Polars[5]
-        integer [3, 4, 2, 1, 5]
+        s64 [3, 4, 2, 1, 5]
       >
   """
   @doc type: :element_wise
@@ -1855,7 +1869,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.slice(s, 1, 2)
       #Explorer.Series<
         Polars[2]
-        integer [2, 3]
+        s64 [2, 3]
       >
 
   Negative offsets count from the end of the series:
@@ -1864,7 +1878,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.slice(s, -3, 2)
       #Explorer.Series<
         Polars[2]
-        integer [3, 4]
+        s64 [3, 4]
       >
 
   If the offset runs past the end of the series,
@@ -1874,7 +1888,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.slice(s, 10, 3)
       #Explorer.Series<
         Polars[0]
-        integer []
+        s64 []
       >
 
   If the size runs past the end of the series,
@@ -1884,7 +1898,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.slice(s, -3, 4)
       #Explorer.Series<
         Polars[3]
-        integer [3, 4, 5]
+        s64 [3, 4, 5]
       >
   """
   @doc type: :shape
@@ -1935,11 +1949,11 @@ defmodule Explorer.Series do
   def slice(series, indices) when is_list(indices),
     do: apply_series(series, :slice, [indices])
 
-  def slice(series, %Series{dtype: :integer} = indices),
+  def slice(series, %Series{dtype: {:s, 64}} = indices),
     do: apply_series(series, :slice, [indices])
 
   def slice(_series, %Series{dtype: invalid_dtype}),
-    do: dtype_error("slice/2", invalid_dtype, [:integer])
+    do: dtype_error("slice/2", invalid_dtype, [{:s, 64}])
 
   def slice(series, first..last//1) do
     first = if first < 0, do: first + size(series), else: first
@@ -2040,7 +2054,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.concat([s1, s2])
       #Explorer.Series<
         Polars[6]
-        integer [1, 2, 3, 4, 5, 6]
+        s64 [1, 2, 3, 4, 5, 6]
       >
 
       iex> s1 = Explorer.Series.from_list([1, 2, 3])
@@ -2092,7 +2106,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.coalesce([s1, s2, s3])
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 3, 4]
+        s64 [1, 2, 3, 4]
       >
   """
   @doc type: :element_wise
@@ -2112,7 +2126,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.coalesce(s1, s2)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 3, 4]
+        s64 [1, 2, 3, 4]
       >
 
       iex> s1 = Explorer.Series.from_list(["foo", nil, "bar", nil])
@@ -2415,7 +2429,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.mode(s)
       #Explorer.Series<
         Polars[1]
-        integer [2]
+        s64 [2]
       >
 
       iex> s = Explorer.Series.from_list(["a", "b", "b", "c"])
@@ -2851,14 +2865,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.cumulative_max(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 3, 4]
+        s64 [1, 2, 3, 4]
       >
 
       iex> s = [1, 2, nil, 4] |> Explorer.Series.from_list()
       iex> Explorer.Series.cumulative_max(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, nil, 4]
+        s64 [1, 2, nil, 4]
       >
 
       iex> s = [~T[03:00:02.000000], ~T[02:04:19.000000], nil, ~T[13:24:56.000000]] |> Explorer.Series.from_list()
@@ -2904,14 +2918,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.cumulative_min(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 1, 1, 1]
+        s64 [1, 1, 1, 1]
       >
 
       iex> s = [1, 2, nil, 4] |> Explorer.Series.from_list()
       iex> Explorer.Series.cumulative_min(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 1, nil, 1]
+        s64 [1, 1, nil, 1]
       >
 
       iex> s = [~T[03:00:02.000000], ~T[02:04:19.000000], nil, ~T[13:24:56.000000]] |> Explorer.Series.from_list()
@@ -2954,14 +2968,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.cumulative_sum(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 3, 6, 10]
+        s64 [1, 3, 6, 10]
       >
 
       iex> s = [1, 2, nil, 4] |> Explorer.Series.from_list()
       iex> Explorer.Series.cumulative_sum(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 3, nil, 7]
+        s64 [1, 3, nil, 7]
       >
   """
   @doc type: :window
@@ -2996,14 +3010,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.cumulative_product(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 6, 12]
+        s64 [1, 2, 6, 12]
       >
 
       iex> s = [1, 2, nil, 4] |> Explorer.Series.from_list()
       iex> Explorer.Series.cumulative_product(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, nil, 8]
+        s64 [1, 2, nil, 8]
       >
   """
   @doc type: :window
@@ -3113,7 +3127,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.add(s1, s2)
       #Explorer.Series<
         Polars[3]
-        integer [5, 7, 9]
+        s64 [5, 7, 9]
       >
 
   You can also use scalar values on both sides:
@@ -3122,14 +3136,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.add(s1, 2)
       #Explorer.Series<
         Polars[3]
-        integer [3, 4, 5]
+        s64 [3, 4, 5]
       >
 
       iex> s1 = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.add(2, s1)
       #Explorer.Series<
         Polars[3]
-        integer [3, 4, 5]
+        s64 [3, 4, 5]
       >
   """
   @doc type: :element_wise
@@ -3147,9 +3161,10 @@ defmodule Explorer.Series do
     end
   end
 
-  defp cast_to_add(:integer, :integer), do: :integer
-  defp cast_to_add(:integer, {:f, _} = float), do: float
-  defp cast_to_add({:f, _} = float, :integer), do: float
+  # TODO: fix the logic for integer dtypes
+  defp cast_to_add({:s, left}, {:s, right}), do: {:s, max(left, right)}
+  defp cast_to_add({:s, _}, {:f, _} = float), do: float
+  defp cast_to_add({:f, _} = float, {:s, _}), do: float
   defp cast_to_add({:f, _}, {:f, _}), do: {:f, 64}
   defp cast_to_add(:date, {:duration, _}), do: :date
   defp cast_to_add({:duration, _}, :date), do: :date
@@ -3180,7 +3195,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.subtract(s1, s2)
       #Explorer.Series<
         Polars[3]
-        integer [-3, -3, -3]
+        s64 [-3, -3, -3]
       >
 
   You can also use scalar values on both sides:
@@ -3189,14 +3204,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.subtract(s1, 2)
       #Explorer.Series<
         Polars[3]
-        integer [-1, 0, 1]
+        s64 [-1, 0, 1]
       >
 
       iex> s1 = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.subtract(2, s1)
       #Explorer.Series<
         Polars[3]
-        integer [1, 0, -1]
+        s64 [1, 0, -1]
       >
   """
   @doc type: :element_wise
@@ -3214,9 +3229,10 @@ defmodule Explorer.Series do
     end
   end
 
-  defp cast_to_subtract(:integer, :integer), do: :integer
-  defp cast_to_subtract(:integer, {:f, _} = float), do: float
-  defp cast_to_subtract({:f, _} = float, :integer), do: float
+  # TODO: fix the logic for new integer dtypes
+  defp cast_to_subtract({:s, left}, {:s, right}), do: {:s, max(left, right)}
+  defp cast_to_subtract({:s, _}, {:f, _} = float), do: float
+  defp cast_to_subtract({:f, _} = float, {:s, _}), do: float
   defp cast_to_subtract({:f, _}, {:f, _}), do: {:f, 64}
 
   defp cast_to_subtract(:date, :date), do: {:duration, :millisecond}
@@ -3248,14 +3264,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.multiply(s1, s2)
       #Explorer.Series<
         Polars[10]
-        integer [11, 24, 39, 56, 75, 96, 119, 144, 171, 200]
+        s64 [11, 24, 39, 56, 75, 96, 119, 144, 171, 200]
       >
 
       iex> s1 = 1..5 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> Explorer.Series.multiply(s1, 2)
       #Explorer.Series<
         Polars[5]
-        integer [2, 4, 6, 8, 10]
+        s64 [2, 4, 6, 8, 10]
       >
   """
   @doc type: :element_wise
@@ -3273,12 +3289,13 @@ defmodule Explorer.Series do
     end
   end
 
-  defp cast_to_multiply(:integer, :integer), do: :integer
-  defp cast_to_multiply(:integer, {:f, _} = float), do: float
-  defp cast_to_multiply({:f, _} = float, :integer), do: float
+  # TODO: fix the logic for new dtypes
+  defp cast_to_multiply({:s, left}, {:s, right}), do: {:s, max(left, right)}
+  defp cast_to_multiply({:s, _}, {:f, _} = float), do: float
+  defp cast_to_multiply({:f, _} = float, {:s, _}), do: float
   defp cast_to_multiply({:f, _}, {:f, _}), do: {:f, 64}
-  defp cast_to_multiply(:integer, {:duration, p}), do: {:duration, p}
-  defp cast_to_multiply({:duration, p}, :integer), do: {:duration, p}
+  defp cast_to_multiply({:s, _}, {:duration, p}), do: {:duration, p}
+  defp cast_to_multiply({:duration, p}, {:s, _}), do: {:duration, p}
   defp cast_to_multiply({:f, _}, {:duration, p}), do: {:duration, p}
   defp cast_to_multiply({:duration, p}, {:f, _}), do: {:duration, p}
   defp cast_to_multiply(_, _), do: nil
@@ -3348,11 +3365,12 @@ defmodule Explorer.Series do
     end
   end
 
-  defp cast_to_divide(:integer, :integer), do: {:f, 64}
-  defp cast_to_divide(:integer, {:f, _} = float), do: float
-  defp cast_to_divide({:f, _} = float, :integer), do: float
+  # Fix the logic for new integer dtypes
+  defp cast_to_divide({:s, _}, {:s, _}), do: {:f, 64}
+  defp cast_to_divide({:s, _}, {:f, _} = float), do: float
+  defp cast_to_divide({:f, _} = float, {:s, _}), do: float
   defp cast_to_divide({:f, _}, {:f, _}), do: {:f, 64}
-  defp cast_to_divide({:duration, p}, :integer), do: {:duration, p}
+  defp cast_to_divide({:duration, p}, {:s, _}), do: {:duration, p}
   defp cast_to_divide({:duration, p}, {:f, _}), do: {:duration, p}
   defp cast_to_divide(_, _), do: nil
 
@@ -3382,7 +3400,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.pow(s, 3)
       #Explorer.Series<
         Polars[3]
-        integer [8, 64, 216]
+        s64 [8, 64, 216]
       >
 
       iex> s = [2, 4, 6] |> Explorer.Series.from_list()
@@ -3495,7 +3513,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.quotient(s1, s2)
       #Explorer.Series<
         Polars[3]
-        integer [5, 5, 5]
+        s64 [5, 5, 5]
       >
 
       iex> s1 = [10, 11, 10] |> Explorer.Series.from_list()
@@ -3503,26 +3521,26 @@ defmodule Explorer.Series do
       iex> Explorer.Series.quotient(s1, s2)
       #Explorer.Series<
         Polars[3]
-        integer [5, 5, nil]
+        s64 [5, 5, nil]
       >
 
       iex> s1 = [10, 12, 15] |> Explorer.Series.from_list()
       iex> Explorer.Series.quotient(s1, 3)
       #Explorer.Series<
         Polars[3]
-        integer [3, 4, 5]
+        s64 [3, 4, 5]
       >
 
   """
   @doc type: :element_wise
   @spec quotient(left :: Series.t(), right :: Series.t() | integer()) :: Series.t()
-  def quotient(%Series{dtype: :integer} = left, %Series{dtype: :integer} = right),
+  def quotient(%Series{dtype: {:s, 64}} = left, %Series{dtype: {:s, 64}} = right),
     do: apply_series_list(:quotient, [left, right])
 
-  def quotient(%Series{dtype: :integer} = left, right) when is_integer(right),
+  def quotient(%Series{dtype: {:s, 64}} = left, right) when is_integer(right),
     do: apply_series_list(:quotient, [left, from_list([right])])
 
-  def quotient(left, %Series{dtype: :integer} = right) when is_integer(left),
+  def quotient(left, %Series{dtype: {:s, 64}} = right) when is_integer(left),
     do: apply_series_list(:quotient, [from_list([left]), right])
 
   @doc """
@@ -3545,7 +3563,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.remainder(s1, s2)
       #Explorer.Series<
         Polars[3]
-        integer [0, 1, 0]
+        s64 [0, 1, 0]
       >
 
       iex> s1 = [10, 11, 10] |> Explorer.Series.from_list()
@@ -3553,26 +3571,26 @@ defmodule Explorer.Series do
       iex> Explorer.Series.remainder(s1, s2)
       #Explorer.Series<
         Polars[3]
-        integer [0, 1, nil]
+        s64 [0, 1, nil]
       >
 
       iex> s1 = [10, 11, 9] |> Explorer.Series.from_list()
       iex> Explorer.Series.remainder(s1, 3)
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 0]
+        s64 [1, 2, 0]
       >
 
   """
   @doc type: :element_wise
   @spec remainder(left :: Series.t(), right :: Series.t() | integer()) :: Series.t()
-  def remainder(%Series{dtype: :integer} = left, %Series{dtype: :integer} = right),
+  def remainder(%Series{dtype: {:s, 64}} = left, %Series{dtype: {:s, 64}} = right),
     do: apply_series_list(:remainder, [left, right])
 
-  def remainder(%Series{dtype: :integer} = left, right) when is_integer(right),
+  def remainder(%Series{dtype: {:s, 64}} = left, right) when is_integer(right),
     do: apply_series_list(:remainder, [left, from_list([right])])
 
-  def remainder(left, %Series{dtype: :integer} = right) when is_integer(left),
+  def remainder(left, %Series{dtype: {:s, 64}} = right) when is_integer(left),
     do: apply_series_list(:remainder, [from_list([left]), right])
 
   @doc """
@@ -4196,7 +4214,7 @@ defmodule Explorer.Series do
 
   defp cast_to_ordered_series(dtype, value)
        when K.and(is_numeric_dtype(dtype), is_integer(value)),
-       do: :integer
+       do: {:s, 64}
 
   defp cast_to_ordered_series(dtype, value)
        when K.and(is_numeric_dtype(dtype), is_numeric(value)),
@@ -4210,7 +4228,7 @@ defmodule Explorer.Series do
 
   defp cast_to_ordered_series({:duration, _}, value)
        when is_integer(value),
-       do: :integer
+       do: {:s, 64}
 
   defp cast_to_ordered_series({:duration, _}, %Explorer.Duration{}),
     do: :duration
@@ -4345,14 +4363,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.sort(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 3, 7, 9]
+        s64 [1, 3, 7, 9]
       >
 
       iex> s = Explorer.Series.from_list([9, 3, 7, 1])
       iex> Explorer.Series.sort(s, direction: :desc)
       #Explorer.Series<
         Polars[4]
-        integer [9, 7, 3, 1]
+        s64 [9, 7, 3, 1]
       >
 
   """
@@ -4387,14 +4405,14 @@ defmodule Explorer.Series do
       iex> Explorer.Series.argsort(s)
       #Explorer.Series<
         Polars[4]
-        integer [3, 1, 2, 0]
+        s64 [3, 1, 2, 0]
       >
 
       iex> s = Explorer.Series.from_list([9, 3, 7, 1])
       iex> Explorer.Series.argsort(s, direction: :desc)
       #Explorer.Series<
         Polars[4]
-        integer [0, 2, 1, 3]
+        s64 [0, 2, 1, 3]
       >
 
   """
@@ -4412,7 +4430,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.reverse(s)
       #Explorer.Series<
         Polars[3]
-        integer [3, 2, 1]
+        s64 [3, 2, 1]
       >
   """
   @doc type: :shape
@@ -4429,7 +4447,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.distinct(s)
       #Explorer.Series<
         Polars[3]
-        integer [1, 2, 3]
+        s64 [1, 2, 3]
       >
   """
   @doc type: :shape
@@ -4470,7 +4488,7 @@ defmodule Explorer.Series do
       #Explorer.DataFrame<
         Polars[3 x 2]
         values string ["c", "a", "b"]
-        counts integer [3, 2, 1]
+        counts s64 [3, 2, 1]
       >
   """
   @doc type: :aggregation
@@ -4605,7 +4623,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.window_sum(s, 4)
       #Explorer.Series<
         Polars[10]
-        integer [1, 3, 6, 10, 14, 18, 22, 26, 30, 34]
+        s64 [1, 3, 6, 10, 14, 18, 22, 26, 30, 34]
       >
 
       iex> s = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
@@ -4718,7 +4736,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.window_min(s, 4)
       #Explorer.Series<
         Polars[10]
-        integer [1, 1, 1, 1, 2, 3, 4, 5, 6, 7]
+        s64 [1, 1, 1, 1, 2, 3, 4, 5, 6, 7]
       >
 
       iex> s = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
@@ -4751,7 +4769,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.window_max(s, 4)
       #Explorer.Series<
         Polars[10]
-        integer [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        s64 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       >
 
       iex> s = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
@@ -4979,35 +4997,35 @@ defmodule Explorer.Series do
       iex> Explorer.Series.fill_missing(s, :forward)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 2, 4]
+        s64 [1, 2, 2, 4]
       >
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
       iex> Explorer.Series.fill_missing(s, :backward)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 4, 4]
+        s64 [1, 2, 4, 4]
       >
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
       iex> Explorer.Series.fill_missing(s, :max)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 4, 4]
+        s64 [1, 2, 4, 4]
       >
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
       iex> Explorer.Series.fill_missing(s, :min)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 1, 4]
+        s64 [1, 2, 1, 4]
       >
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
       iex> Explorer.Series.fill_missing(s, :mean)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 2, 4]
+        s64 [1, 2, 2, 4]
       >
 
   Values that belong to the series itself can also be added as missing:
@@ -5016,7 +5034,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.fill_missing(s, 3)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 3, 4]
+        s64 [1, 2, 3, 4]
       >
 
       iex> s = Explorer.Series.from_list(["a", "b", nil, "d"])
@@ -5030,7 +5048,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
       iex> Explorer.Series.fill_missing(s, "foo")
-      ** (ArgumentError) cannot invoke Explorer.Series.fill_missing/2 with mismatched dtypes: :integer and "foo"
+      ** (ArgumentError) cannot invoke Explorer.Series.fill_missing/2 with mismatched dtypes: {:s, 64} and "foo"
 
   Floats in particular accept missing values to be set to NaN, Inf, and -Inf:
 
@@ -5138,7 +5156,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.abs(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 1, 3]
+        s64 [1, 2, 1, 3]
       >
 
       iex> s = Explorer.Series.from_list([1.0, 2.0, -1.0, -3.0])
@@ -5617,7 +5635,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.month(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 3, nil]
+        s64 [1, 2, 3, nil]
       >
 
   It can also be called on a datetime series.
@@ -5626,7 +5644,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.month(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 3, nil]
+        s64 [1, 2, 3, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5646,7 +5664,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.year(s)
       #Explorer.Series<
         Polars[4]
-        integer [2023, 2022, 2021, nil]
+        s64 [2023, 2022, 2021, nil]
       >
 
   It can also be called on a datetime series.
@@ -5655,7 +5673,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.year(s)
       #Explorer.Series<
         Polars[4]
-        integer [2023, 2022, 2021, nil]
+        s64 [2023, 2022, 2021, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5675,7 +5693,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.hour(s)
       #Explorer.Series<
         Polars[4]
-        integer [0, 23, 12, nil]
+        s64 [0, 23, 12, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5695,7 +5713,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.minute(s)
       #Explorer.Series<
         Polars[4]
-        integer [0, 59, 0, nil]
+        s64 [0, 59, 0, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5715,7 +5733,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.second(s)
       #Explorer.Series<
         Polars[4]
-        integer [0, 59, 0, nil]
+        s64 [0, 59, 0, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5735,7 +5753,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.day_of_week(s)
       #Explorer.Series<
         Polars[4]
-        integer [7, 1, 5, nil]
+        s64 [7, 1, 5, nil]
       >
 
   It can also be called on a datetime series.
@@ -5744,7 +5762,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.day_of_week(s)
       #Explorer.Series<
         Polars[4]
-        integer [7, 1, 5, nil]
+        s64 [7, 1, 5, nil]
       >
   """
 
@@ -5767,7 +5785,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.day_of_year(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 32, nil]
+        s64 [1, 2, 32, nil]
       >
 
   It can also be called on a datetime series.
@@ -5778,7 +5796,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.day_of_year(s)
       #Explorer.Series<
         Polars[4]
-        integer [1, 2, 32, nil]
+        s64 [1, 2, 32, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5803,7 +5821,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.week_of_year(s)
       #Explorer.Series<
         Polars[4]
-        integer [52, 1, 5, nil]
+        s64 [52, 1, 5, nil]
       >
 
   It can also be called on a datetime series.
@@ -5814,7 +5832,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.week_of_year(s)
       #Explorer.Series<
         Polars[4]
-        integer [52, 1, 5, nil]
+        s64 [52, 1, 5, nil]
       >
   """
   @doc type: :datetime_wise
@@ -5980,11 +5998,11 @@ defmodule Explorer.Series do
     :"#{backend}.Series"
   end
 
-  defp dtype_error(function, dtype, valid_dtypes) do
+  defp dtype_error(function, dtype, valid_dtypes) when is_list(valid_dtypes) do
     raise(
       ArgumentError,
       "Explorer.Series.#{function} not implemented for dtype #{inspect(dtype)}. " <>
-        "Valid dtypes are #{inspect(valid_dtypes)}"
+        "Valid " <> Explorer.Shared.inspect_dtypes(valid_dtypes, with_prefix: true)
     )
   end
 
@@ -6037,10 +6055,11 @@ defmodule Explorer.Series do
   end
 
   defp check_dtypes_for_coalesce!(%Series{} = s1, %Series{} = s2) do
+    # TODO: consider the unsigned types here.
     case {s1.dtype, s2.dtype} do
       {dtype, dtype} -> :ok
-      {:integer, {:f, _}} -> :ok
-      {{:f, _}, :integer} -> :ok
+      {{:s, _}, {:f, _}} -> :ok
+      {{:f, _}, {:s, _}} -> :ok
       {left, right} -> dtype_mismatch_error("coalesce/2", left, right)
     end
   end

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -362,10 +362,8 @@ defmodule Explorer.Shared do
     end)
   end
 
-  # TODO: check if only @numeric_types can be used here
   defp new_type_matches?(type, new_type) do
-    leaf_dtype(new_type) == :numeric and
-      leaf_dtype(type) in ([{:f, 32}, {:f, 64}] ++ @integer_types)
+    leaf_dtype(new_type) == :numeric and leaf_dtype(type) in numeric_types()
   end
 
   @doc """

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -83,7 +83,7 @@ defmodule Explorer.Shared do
       maybe_dtype
     else
       raise ArgumentError,
-            "unsupported dtype #{inspect(dtype)}, expected one of #{inspect(dtypes())}"
+            "unsupported dtype #{inspect(dtype)}, expected one of #{inspect_dtypes(dtypes())}"
     end
   end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -495,8 +495,9 @@ defmodule Explorer.Shared do
   """
   def dtype_to_iotype!(dtype) do
     case dtype do
-      {:f, _n} -> dtype
-      {:s, 64} -> {:s, 64}
+      {:f, n} when n in [32, 64] -> dtype
+      {:s, n} when n in [8, 16, 32, 64] -> dtype
+      {:u, n} when n in [8, 16, 32, 64] -> dtype
       :boolean -> {:u, 8}
       :date -> {:s, 32}
       :time -> {:s, 64}

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -2,13 +2,7 @@ defmodule Explorer.Shared do
   # A collection of **private** helpers shared in Explorer.
   @moduledoc false
 
-  @scalar_types [
-    :binary,
-    :boolean,
-    :category,
-    :date,
-    {:f, 32},
-    {:f, 64},
+  @integer_types [
     {:s, 8},
     {:s, 16},
     {:s, 32},
@@ -16,18 +10,26 @@ defmodule Explorer.Shared do
     {:u, 8},
     {:u, 16},
     {:u, 32},
-    {:u, 64},
-    # TODO: remove this integer
-    :integer,
-    :string,
-    :time,
-    {:datetime, :microsecond},
-    {:datetime, :millisecond},
-    {:datetime, :nanosecond},
-    {:duration, :microsecond},
-    {:duration, :millisecond},
-    {:duration, :nanosecond}
+    {:u, 64}
   ]
+
+  @scalar_types @integer_types ++
+                  [
+                    :binary,
+                    :boolean,
+                    :category,
+                    :date,
+                    {:f, 32},
+                    {:f, 64},
+                    :string,
+                    :time,
+                    {:datetime, :microsecond},
+                    {:datetime, :millisecond},
+                    {:datetime, :nanosecond},
+                    {:duration, :microsecond},
+                    {:duration, :millisecond},
+                    {:duration, :nanosecond}
+                  ]
 
   @doc """
   All supported dtypes.
@@ -105,7 +107,7 @@ defmodule Explorer.Shared do
   @doc """
   Supported signed integer dtypes.
   """
-  def signed_integer_types, do: [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer]
+  def signed_integer_types, do: [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}]
 
   @doc """
   Supported unsigned integer dtypes.
@@ -116,6 +118,11 @@ defmodule Explorer.Shared do
   All integer dtypes.
   """
   def integer_types, do: signed_integer_types() ++ unsigned_integer_types()
+
+  @doc """
+  Both integer and float dtypes.
+  """
+  def numeric_types, do: float_types() ++ integer_types()
 
   @doc """
   Gets the backend from a `Keyword.t()` or `nil`.
@@ -252,22 +259,13 @@ defmodule Explorer.Shared do
   """
   def dtype_from_list!(list, preferable_type \\ nil) do
     initial_type =
-      if leaf_dtype(preferable_type) in [
-           :numeric,
-           :binary,
-           {:f, 32},
-           {:f, 64},
-           {:s, 8},
-           {:s, 16},
-           {:s, 32},
-           {:s, 64},
-           {:u, 8},
-           {:u, 16},
-           {:u, 32},
-           {:u, 64},
-           :integer,
-           :category
-         ],
+      if leaf_dtype(preferable_type) in ([
+                                           :numeric,
+                                           :binary,
+                                           {:f, 32},
+                                           {:f, 64},
+                                           :category
+                                         ] ++ @integer_types),
          do: preferable_type
 
     type =
@@ -285,23 +283,25 @@ defmodule Explorer.Shared do
     type || preferable_type || {:f, 64}
   end
 
+  @numeric_types @integer_types ++ [{:f, 32}, {:f, 64}, :numeric]
+
   defp type(%Date{} = _item, _type), do: :date
   defp type(%Time{} = _item, _type), do: :time
   defp type(%NaiveDateTime{} = _item, _type), do: {:datetime, :microsecond}
   defp type(%Explorer.Duration{precision: precision} = _item, _type), do: {:duration, precision}
 
   defp type(item, type) when is_integer(item) and type in [{:f, 32}, {:f, 64}], do: :numeric
-  defp type(item, type) when is_float(item) and type == :integer, do: :numeric
+  defp type(item, type) when is_float(item) and type in @integer_types, do: :numeric
   defp type(item, type) when is_number(item) and type == :numeric, do: :numeric
 
   defp type(item, type)
        when item in [:nan, :infinity, :neg_infinity] and
-              type in [:integer, {:f, 32}, {:f, 64}, :numeric],
+              type in @numeric_types,
        do: :numeric
 
   defp type(item, {:s, _} = integer_type) when is_integer(item), do: integer_type
   defp type(item, {:u, _} = integer_type) when is_integer(item) and item >= 0, do: integer_type
-  defp type(item, _type) when is_integer(item), do: :integer
+  defp type(item, _type) when is_integer(item), do: {:s, 64}
   defp type(item, {:f, _} = float_dtype) when is_float(item), do: float_dtype
   defp type(item, _type) when is_float(item), do: {:f, 64}
   defp type(item, _type) when item in [:nan, :infinity, :neg_infinity], do: {:f, 64}
@@ -362,8 +362,10 @@ defmodule Explorer.Shared do
     end)
   end
 
+  # TODO: check if only @numeric_types can be used here
   defp new_type_matches?(type, new_type) do
-    leaf_dtype(new_type) == :numeric and leaf_dtype(type) in [:integer, {:f, 32}, {:f, 64}]
+    leaf_dtype(new_type) == :numeric and
+      leaf_dtype(type) in ([{:f, 32}, {:f, 64}] ++ @integer_types)
   end
 
   @doc """
@@ -449,12 +451,45 @@ defmodule Explorer.Shared do
   end
 
   @doc """
+  Helper to inspect dtypes in a sentence.
+  """
+  def inspect_dtypes(dtypes, opts \\ []) do
+    opts = Keyword.validate!(opts, with_prefix: false)
+
+    case dtypes do
+      [dtype] ->
+        if opts[:with_prefix] do
+          "dtype is #{inspect(dtype)}"
+        else
+          inspect(dtype)
+        end
+
+      [_ | _] = dtypes ->
+        prefix =
+          if opts[:with_prefix] do
+            "dtypes are "
+          else
+            ""
+          end
+
+        {items, [last]} = Enum.split(Enum.sort(dtypes), -1)
+
+        IO.iodata_to_binary([
+          prefix,
+          Enum.map_intersperse(items, ", ", &Kernel.inspect/1),
+          " and ",
+          inspect(last)
+        ])
+    end
+  end
+
+  @doc """
   Converts a dtype to a binary type when possible.
   """
   def dtype_to_iotype!(dtype) do
     case dtype do
       {:f, _n} -> dtype
-      :integer -> {:s, 64}
+      {:s, 64} -> {:s, 64}
       :boolean -> {:u, 8}
       :date -> {:s, 32}
       :time -> {:s, 64}
@@ -470,7 +505,7 @@ defmodule Explorer.Shared do
   def iotype_to_dtype!(type) do
     case type do
       {:f, _} -> type
-      {:s, 64} -> :integer
+      {:s, 64} -> {:s, 64}
       {:u, 8} -> :boolean
       {:s, 32} -> :date
       _ -> raise ArgumentError, "cannot convert binary/tensor type #{inspect(type)} into dtype"

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -454,14 +454,21 @@ defmodule Explorer.Shared do
   Helper to inspect dtypes in a sentence.
   """
   def inspect_dtypes(dtypes, opts \\ []) do
-    opts = Keyword.validate!(opts, with_prefix: false)
+    opts = Keyword.validate!(opts, with_prefix: false, backsticks: false)
+
+    inspect_fun =
+      if opts[:backsticks] do
+        fn item -> "`" <> inspect(item) <> "`" end
+      else
+        &Kernel.inspect/1
+      end
 
     case dtypes do
       [dtype] ->
         if opts[:with_prefix] do
-          "dtype is #{inspect(dtype)}"
+          "dtype is #{inspect_fun.(dtype)}"
         else
-          inspect(dtype)
+          inspect_fun.(dtype)
         end
 
       [_ | _] = dtypes ->
@@ -476,9 +483,9 @@ defmodule Explorer.Shared do
 
         IO.iodata_to_binary([
           prefix,
-          Enum.map_intersperse(items, ", ", &Kernel.inspect/1),
+          Enum.map_intersperse(items, ", ", inspect_fun),
           " and ",
-          inspect(last)
+          inspect_fun.(last)
         ])
     end
   end

--- a/lib/explorer/tensor_frame.ex
+++ b/lib/explorer/tensor_frame.ex
@@ -72,9 +72,9 @@ if Code.ensure_loaded?(Nx) do
         iex> Explorer.DataFrame.put(df, "result", add_columns(df))
         #Explorer.DataFrame<
           Polars[2 x 3]
-          a integer [11, 12]
-          b integer [21, 22]
-          result integer [32, 34]
+          a s64 [11, 12]
+          b s64 [21, 22]
+          result s64 [32, 34]
         >
 
     One benefit of using `Explorer.DataFrame.put/4` is that it will
@@ -252,7 +252,7 @@ if Code.ensure_loaded?(Nx) do
       :time,
       {:f, 32},
       {:f, 64},
-      :integer,
+      {:s, 64},
       {:datetime, :millisecond},
       {:datetime, :microsecond},
       {:datetime, :nanosecond}

--- a/native/explorer/src/datatypes/ex_dtypes.rs
+++ b/native/explorer/src/datatypes/ex_dtypes.rs
@@ -37,7 +37,6 @@ pub enum ExSeriesDtype {
     F(u8),
     S(u8),
     U(u8),
-    Integer,
     String,
     Time,
     Datetime(ExTimeUnit),
@@ -60,7 +59,7 @@ impl TryFrom<&DataType> for ExSeriesDtype {
             DataType::Int8 => Ok(ExSeriesDtype::S(8)),
             DataType::Int16 => Ok(ExSeriesDtype::S(16)),
             DataType::Int32 => Ok(ExSeriesDtype::S(32)),
-            DataType::Int64 => Ok(ExSeriesDtype::Integer),
+            DataType::Int64 => Ok(ExSeriesDtype::S(64)),
 
             DataType::UInt8 => Ok(ExSeriesDtype::U(8)),
             DataType::UInt16 => Ok(ExSeriesDtype::U(16)),
@@ -140,7 +139,6 @@ impl TryFrom<&ExSeriesDtype> for DataType {
             ExSeriesDtype::U(size) => Err(ExplorerError::Other(format!(
                 "unsigned integer dtype of size {size} is not valid"
             ))),
-            ExSeriesDtype::Integer => Ok(DataType::Int64),
             ExSeriesDtype::String => Ok(DataType::Utf8),
             ExSeriesDtype::Time => Ok(DataType::Time),
             ExSeriesDtype::Datetime(ExTimeUnit::Nanosecond) => {

--- a/test/explorer/backend/lazy_frame_test.exs
+++ b/test/explorer/backend/lazy_frame_test.exs
@@ -10,7 +10,7 @@ defmodule Explorer.Backend.LazyFrameTest do
              """
              #Explorer.DataFrame<
                LazyFrame[??? x 2]
-               a integer
+               a s64
                b f64
              >\
              """

--- a/test/explorer/backend/lazy_series_test.exs
+++ b/test/explorer/backend/lazy_series_test.exs
@@ -6,13 +6,13 @@ defmodule Explorer.Backend.LazySeriesTest do
 
   test "inspect/2 gives a basic hint of lazy series" do
     data = LazySeries.new(:column, ["col_a"], :unknown)
-    opaque_series = Backend.Series.new(data, :integer)
+    opaque_series = Backend.Series.new(data, {:s, 64})
 
     assert inspect(opaque_series) ==
              """
              #Explorer.Series<
                LazySeries[???]
-               integer (column("col_a"))
+               s64 (column("col_a"))
              >\
              """
   end
@@ -59,7 +59,7 @@ defmodule Explorer.Backend.LazySeriesTest do
                LazySeries[???]
                boolean (column("col_a") == #Explorer.Series<
                Polars[3]
-               integer [1, 2, 3]
+               s64 [1, 2, 3]
              >)
              >\
              """

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -97,8 +97,8 @@ defmodule Explorer.DataFrame.CSVTest do
 
   describe "dtypes" do
     test "integer" do
-      assert_csv(:integer, "100", 100)
-      assert_csv(:integer, "-101", -101)
+      assert_csv({:s, 64}, "100", 100)
+      assert_csv({:s, 64}, "-101", -101)
     end
 
     test "float" do

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -82,8 +82,8 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.names(df1) == ["year", "total"]
 
       assert DF.dtypes(df1) == %{
-               "year" => :integer,
-               "total" => :integer
+               "year" => {:s, 64},
+               "total" => {:s, 64}
              }
 
       assert DF.groups(df1) == []
@@ -104,9 +104,9 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.names(df1) == ["country", "year", "total_max", "total_min"]
 
       assert DF.dtypes(df1) == %{
-               "year" => :integer,
-               "total_min" => :integer,
-               "total_max" => :integer,
+               "year" => {:s, 64},
+               "total_min" => {:s, 64},
+               "total_max" => {:s, 64},
                "country" => :string
              }
 
@@ -382,7 +382,7 @@ defmodule Explorer.DataFrame.GroupedTest do
       message = """
       expecting summarise with an aggregation operation or plain column, but none of which were found in: #Explorer.Series<
         LazySeries[???]
-        integer (column("solid_fuel") + 50)
+        s64 (column("solid_fuel") + 50)
       >\
       """
 
@@ -482,7 +482,7 @@ defmodule Explorer.DataFrame.GroupedTest do
              }
 
       assert df2.names == ["a", "b", "c", "d"]
-      assert df2.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer, "d" => {:f, 64}}
+      assert df2.dtypes == %{"a" => {:s, 64}, "b" => :string, "c" => {:s, 64}, "d" => {:f, 64}}
       assert df2.groups == ["c"]
     end
 
@@ -500,7 +500,7 @@ defmodule Explorer.DataFrame.GroupedTest do
              }
 
       assert df2.names == ["a", "b", "c", "d"]
-      assert df2.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer, "d" => {:f, 64}}
+      assert df2.dtypes == %{"a" => {:s, 64}, "b" => :string, "c" => {:s, 64}, "d" => {:f, 64}}
       assert df2.groups == ["c"]
     end
   end
@@ -527,11 +527,11 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert df2.names == ["a", "b", "c", "d", "e"]
 
       assert df2.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => :string,
-               "c" => :integer,
+               "c" => {:s, 64},
                "d" => {:f, 64},
-               "e" => :integer
+               "e" => {:s, 64}
              }
 
       assert df2.groups == ["c"]
@@ -1185,7 +1185,7 @@ defmodule Explorer.DataFrame.GroupedTest do
       stacked = DF.concat_rows([grouped_first, grouped_second])
 
       assert DF.groups(stacked) == ["a"]
-      assert DF.dtypes(stacked) == %{"a" => :integer, "b" => :string}
+      assert DF.dtypes(stacked) == %{"a" => {:s, 64}, "b" => :string}
       assert DF.n_rows(stacked) == 6
     end
 
@@ -1217,9 +1217,9 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.groups(stacked) == ["a"]
 
       assert DF.dtypes(stacked) == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => :string,
-               "c" => :integer,
+               "c" => {:s, 64},
                "d" => {:f, 64}
              }
 
@@ -1239,10 +1239,10 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.groups(stacked) == ["a"]
 
       assert DF.dtypes(stacked) == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => :string,
                "a_1" => {:f, 64},
-               "d" => :integer
+               "d" => {:s, 64}
              }
 
       assert DF.n_rows(stacked) == 3
@@ -1263,7 +1263,7 @@ defmodule Explorer.DataFrame.GroupedTest do
       df1 = DF.put(grouped, :c, Series.from_list(~w(a b c)))
 
       assert DF.names(df1) == ["a", "b", "c"]
-      assert DF.dtypes(df1) == %{"a" => :integer, "b" => :integer, "c" => :string}
+      assert DF.dtypes(df1) == %{"a" => {:s, 64}, "b" => {:s, 64}, "c" => :string}
       assert DF.groups(df1) == ["a"]
 
       assert DF.to_columns(df1, atom_keys: true) == %{
@@ -1280,7 +1280,7 @@ defmodule Explorer.DataFrame.GroupedTest do
       df1 = DF.put(grouped, :b, Series.from_list([10, 10, 10]))
 
       assert DF.names(df1) == ["a", "b"]
-      assert DF.dtypes(df1) == %{"a" => :integer, "b" => :integer}
+      assert DF.dtypes(df1) == %{"a" => {:s, 64}, "b" => {:s, 64}}
       assert DF.groups(df1) == ["a"]
 
       assert DF.to_columns(df1, atom_keys: true) == %{

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -44,16 +44,16 @@ defmodule Explorer.DataFrame.LazyTest do
 
   test "dtypes/1", %{ldf: ldf} do
     assert DF.dtypes(ldf) == %{
-             "bunker_fuels" => :integer,
-             "cement" => :integer,
+             "bunker_fuels" => {:s, 64},
+             "cement" => {:s, 64},
              "country" => :string,
-             "gas_flaring" => :integer,
-             "gas_fuel" => :integer,
-             "liquid_fuel" => :integer,
+             "gas_flaring" => {:s, 64},
+             "gas_fuel" => {:s, 64},
+             "liquid_fuel" => {:s, 64},
              "per_capita" => {:f, 64},
-             "solid_fuel" => :integer,
-             "total" => :integer,
-             "year" => :integer
+             "solid_fuel" => {:s, 64},
+             "total" => {:s, 64},
+             "year" => {:s, 64}
            }
   end
 
@@ -68,16 +68,16 @@ defmodule Explorer.DataFrame.LazyTest do
   test "slice/3", %{ldf: ldf} do
     assert ldf |> DF.slice(0, 5) |> inspect() == ~s(#Explorer.DataFrame<
   LazyPolars[??? x 10]
-  year integer [2010, 2010, 2010, 2010, 2010]
+  year s64 [2010, 2010, 2010, 2010, 2010]
   country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA"]
-  total integer [2308, 1254, 32500, 141, 7924]
-  solid_fuel integer [627, 117, 332, 0, 0]
-  liquid_fuel integer [1601, 953, 12381, 141, 3649]
-  gas_fuel integer [74, 7, 14565, 0, 374]
-  cement integer [5, 177, 2598, 0, 204]
-  gas_flaring integer [0, 0, 2623, 0, 3697]
+  total s64 [2308, 1254, 32500, 141, 7924]
+  solid_fuel s64 [627, 117, 332, 0, 0]
+  liquid_fuel s64 [1601, 953, 12381, 141, 3649]
+  gas_fuel s64 [74, 7, 14565, 0, 374]
+  cement s64 [5, 177, 2598, 0, 204]
+  gas_flaring s64 [0, 0, 2623, 0, 3697]
   per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37]
-  bunker_fuels integer [9, 7, 663, 0, 321]
+  bunker_fuels s64 [9, 7, 663, 0, 321]
 >)
   end
 
@@ -105,16 +105,16 @@ defmodule Explorer.DataFrame.LazyTest do
   test "inspect/1", %{ldf: ldf} do
     assert inspect(ldf) == ~s(#Explorer.DataFrame<
   LazyPolars[??? x 10]
-  year integer [2010, 2010, 2010, 2010, 2010, ...]
+  year s64 [2010, 2010, 2010, 2010, 2010, ...]
   country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-  total integer [2308, 1254, 32500, 141, 7924, ...]
-  solid_fuel integer [627, 117, 332, 0, 0, ...]
-  liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
-  gas_fuel integer [74, 7, 14565, 0, 374, ...]
-  cement integer [5, 177, 2598, 0, 204, ...]
-  gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+  total s64 [2308, 1254, 32500, 141, 7924, ...]
+  solid_fuel s64 [627, 117, 332, 0, 0, ...]
+  liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+  gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+  cement s64 [5, 177, 2598, 0, 204, ...]
+  gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
   per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-  bunker_fuels integer [9, 7, 663, 0, 321, ...]
+  bunker_fuels s64 [9, 7, 663, 0, 321, ...]
 >)
   end
 
@@ -769,7 +769,7 @@ defmodule Explorer.DataFrame.LazyTest do
         end)
 
       assert ldf1.names == ["a", "b", "c", "d"]
-      assert ldf1.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer, "d" => :integer}
+      assert ldf1.dtypes == %{"a" => {:s, 64}, "b" => :string, "c" => {:s, 64}, "d" => {:s, 64}}
 
       df = DF.collect(ldf1)
 
@@ -789,7 +789,7 @@ defmodule Explorer.DataFrame.LazyTest do
       ldf1 = DF.mutate_with(ldf, fn _ -> [a: 1, b: 2.0, c: true] end)
 
       assert ldf1.names == ["d", "a", "b", "c"]
-      assert ldf1.dtypes == %{"a" => :integer, "b" => {:f, 64}, "c" => :boolean, "d" => :string}
+      assert ldf1.dtypes == %{"a" => {:s, 64}, "b" => {:f, 64}, "c" => :boolean, "d" => :string}
 
       df = DF.collect(ldf1)
 
@@ -928,7 +928,7 @@ defmodule Explorer.DataFrame.LazyTest do
       ldf1 = DF.rename(ldf, %{"a" => "ids"})
 
       assert ldf1.names == ["ids", "b"]
-      assert ldf1.dtypes == %{"ids" => :integer, "b" => :string}
+      assert ldf1.dtypes == %{"ids" => {:s, 64}, "b" => :string}
 
       df = DF.collect(ldf1)
 
@@ -976,7 +976,7 @@ defmodule Explorer.DataFrame.LazyTest do
       ldf = DF.pivot_longer(ldf, &String.ends_with?(&1, "fuel"), select: [])
 
       assert ldf.names == ["variable", "value"]
-      assert ldf.dtypes == %{"variable" => :string, "value" => :integer}
+      assert ldf.dtypes == %{"variable" => :string, "value" => {:s, 64}}
 
       df = DF.collect(ldf)
       assert DF.shape(df) == {3282, 2}
@@ -990,10 +990,10 @@ defmodule Explorer.DataFrame.LazyTest do
       assert ldf.names == ["year", "country", "variable", "value"]
 
       assert ldf.dtypes == %{
-               "year" => :integer,
+               "year" => {:s, 64},
                "country" => :string,
                "variable" => :string,
-               "value" => :integer
+               "value" => {:s, 64}
              }
 
       df = DF.collect(ldf)

--- a/test/explorer/data_frame/ndjson_test.exs
+++ b/test/explorer/data_frame/ndjson_test.exs
@@ -122,7 +122,7 @@ defmodule Explorer.DataFrame.NDJSONTest do
     end
 
     test "structs" do
-      assert_ndjson({:struct, %{"a" => :integer}}, [%{a: 1}], %{"a" => 1})
+      assert_ndjson({:struct, %{"a" => {:s, 64}}}, [%{a: 1}], %{"a" => 1})
     end
 
     # test "date" do
@@ -143,7 +143,7 @@ defmodule Explorer.DataFrame.NDJSONTest do
       assert {:ok, df} = DF.from_ndjson(ndjson_path)
 
       assert DF.names(df) == ~w[a b c d]
-      assert DF.dtypes(df) == %{"a" => :integer, "b" => {:f, 64}, "c" => :boolean, "d" => :string}
+      assert DF.dtypes(df) == %{"a" => {:s, 64}, "b" => {:f, 64}, "c" => :boolean, "d" => :string}
 
       sliced = DF.slice(df, 0, 5)
 
@@ -164,7 +164,7 @@ defmodule Explorer.DataFrame.NDJSONTest do
       assert {:ok, df} = DF.from_ndjson(ndjson_path, infer_schema_length: 3, batch_size: 3)
 
       assert DF.names(df) == ~w[a b c d]
-      assert DF.dtypes(df) == %{"a" => :integer, "b" => {:f, 64}, "c" => :boolean, "d" => :string}
+      assert DF.dtypes(df) == %{"a" => {:s, 64}, "b" => {:f, 64}, "c" => :boolean, "d" => :string}
     end
 
     defp to_ndjson(tmp_dir) do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -74,14 +74,14 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(%{floats: Series.from_list([1.0, 2.0]), integers: Series.from_list([1, 2])})
 
       assert DF.to_columns(df, atom_keys: true) == %{floats: [1.0, 2.0], integers: [1, 2]}
-      assert DF.dtypes(df) == %{"floats" => {:f, 64}, "integers" => :integer}
+      assert DF.dtypes(df) == %{"floats" => {:f, 64}, "integers" => {:s, 64}}
     end
 
     test "from columnar data" do
       df = DF.new(%{floats: [1.0, 2.0], integers: [1, nil]})
 
       assert DF.to_columns(df, atom_keys: true) == %{floats: [1.0, 2.0], integers: [1, nil]}
-      assert DF.dtypes(df) == %{"floats" => {:f, 64}, "integers" => :integer}
+      assert DF.dtypes(df) == %{"floats" => {:f, 64}, "integers" => {:s, 64}}
     end
 
     test "from columnar data with binaries" do
@@ -98,7 +98,7 @@ defmodule Explorer.DataFrameTest do
 
       assert DF.dtypes(df) == %{
                "floats" => {:f, 64},
-               "integers" => :integer,
+               "integers" => {:s, 64},
                "binaries" => :binary
              }
     end
@@ -160,7 +160,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(%{integers: [1, 2, 3]})
 
       assert DF.to_columns(df, atom_keys: true) == %{integers: [1, 2, 3]}
-      assert DF.dtypes(df) == %{"integers" => :integer}
+      assert DF.dtypes(df) == %{"integers" => {:s, 64}}
     end
 
     test "with floats" do
@@ -246,7 +246,7 @@ defmodule Explorer.DataFrameTest do
                integers: [nil, nil, nil]
              }
 
-      assert DF.dtypes(df) == %{"integers" => :integer}
+      assert DF.dtypes(df) == %{"integers" => {:s, 64}}
     end
 
     test "with series of integers and dtype string" do
@@ -299,7 +299,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 
       message =
-        "expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type :integer"
+        "expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type {:s, 64}"
 
       assert_raise ArgumentError, message, fn ->
         DF.filter_with(df, fn ldf ->
@@ -315,7 +315,7 @@ defmodule Explorer.DataFrameTest do
 
       message =
         "expecting the function to return a boolean LazySeries, " <>
-          "but instead it returned a LazySeries of type :integer"
+          "but instead it returned a LazySeries of type {:s, 64}"
 
       assert_raise ArgumentError, message, fn ->
         DF.filter_with(df, fn ldf ->
@@ -586,7 +586,7 @@ defmodule Explorer.DataFrameTest do
 
       error_message =
         "expecting the function to return a single or a list of boolean LazySeries, but instead it contains:\n" <>
-          "#Explorer.Series<\n  LazySeries[???]\n  integer (column(\"a\") + column(\"b\"))\n>"
+          "#Explorer.Series<\n  LazySeries[???]\n  s64 (column(\"a\") + column(\"b\"))\n>"
 
       assert_raise ArgumentError, error_message, fn ->
         DF.filter(df, [a > 4, b < 4, a + b])
@@ -641,7 +641,7 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert df1.names == ["a", "b", "c", "d"]
-      assert df1.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer, "d" => :integer}
+      assert df1.dtypes == %{"a" => {:s, 64}, "b" => :string, "c" => {:s, 64}, "d" => {:s, 64}}
     end
 
     test "changes a column" do
@@ -698,11 +698,11 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => :string,
-               "c" => :integer,
-               "d" => :integer,
-               "e" => :integer,
+               "c" => {:s, 64},
+               "d" => {:s, 64},
+               "e" => {:s, 64},
                "f" => {:f, 64},
                "g" => :string,
                "h" => :boolean,
@@ -756,15 +756,15 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => :string,
-               "c" => :integer,
-               "d" => :integer,
+               "c" => {:s, 64},
+               "d" => {:s, 64},
                "e" => :string,
-               "f" => :integer,
-               "g" => :integer,
-               "h" => :integer,
-               "i" => :integer,
+               "f" => {:s, 64},
+               "g" => {:s, 64},
+               "h" => {:s, 64},
+               "i" => {:s, 64},
                "j" => {:f, 64}
              }
     end
@@ -801,14 +801,14 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "calc1" => :integer,
-               "calc2" => :integer,
-               "calc3" => :integer,
+               "a" => {:s, 64},
+               "calc1" => {:s, 64},
+               "calc2" => {:s, 64},
+               "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => :integer,
-               "calc6" => :integer,
-               "calc7" => :integer,
+               "calc5" => {:s, 64},
+               "calc6" => {:s, 64},
+               "calc7" => {:s, 64},
                "calc8" => {:f, 64},
                "calc9" => {:f, 64},
                "calc10" => :boolean
@@ -843,16 +843,16 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "calc1" => :integer,
-               "calc2" => :integer,
-               "calc3" => :integer,
+               "a" => {:s, 64},
+               "calc1" => {:s, 64},
+               "calc2" => {:s, 64},
+               "calc3" => {:s, 64},
                "calc4" => {:f, 64},
                # TODO: This should be float after #374 is resolved
-               "calc5" => :integer,
+               "calc5" => {:s, 64},
                "calc5_1" => {:f, 64},
-               "calc6" => :integer,
-               "calc7" => :integer
+               "calc6" => {:s, 64},
+               "calc7" => {:s, 64}
              }
     end
 
@@ -883,14 +883,14 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "calc1" => :integer,
-               "calc2" => :integer,
-               "calc3" => :integer,
+               "a" => {:s, 64},
+               "calc1" => {:s, 64},
+               "calc2" => {:s, 64},
+               "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => :integer,
-               "calc6" => :integer,
-               "calc7" => :integer
+               "calc5" => {:s, 64},
+               "calc6" => {:s, 64},
+               "calc7" => {:s, 64}
              }
     end
 
@@ -921,14 +921,14 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "calc1" => :integer,
-               "calc2" => :integer,
-               "calc3" => :integer,
+               "a" => {:s, 64},
+               "calc1" => {:s, 64},
+               "calc2" => {:s, 64},
+               "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => :integer,
-               "calc6" => :integer,
-               "calc7" => :integer
+               "calc5" => {:s, 64},
+               "calc6" => {:s, 64},
+               "calc7" => {:s, 64}
              }
     end
 
@@ -961,17 +961,17 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "b" => :integer,
-               "c" => :integer,
-               "d" => :integer,
-               "calc1" => :integer,
-               "calc2" => :integer,
-               "calc3" => :integer,
+               "a" => {:s, 64},
+               "b" => {:s, 64},
+               "c" => {:s, 64},
+               "d" => {:s, 64},
+               "calc1" => {:s, 64},
+               "calc2" => {:s, 64},
+               "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => :integer,
-               "calc6" => :integer,
-               "calc7" => :integer
+               "calc5" => {:s, 64},
+               "calc6" => {:s, 64},
+               "calc7" => {:s, 64}
              }
     end
 
@@ -1006,15 +1006,15 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => :string,
-               "c" => :integer,
-               "d" => :integer,
-               "e" => :integer,
+               "c" => {:s, 64},
+               "d" => {:s, 64},
+               "e" => {:s, 64},
                "f" => {:f, 64},
-               "g" => :integer,
-               "h" => :integer,
-               "i" => :integer,
+               "g" => {:s, 64},
+               "h" => {:s, 64},
+               "i" => {:s, 64},
                "j" => {:f, 64}
              }
     end
@@ -1038,7 +1038,7 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "c" => {:f, 64}
              }
     end
@@ -1068,7 +1068,7 @@ defmodule Explorer.DataFrameTest do
 
       df1 = df |> DF.mutate(b: clip(a, 1, 10)) |> DF.select(:b)
       assert DF.to_columns(df1, atom_keys: true) == %{b: [1, 5, nil, 10]}
-      assert DF.dtypes(df1) == %{"b" => :integer}
+      assert DF.dtypes(df1) == %{"b" => {:s, 64}}
 
       df2 = df |> DF.mutate(b: clip(a, 1.5, 10.5)) |> DF.select(:b)
       assert DF.to_columns(df2, atom_keys: true) == %{b: [1.5, 5.0, nil, 10.5]}
@@ -1156,7 +1156,7 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => {:f, 64},
                "concat1" => {:f, 64},
                "concat2" => {:f, 64},
@@ -1188,7 +1188,7 @@ defmodule Explorer.DataFrameTest do
         )
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => {:f, 64},
                "c" => {:f, 64},
                "d" => {:f, 64},
@@ -1196,11 +1196,11 @@ defmodule Explorer.DataFrameTest do
                "f" => {:f, 64},
                "g" => {:f, 64},
                "h" => {:f, 64},
-               "p" => :integer,
-               "q" => :integer,
-               "r" => :integer,
-               "s" => :integer,
-               "t" => :integer,
+               "p" => {:s, 64},
+               "q" => {:s, 64},
+               "r" => {:s, 64},
+               "s" => {:s, 64},
+               "t" => {:s, 64},
                "z" => {:f, 64}
              }
 
@@ -1255,7 +1255,7 @@ defmodule Explorer.DataFrameTest do
                c: [true, false, false, false, true, false]
              }
 
-      assert df1.dtypes == %{"a" => :integer, "b" => :boolean, "c" => :boolean}
+      assert df1.dtypes == %{"a" => {:s, 64}, "b" => :boolean, "c" => :boolean}
     end
 
     test "add columns with missing values" do
@@ -1282,13 +1282,13 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert df1.dtypes == %{
-               "a" => :integer,
-               "b" => :integer,
-               "c" => :integer,
-               "d" => :integer,
-               "e" => :integer,
+               "a" => {:s, 64},
+               "b" => {:s, 64},
+               "c" => {:s, 64},
+               "d" => {:s, 64},
+               "e" => {:s, 64},
                "f" => {:f, 64},
-               "g" => :integer
+               "g" => {:s, 64}
              }
     end
 
@@ -1363,10 +1363,10 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert df1.dtypes == %{
-               "a" => :integer,
-               "b" => :integer,
-               "c" => :integer,
-               "d" => :integer
+               "a" => {:s, 64},
+               "b" => {:s, 64},
+               "c" => {:s, 64},
+               "d" => {:s, 64}
              }
     end
 
@@ -1414,8 +1414,8 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "b" => :integer
+               "a" => {:s, 64},
+               "b" => {:s, 64}
              }
     end
 
@@ -1431,8 +1431,8 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.dtypes(df1) == %{
-               "a" => :integer,
-               "b" => :integer
+               "a" => {:s, 64},
+               "b" => {:s, 64}
              }
     end
 
@@ -1450,7 +1450,7 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b", "c"]
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => {:f, 64},
                "c" => {:f, 64}
              }
@@ -1480,7 +1480,7 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b"]
 
       assert df1.dtypes == %{
-               "a" => :integer,
+               "a" => {:s, 64},
                "b" => {:f, 64}
              }
     end
@@ -1762,19 +1762,19 @@ defmodule Explorer.DataFrameTest do
       assert df1.dtypes == %{
                "a" => :date,
                "b" => {:datetime, :microsecond},
-               "c" => :integer,
-               "d" => :integer,
-               "e" => :integer,
-               "f" => :integer,
-               "g" => :integer,
-               "h" => :integer,
-               "i" => :integer,
-               "j" => :integer,
-               "k" => :integer,
-               "l" => :integer,
-               "m" => :integer,
-               "n" => :integer,
-               "o" => :integer
+               "c" => {:s, 64},
+               "d" => {:s, 64},
+               "e" => {:s, 64},
+               "f" => {:s, 64},
+               "g" => {:s, 64},
+               "h" => {:s, 64},
+               "i" => {:s, 64},
+               "j" => {:s, 64},
+               "k" => {:s, 64},
+               "l" => {:s, 64},
+               "m" => {:s, 64},
+               "n" => {:s, 64},
+               "o" => {:s, 64}
              }
     end
 
@@ -2254,30 +2254,30 @@ defmodule Explorer.DataFrameTest do
         )
 
       assert capture_io(fn -> DF.print(df, limit: :infinity) end) == """
-             +---------------------------------------------+
-             |  Explorer DataFrame: [rows: 9, columns: 3]  |
-             +----------------+---------------+------------+
-             |       a        |       b       |     c      |
-             |   <integer>    |   <string>    |   <f64>    |
-             +================+===============+============+
-             | 1              | a             | 9.1        |
-             +----------------+---------------+------------+
-             | 2              | b             | 8.2        |
-             +----------------+---------------+------------+
-             | 3              | c             | 7.3        |
-             +----------------+---------------+------------+
-             | 4              | d             | 6.4        |
-             +----------------+---------------+------------+
-             | 5              | e             | 5.5        |
-             +----------------+---------------+------------+
-             | 6              | f             | 4.6        |
-             +----------------+---------------+------------+
-             | 7              | g             | 3.7        |
-             +----------------+---------------+------------+
-             | 8              | h             | 2.8        |
-             +----------------+---------------+------------+
-             | 9              | i             | 1.9        |
-             +----------------+---------------+------------+
+             +--------------------------------------------+
+             | Explorer DataFrame: [rows: 9, columns: 3]  |
+             +-------------+----------------+-------------+
+             |      a      |       b        |      c      |
+             |    <s64>    |    <string>    |    <f64>    |
+             +=============+================+=============+
+             | 1           | a              | 9.1         |
+             +-------------+----------------+-------------+
+             | 2           | b              | 8.2         |
+             +-------------+----------------+-------------+
+             | 3           | c              | 7.3         |
+             +-------------+----------------+-------------+
+             | 4           | d              | 6.4         |
+             +-------------+----------------+-------------+
+             | 5           | e              | 5.5         |
+             +-------------+----------------+-------------+
+             | 6           | f              | 4.6         |
+             +-------------+----------------+-------------+
+             | 7           | g              | 3.7         |
+             +-------------+----------------+-------------+
+             | 8           | h              | 2.8         |
+             +-------------+----------------+-------------+
+             | 9           | i              | 1.9         |
+             +-------------+----------------+-------------+
 
              """
     end
@@ -2769,7 +2769,7 @@ defmodule Explorer.DataFrameTest do
         |> DF.put(:category, Series.from_list(["a", "b", "a"], dtype: :category))
         |> DF.pivot_wider("category", "category")
 
-      assert DF.dtypes(df1) == %{"a" => :category, "b" => :category, "id" => :integer}
+      assert DF.dtypes(df1) == %{"a" => :category, "b" => :category, "id" => {:s, 64}}
       assert DF.to_columns(df1, atom_keys: true) == %{id: [1], a: ["a"], b: ["b"]}
     end
 
@@ -2995,7 +2995,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.pivot_longer(df, &String.ends_with?(&1, "fuel"), select: [])
 
       assert df.names == ["variable", "value"]
-      assert df.dtypes == %{"variable" => :string, "value" => :integer}
+      assert df.dtypes == %{"variable" => :string, "value" => {:s, 64}}
       assert DF.shape(df) == {3282, 2}
     end
 
@@ -3005,10 +3005,10 @@ defmodule Explorer.DataFrameTest do
       assert df.names == ["year", "country", "variable", "value"]
 
       assert df.dtypes == %{
-               "year" => :integer,
+               "year" => {:s, 64},
                "country" => :string,
                "variable" => :string,
-               "value" => :integer
+               "value" => {:s, 64}
              }
 
       assert DF.shape(df) == {3282, 4}
@@ -3073,7 +3073,7 @@ defmodule Explorer.DataFrameTest do
 
     test "with multiple types of columns to pivot", %{df: df} do
       assert_raise ArgumentError,
-                   "columns to pivot must include columns with the same dtype, but found multiple dtypes: [:string, :integer]",
+                   "columns to pivot must include columns with the same dtype, but found multiple dtypes: :string and {:s, 64}",
                    fn ->
                      DF.pivot_longer(df, &(&1 in ["solid_fuel", "country"]))
                    end
@@ -3290,7 +3290,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.put(df, :b, Series.transform(df[:a], fn n -> n * 2 end))
 
       assert DF.names(df1) == ["a", "b"]
-      assert DF.dtypes(df1) == %{"a" => :integer, "b" => :integer}
+      assert DF.dtypes(df1) == %{"a" => {:s, 64}, "b" => {:s, 64}}
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 2, 3],
@@ -3303,7 +3303,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.put(df, :a, Series.transform(df[:a], fn n -> n * 2 end))
 
       assert DF.names(df1) == ["a"]
-      assert DF.dtypes(df1) == %{"a" => :integer}
+      assert DF.dtypes(df1) == %{"a" => {:s, 64}}
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [2, 4, 6]
@@ -3593,9 +3593,9 @@ defmodule Explorer.DataFrameTest do
       assert DF.names(df1) == ["total", "solid_fuel_mean", "gas_fuel_max"]
 
       assert DF.dtypes(df1) == %{
-               "total" => :integer,
+               "total" => {:s, 64},
                "solid_fuel_mean" => {:f, 64},
-               "gas_fuel_max" => :integer
+               "gas_fuel_max" => {:s, 64}
              }
 
       assert DF.groups(df1) == []
@@ -3766,11 +3766,11 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: [1, 2, 3], b: [[1, 2], [3, 4], [5, 6]])
 
       assert_raise ArgumentError,
-                   "explode/2 expects list columns, but the given columns have the types: [:integer]",
+                   "explode/2 expects list columns, but the given columns have the types: {:s, 64}",
                    fn -> DF.explode(df, :a) end
 
       assert_raise ArgumentError,
-                   "explode/2 expects list columns, but the given columns have the types: [:integer, {:list, :integer}]",
+                   "explode/2 expects list columns, but the given columns have the types: {:list, {:s, 64}} and {:s, 64}",
                    fn -> DF.explode(df, [:a, :b]) end
     end
   end
@@ -3782,7 +3782,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.unnest(df, :a)
 
       assert DF.names(df1) == ["x", "y"]
-      assert DF.dtypes(df1) == %{"x" => :integer, "y" => :integer}
+      assert DF.dtypes(df1) == %{"x" => {:s, 64}, "y" => {:s, 64}}
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                x: [1, 3],
@@ -3796,7 +3796,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.unnest(df, [:a, :b])
 
       assert DF.names(df1) == ["x", "y", "z"]
-      assert DF.dtypes(df1) == %{"x" => :integer, "y" => :integer, "z" => :integer}
+      assert DF.dtypes(df1) == %{"x" => {:s, 64}, "y" => {:s, 64}, "z" => {:s, 64}}
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                x: [1, 3],
@@ -3820,11 +3820,11 @@ defmodule Explorer.DataFrameTest do
       assert DF.names(df1) == ["before", "x", "between", "y", "after"]
 
       assert DF.dtypes(df1) == %{
-               "before" => :integer,
-               "x" => :integer,
-               "between" => :integer,
-               "y" => :integer,
-               "after" => :integer
+               "before" => {:s, 64},
+               "x" => {:s, 64},
+               "between" => {:s, 64},
+               "y" => {:s, 64},
+               "after" => {:s, 64}
              }
     end
 
@@ -3832,7 +3832,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: [1, 2, 3])
 
       assert_raise ArgumentError,
-                   "unnest/2 expects struct columns, but the given columns have the types: [:integer]",
+                   "unnest/2 expects struct columns, but the given columns have the types: {:s, 64}",
                    fn -> DF.unnest(df, :a) end
     end
 

--- a/test/explorer/query_test.exs
+++ b/test/explorer/query_test.exs
@@ -67,7 +67,7 @@ defmodule Explorer.QueryTest do
 
       assert abc()
              |> DF.mutate(
-               for col <- across(), col.dtype in [:integer, {:f, 64}] do
+               for col <- across(), col.dtype in [{:s, 64}, {:f, 64}] do
                  {col.name, -col}
                end
              )

--- a/test/explorer/series/list_test.exs
+++ b/test/explorer/series/list_test.exs
@@ -7,7 +7,7 @@ defmodule Explorer.Series.ListTest do
     test "list of lists of one integer" do
       series = Series.from_list([[1]])
 
-      assert series.dtype == {:list, :integer}
+      assert series.dtype == {:list, {:s, 64}}
       assert series[0] == [1]
       assert Series.to_list(series) == [[1]]
     end
@@ -15,7 +15,7 @@ defmodule Explorer.Series.ListTest do
     test "list of lists of integers" do
       series = Series.from_list([[-1], [1], [2], [3, nil, 4], nil, []])
 
-      assert series.dtype == {:list, :integer}
+      assert series.dtype == {:list, {:s, 64}}
       assert series[0] == [-1]
       assert Series.to_list(series) == [[-1], [1], [2], [3, nil, 4], nil, []]
     end
@@ -23,7 +23,7 @@ defmodule Explorer.Series.ListTest do
     test "list of lists of integers recursively" do
       series = Series.from_list([[[1]]])
 
-      assert series.dtype == {:list, {:list, :integer}}
+      assert series.dtype == {:list, {:list, {:s, 64}}}
       assert series[0] == [[1]]
       assert Series.to_list(series) == [[[1]]]
     end
@@ -116,7 +116,7 @@ defmodule Explorer.Series.ListTest do
     test "list of lists of lists of lists of integers" do
       series = Series.from_list([[[[[1, 2]]]]])
 
-      assert series.dtype == {:list, {:list, {:list, {:list, :integer}}}}
+      assert series.dtype == {:list, {:list, {:list, {:list, {:s, 64}}}}}
       assert series[0] == [[[[1, 2]]]]
       assert Series.to_list(series) == [[[[[1, 2]]]]]
     end
@@ -155,11 +155,11 @@ defmodule Explorer.Series.ListTest do
 
     test "mixing list of lists of strings and numbers" do
       assert_raise ArgumentError,
-                   "the value \"a\" does not match the inferred series dtype :integer",
+                   "the value \"a\" does not match the inferred series dtype {:s, 64}",
                    fn -> Series.from_list([[1], ["a"]]) end
 
       assert_raise ArgumentError,
-                   "the value \"z\" does not match the inferred series dtype :integer",
+                   "the value \"z\" does not match the inferred series dtype {:s, 64}",
                    fn -> Series.from_list([[[[[1, 2], ["z", "b"]]]]]) end
     end
   end
@@ -178,9 +178,9 @@ defmodule Explorer.Series.ListTest do
     test "list of floats series to list of integers" do
       s = Series.from_list([[1.0]])
 
-      s1 = Series.cast(s, {:list, :integer})
+      s1 = Series.cast(s, {:list, {:s, 64}})
 
-      assert s1.dtype == {:list, :integer}
+      assert s1.dtype == {:list, {:s, 64}}
       assert s1[0] === [1]
       assert Series.to_list(s1) === [[1]]
     end
@@ -231,7 +231,7 @@ defmodule Explorer.Series.ListTest do
                """
                #Explorer.Series<
                  Polars[3]
-                 list[integer] [[1, 2], [3, nil, 4], [5, 6]]
+                 list[s64] [[1, 2], [3, nil, 4], [5, 6]]
                >\
                """
     end
@@ -262,7 +262,7 @@ defmodule Explorer.Series.ListTest do
                """
                #Explorer.Series<
                  Polars[2]
-                 list[list[integer]] [[[1, 2]], [[3, 4]]]
+                 list[list[s64]] [[[1, 2]], [[3, 4]]]
                >\
                """
     end

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -7,7 +7,7 @@ defmodule Explorer.Series.StructTest do
     test "allows struct values" do
       s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}])
 
-      assert s.dtype == {:struct, %{"a" => :integer}}
+      assert s.dtype == {:struct, %{"a" => {:s, 64}}}
 
       assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
     end
@@ -20,7 +20,7 @@ defmodule Explorer.Series.StructTest do
           %{a: 5, b: 6}
         ])
 
-      assert s.dtype == {:struct, %{"a" => :integer, "b" => :integer}}
+      assert s.dtype == {:struct, %{"a" => {:s, 64}, "b" => {:s, 64}}}
 
       assert Series.to_list(s) == [
                %{"a" => nil, "b" => 2},
@@ -37,7 +37,7 @@ defmodule Explorer.Series.StructTest do
           %{a: %{b: 3}}
         ])
 
-      assert s.dtype == {:struct, %{"a" => {:struct, %{"b" => :integer}}}}
+      assert s.dtype == {:struct, %{"a" => {:struct, %{"b" => {:s, 64}}}}}
 
       assert Series.to_list(s) == [
                %{"a" => %{"b" => 1}},
@@ -64,21 +64,21 @@ defmodule Explorer.Series.StructTest do
     test "allows nested lists with structs" do
       series = Series.from_list([[%{a: 1}, %{a: 2}], [%{a: 3}]])
 
-      assert series.dtype == {:list, {:struct, %{"a" => :integer}}}
+      assert series.dtype == {:list, {:struct, %{"a" => {:s, 64}}}}
       assert Series.to_list(series) == [[%{"a" => 1}, %{"a" => 2}], [%{"a" => 3}]]
     end
 
     test "errors when structs have mismatched types" do
       assert_raise ArgumentError,
-                   "the value %{a: \"a\"} does not match the inferred series dtype {:struct, %{\"a\" => :integer}}",
+                   "the value %{a: \"a\"} does not match the inferred series dtype {:struct, %{\"a\" => {:s, 64}}}",
                    fn -> Series.from_list([%{a: 1}, %{a: "a"}]) end
 
       assert_raise ArgumentError,
-                   "the value %{b: 1} does not match the inferred series dtype {:struct, %{\"a\" => :integer}}",
+                   "the value %{b: 1} does not match the inferred series dtype {:struct, %{\"a\" => {:s, 64}}}",
                    fn -> Series.from_list([%{a: 1}, %{b: 1}]) end
 
       assert_raise ArgumentError,
-                   "the value [%{a: \"a\"}] does not match the inferred series dtype {:list, {:struct, %{\"a\" => :integer}}}",
+                   "the value [%{a: \"a\"}] does not match the inferred series dtype {:list, {:struct, %{\"a\" => {:s, 64}}}}",
                    fn -> Series.from_list([[%{a: 1}], [%{a: "a"}]]) end
     end
   end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -34,7 +34,7 @@ defmodule Explorer.SeriesTest do
       s = Series.from_list([1, 2, 3])
 
       assert Series.to_list(s) === [1, 2, 3]
-      assert Series.dtype(s) == :integer
+      assert Series.dtype(s) == {:s, 64}
     end
 
     test "with floats" do
@@ -609,7 +609,7 @@ defmodule Explorer.SeriesTest do
       s1 = Series.from_list([1, 2, nil, 4])
 
       assert_raise ArgumentError,
-                   "fill_missing with :nan values require a float series, got :integer",
+                   "fill_missing with :nan values require a float series, got {:s, 64}",
                    fn -> Series.fill_missing(s1, :nan) end
     end
 
@@ -622,7 +622,7 @@ defmodule Explorer.SeriesTest do
       s1 = Series.from_list([1, 2, nil, 4])
 
       assert_raise ArgumentError,
-                   "fill_missing with :infinity values require a float series, got :integer",
+                   "fill_missing with :infinity values require a float series, got {:s, 64}",
                    fn -> Series.fill_missing(s1, :infinity) end
     end
 
@@ -637,7 +637,7 @@ defmodule Explorer.SeriesTest do
       s1 = Series.from_list([1, 2, nil, 4])
 
       assert_raise ArgumentError,
-                   "fill_missing with :neg_infinity values require a float series, got :integer",
+                   "fill_missing with :neg_infinity values require a float series, got {:s, 64}",
                    fn -> Series.fill_missing(s1, :neg_infinity) end
     end
   end
@@ -1514,7 +1514,7 @@ defmodule Explorer.SeriesTest do
 
       s3 = Series.add(s1, s2)
 
-      assert s3.dtype == :integer
+      assert s3.dtype == {:s, 64}
       assert Series.to_list(s3) == [5, 7, 9]
     end
 
@@ -1533,7 +1533,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.add(s1, -2)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [-1, 0, 1]
     end
 
@@ -1633,7 +1633,7 @@ defmodule Explorer.SeriesTest do
 
       s3 = Series.subtract(s1, s2)
 
-      assert s3.dtype == :integer
+      assert s3.dtype == {:s, 64}
       assert Series.to_list(s3) == [-3, -3, -3]
     end
 
@@ -1652,7 +1652,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.subtract(s1, -2)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [3, 4, 5]
     end
 
@@ -1744,7 +1744,7 @@ defmodule Explorer.SeriesTest do
 
       s3 = Series.multiply(s1, s2)
 
-      assert s3.dtype == :integer
+      assert s3.dtype == {:s, 64}
       assert Series.to_list(s3) == [4, 10, 18]
     end
 
@@ -1763,7 +1763,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.multiply(s1, -2)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [-2, -4, -6]
     end
 
@@ -1772,7 +1772,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.multiply(-2, s1)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [-2, -4, -6]
     end
 
@@ -1968,7 +1968,7 @@ defmodule Explorer.SeriesTest do
 
       s3 = Series.quotient(s1, s2)
 
-      assert s3.dtype == :integer
+      assert s3.dtype == {:s, 64}
       assert Series.to_list(s3) == [5, 5, 7]
     end
 
@@ -1977,7 +1977,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.quotient(s1, -2)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [-5, -5, -7]
     end
 
@@ -1986,7 +1986,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.quotient(101, s1)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [10, 5, 4]
     end
   end
@@ -1998,7 +1998,7 @@ defmodule Explorer.SeriesTest do
 
       s3 = Series.remainder(s1, s2)
 
-      assert s3.dtype == :integer
+      assert s3.dtype == {:s, 64}
       assert Series.to_list(s3) == [0, 1, 1]
     end
 
@@ -2007,7 +2007,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.remainder(s1, -2)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [0, 1, 1]
     end
 
@@ -2016,7 +2016,7 @@ defmodule Explorer.SeriesTest do
 
       s2 = Series.remainder(101, s1)
 
-      assert s2.dtype == :integer
+      assert s2.dtype == {:s, 64}
       assert Series.to_list(s2) == [1, 1, 1]
     end
   end
@@ -2028,7 +2028,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(s1, s2)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [1, 4, 3]
     end
 
@@ -2067,7 +2067,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(s1, s2)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [1, nil, 3]
     end
 
@@ -2077,7 +2077,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(s1, s2)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [1, nil, 3]
     end
 
@@ -2087,7 +2087,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(s1, s2)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [1, nil, 3]
     end
 
@@ -2096,7 +2096,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(s1, 2)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [1, 4, 9]
     end
 
@@ -2158,7 +2158,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(2, s1)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [2, 4, 8]
     end
 
@@ -2175,7 +2175,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(-2, s1)
 
-      assert result.dtype == :integer
+      assert result.dtype == {:s, 64}
       assert Series.to_list(result) == [-2, 4, -8]
     end
 
@@ -3521,7 +3521,7 @@ defmodule Explorer.SeriesTest do
 
       assert Series.size(s3) == 6
       assert Series.to_list(s3) == [1, 2, 3, 4, 5, 6]
-      assert Series.dtype(s3) == :integer
+      assert Series.dtype(s3) == {:s, 64}
     end
 
     test "concat float series" do
@@ -3551,7 +3551,7 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list(["a", "b", "c"])
 
       error_message =
-        "cannot concatenate series with mismatched dtypes: [:integer, :string]. " <>
+        "cannot concatenate series with mismatched dtypes: [{:s, 64}, :string]. " <>
           "First cast the series to the desired dtype."
 
       assert_raise ArgumentError, error_message, fn ->
@@ -4429,7 +4429,7 @@ defmodule Explorer.SeriesTest do
       s1 = Series.from_list([-50, 5, nil, 50])
       clipped1 = Series.clip(s1, 1, 10)
       assert Series.to_list(clipped1) == [1, 5, nil, 10]
-      assert clipped1.dtype == :integer
+      assert clipped1.dtype == {:s, 64}
     end
 
     test "with regular floats" do
@@ -4461,8 +4461,7 @@ defmodule Explorer.SeriesTest do
 
       assert_raise ArgumentError,
                    "Explorer.Series.clip/3 not implemented for dtype :string. " <>
-                     "Valid dtypes are [{:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, :integer, " <>
-                     "{:u, 8}, {:u, 16}, {:u, 32}, {:u, 64}, {:f, 32}, {:f, 64}]",
+                     "Valid dtypes are {:f, 32}, {:f, 64}, {:s, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:u, 8}, {:u, 16}, {:u, 32} and {:u, 64}",
                    fn -> Series.clip(Series.from_list(["a"]), 1, 10) end
     end
   end
@@ -4728,7 +4727,7 @@ defmodule Explorer.SeriesTest do
       series = Series.from_list([1200, 1_234_567, nil])
 
       assert_raise ArgumentError,
-                   "Explorer.Series.replace/3 not implemented for dtype :integer. Valid dtypes are [:string]",
+                   "Explorer.Series.replace/3 not implemented for dtype {:s, 64}. Valid dtype is :string",
                    fn -> Series.replace(series, ",", "") end
     end
 
@@ -5071,7 +5070,7 @@ defmodule Explorer.SeriesTest do
       series = Series.from_list([[-1], [0, 1]])
 
       assert_raise ArgumentError,
-                   "cannot convert series of dtype {:list, :integer} into iovec",
+                   "cannot convert series of dtype {:list, {:s, 64}} into iovec",
                    fn -> Series.to_iovec(series) end
     end
 
@@ -5079,7 +5078,7 @@ defmodule Explorer.SeriesTest do
       series = Series.from_list([%{a: 1}, %{a: 2}])
 
       assert_raise ArgumentError,
-                   ~S'cannot convert series of dtype {:struct, %{"a" => :integer}} into iovec',
+                   ~S'cannot convert series of dtype {:struct, %{"a" => {:s, 64}}} into iovec',
                    fn -> Series.to_iovec(series) end
     end
   end
@@ -5092,7 +5091,7 @@ defmodule Explorer.SeriesTest do
           :integer
         )
 
-      assert series.dtype == :integer
+      assert series.dtype == {:s, 64}
       assert Series.to_list(series) == [-1, 0, 1]
     end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4432,6 +4432,13 @@ defmodule Explorer.SeriesTest do
       assert clipped1.dtype == {:s, 64}
     end
 
+    test "with unsigned integers" do
+      s1 = Series.from_list([1, 5, nil, 50], dtype: :u16)
+      clipped1 = Series.clip(s1, 3, 10)
+      assert Series.to_list(clipped1) == [3, 5, nil, 10]
+      assert clipped1.dtype == {:u, 16}
+    end
+
     test "with regular floats" do
       s2 = Series.from_list([-50, 5, nil, 50])
       clipped2 = Series.clip(s2, 1.5, 10.5)


### PR DESCRIPTION
This PR is a followup of https://github.com/elixir-explorer/explorer/pull/769.

The main goal of this PR is to "rename" the main integer dtype to `{:s, 64}` and introduce the other signed and unsigned dtypes.

There is still a big work to do regarding making the operations compatible when using different types of series.
My idea is to add support for it in smaller PRs.