### PR TITLE
Improve documentation about encoding option

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -543,6 +543,9 @@ defmodule Explorer.DataFrame do
 
     * `:lazy` - force the results into the lazy version of the current backend.
 
+    * `:encoding` - Encoding to use when reading the file. For now, the only possible values are `utf8` and `utf8-lossy`.
+      The utf8-lossy option means that invalid utf8 values are replaced with � characters. (default: `"utf8"`)
+
   """
   @doc type: :io
   @spec from_csv(filename :: String.t() | fs_entry(), opts :: Keyword.t()) ::
@@ -627,6 +630,7 @@ defmodule Explorer.DataFrame do
     * `:eol_delimiter` - A single character used to represent new lines. (default: `"\n"`)
     * `:backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
     * `:lazy` - force the results into the lazy version of the current backend.
+    * `:encoding` - Encoding to use when reading the file. For now, the only possible values are `utf8` and `utf8-lossy`. The utf8-lossy option means that invalid utf8 values are replaced with � characters. (default: `"utf8"`)
   """
   @doc type: :io
   @spec load_csv(contents :: String.t(), opts :: Keyword.t()) ::

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -630,7 +630,9 @@ defmodule Explorer.DataFrame do
     * `:eol_delimiter` - A single character used to represent new lines. (default: `"\n"`)
     * `:backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
     * `:lazy` - force the results into the lazy version of the current backend.
-    * `:encoding` - Encoding to use when reading the file. For now, the only possible values are `utf8` and `utf8-lossy`. The utf8-lossy option means that invalid utf8 values are replaced with � characters. (default: `"utf8"`)
+    * `:encoding` - Encoding to use when reading the file. For now, the only possible values are
+      `utf8` and `utf8-lossy`. The utf8-lossy option means that invalid utf8 values are
+      replaced with � characters. (default: `"utf8"`)
   """
   @doc type: :io
   @spec load_csv(contents :: String.t(), opts :: Keyword.t()) ::


### PR DESCRIPTION
This PR resolves https://github.com/elixir-explorer/explorer/issues/791

After this PR:

DataFrame.from_csv/2:

<img width="647" alt="image" src="https://github.com/elixir-explorer/explorer/assets/44319738/5f653b3e-2337-4a54-adce-9b0d8118294a">

DataFrame.load_csv/2:

<img width="614" alt="image" src="https://github.com/elixir-explorer/explorer/assets/44319738/f24bbfd8-a380-4c30-8cf5-4a4286a59b92">


