### PR TITLE
docs - add :lazy option to DataFrame.new/2

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1642,6 +1642,7 @@ defmodule Explorer.DataFrame do
 
     * `:backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
     * `:dtypes` - A list/map of `{column_name, dtype}` pairs. (default: `[]`)
+    * `:lazy` - force the results into the lazy version of the current backend.
 
   ## Examples
 


### PR DESCRIPTION
Missing :lazy option in DataFrame.new() docs.