### PR TITLE
docs - categorize deprecated functions

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1615,7 +1615,7 @@ defmodule Explorer.DataFrame do
   def lazy(df), do: Shared.apply_impl(df, :lazy)
 
   @deprecated "Use lazy/1 instead"
-  @doc type: :conversion
+  @doc type: :deprecated
   def to_lazy(df), do: Shared.apply_impl(df, :lazy)
 
   @doc """
@@ -3162,7 +3162,7 @@ defmodule Explorer.DataFrame do
   end
 
   @deprecated "Use sort_by/3 instead"
-  @doc type: :single
+  @doc type: :deprecated
   defmacro arrange(df, query, opts \\ []) do
     quote do
       Explorer.DataFrame.sort_by(unquote(df), unquote(query), unquote(opts))
@@ -3288,7 +3288,7 @@ defmodule Explorer.DataFrame do
   end
 
   @deprecated "Use sort_with/3 instead"
-  @doc type: :single
+  @doc type: :deprecated
   def arrange_with(df, fun, opts \\ []), do: sort_with(df, fun, opts)
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -5838,6 +5838,7 @@ defmodule Explorer.Series do
     do: dtype_error("week_of_year/1", dtype, @date_or_datetime_dtypes)
 
   @deprecated "Use cast(:date) instead"
+  @doc type: :deprecated
   def to_date(%Series{dtype: dtype} = series) when K.in(dtype, @datetime_dtypes),
     do: cast(series, :date)
 
@@ -5845,6 +5846,7 @@ defmodule Explorer.Series do
     do: dtype_error("to_date/1", dtype, @datetime_dtypes)
 
   @deprecated "Use cast(:time) instead"
+  @doc type: :deprecated
   def to_time(%Series{dtype: dtype} = series) when K.in(dtype, @datetime_dtypes),
     do: cast(series, :time)
 

--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,8 @@ defmodule Explorer.MixProject do
         "Functions: Introspection": &(&1[:type] == :introspection),
         "Functions: IO": &(&1[:type] == :io),
         "Functions: Shape": &(&1[:type] == :shape),
-        "Functions: Window": &(&1[:type] == :window)
+        "Functions: Window": &(&1[:type] == :window),
+        "Functions: Deprecated": &(&1[:type] == :deprecated)
       ],
       extras: ["notebooks/exploring_explorer.livemd", "CHANGELOG.md"],
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"]


### PR DESCRIPTION
Create a new category for grouping deprecated functions in docs