### PR TITLE
Fix `Series.from_tensor/2` to use new integer types

### DIFF
--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -510,10 +510,9 @@ defmodule Explorer.Shared do
   """
   def iotype_to_dtype!(type) do
     case type do
-      {:f, _} -> type
-      {:s, 64} -> {:s, 64}
-      {:u, 8} -> :boolean
-      {:s, 32} -> :date
+      {:f, n} when n in [32, 64] -> type
+      {:s, n} when n in [8, 16, 32, 64] -> type
+      {:u, n} when n in [8, 16, 32, 64] -> type
       _ -> raise ArgumentError, "cannot convert binary/tensor type #{inspect(type)} into dtype"
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3310,10 +3310,6 @@ defmodule Explorer.DataFrameTest do
       assert_raise ArgumentError,
                    "cannot convert dtype string into a binary/tensor type",
                    fn -> DF.put(df, :c, i) end
-
-      assert_raise ArgumentError,
-                   "cannot convert binary/tensor type {:u, 32} into dtype",
-                   fn -> DF.put(df, :e, Nx.tensor([1, 2, 3], type: {:u, 32})) end
     end
   end
 


### PR DESCRIPTION
This makes the function stop infering the target series dtype and make it suppport all the new integer signed and unsigned dtypes.

If people want to read a given tensor in a different type, they must pass the `:dtype` option.

Related to https://github.com/elixir-explorer/explorer/issues/794