### PR TITLE
add nil expr for summarise and mutate - Py Polars `lit(None)`

### DIFF
--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -307,6 +307,7 @@ defmodule Explorer.PolarsBackend.Expression do
     end
   end
 
+  def to_expr(nil), do: Native.expr_nil()
   def to_expr(bool) when is_boolean(bool), do: Native.expr_boolean(bool)
   def to_expr(atom) when is_atom(atom), do: Native.expr_atom(Atom.to_string(atom))
   def to_expr(binary) when is_binary(binary), do: Native.expr_string(binary)

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -200,6 +200,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   # Then we generate for some specific expressions
   def expr_alias(_ex_expr, _alias_name), do: err()
+  def expr_nil(), do: err()
   def expr_atom(_atom), do: err()
   def expr_boolean(_bool), do: err()
   def expr_date(_date), do: err()

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -25,6 +25,12 @@ pub fn ex_expr_to_exprs(ex_exprs: Vec<ExExpr>) -> Vec<Expr> {
 }
 
 #[rustler::nif]
+pub fn expr_nil() -> ExExpr {
+    let expr = Expr::Literal(LiteralValue::Null);
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
 pub fn expr_integer(number: i64) -> ExExpr {
     let expr = number.lit();
     ExExpr::new(expr)

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -140,6 +140,7 @@ rustler::init!(
         df_unnest,
         df_width,
         // expressions
+        expr_nil,
         expr_atom,
         expr_boolean,
         expr_cast,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -663,6 +663,16 @@ defmodule Explorer.DataFrameTest do
   end
 
   describe "mutate/2" do
+    test "with nil" do
+      df = DF.new(strs: ["a", "b", "c"], nums: [1, 2, 3])
+      assert DF.mutate(df, c: nil) |> inspect() == ~s(#Explorer.DataFrame<
+  Polars[3 x 3]
+  strs string ["a", "b", "c"]
+  nums s64 [1, 2, 3]
+  c null [nil, nil, nil]
+>)
+    end
+
     test "adds new columns" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
@@ -3527,6 +3537,14 @@ defmodule Explorer.DataFrameTest do
   end
 
   describe "summarise/2" do
+    test "summarise with nil" do
+      df = DF.new(strs: ["a", "b", "c"], nums: [1, 2, 3])
+      assert DF.summarise(df, c: nil) |> inspect() == ~s(#Explorer.DataFrame<
+  Polars[1 x 1]
+  c null [nil]
+>)
+    end
+
     test "one column with aggregation and without groups", %{df: df} do
       df1 =
         DF.summarise(df,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -665,12 +665,15 @@ defmodule Explorer.DataFrameTest do
   describe "mutate/2" do
     test "with nil" do
       df = DF.new(strs: ["a", "b", "c"], nums: [1, 2, 3])
-      assert DF.mutate(df, c: nil) |> inspect() == ~s(#Explorer.DataFrame<
-  Polars[3 x 3]
-  strs string ["a", "b", "c"]
-  nums s64 [1, 2, 3]
-  c null [nil, nil, nil]
->)
+      df1 = DF.mutate(df, c: nil)
+      assert df1.names == ["strs", "nums", "c"]
+      assert df1.dtypes == %{"strs" => :string, "nums" => {:s, 64}, "c" => :null}
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               strs: ["a", "b", "c"],
+               nums: [1, 2, 3],
+               c: [nil, nil, nil]
+             }
     end
 
     test "adds new columns" do
@@ -3539,10 +3542,9 @@ defmodule Explorer.DataFrameTest do
   describe "summarise/2" do
     test "summarise with nil" do
       df = DF.new(strs: ["a", "b", "c"], nums: [1, 2, 3])
-      assert DF.summarise(df, c: nil) |> inspect() == ~s(#Explorer.DataFrame<
-  Polars[1 x 1]
-  c null [nil]
->)
+      df1 = DF.summarise(df, c: nil)
+      assert DF.dtypes(df1) == %{"c" => :null}
+      assert DF.to_columns(df1, atom_keys: true) == %{c: [nil]}
     end
 
     test "one column with aggregation and without groups", %{df: df} do


### PR DESCRIPTION
This PR add `lit(None)`.  Can be used to align `describe` with Py Polars. 

```elixir
df = DF.new(strs: ["a", "b", "c"], nums: [1, 2, 3])
DF.mutate(df, c: nil)
#Explorer.DataFrame<
  Polars[3 x 3]
  strs string ["a", "b", "c"]
  nums s64 [1, 2, 3]
  c null [nil, nil, nil]
>
DF.summarise(df, c: nil)
#Explorer.DataFrame<
  Polars[1 x 1]
  c null [nil]
>
```

I will add test cases after review. 

