### PR TITLE
align describe with py polars

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5628,9 +5628,9 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[9 x 4]
         describe string ["count", "nil_count", "mean", "std", "min", ...]
-        a string ["2", "1", "", "", "", ...]
+        a string ["2", "1", nil, nil, nil, ...]
         b f64 [3.0, 0.0, 2.0, 1.0, 1.0, ...]
-        c string ["3", "0", "", "", "", ...]
+        c string ["3", "0", nil, nil, nil, ...]
       >
 
       iex> df = Explorer.DataFrame.new(a: ["d", nil, "f"], b: [1, 2, 3], c: ["a", "b", "c"])
@@ -5638,9 +5638,9 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[9 x 4]
         describe string ["count", "nil_count", "mean", "std", "min", ...]
-        a string ["2", "1", "", "", "", ...]
+        a string ["2", "1", nil, nil, nil, ...]
         b f64 [3.0, 0.0, 2.0, 1.0, 1.0, ...]
-        c string ["3", "0", "", "", "", ...]
+        c string ["3", "0", nil, nil, nil, ...]
       >
   """
   @doc type: :single
@@ -5663,7 +5663,7 @@ defmodule Explorer.DataFrame do
         Enum.flat_map(stat_cols, fn c ->
           dt = x[c].dtype
           numeric? = dt in numeric_types
-          min_max? = numeric? || dt in datetime_types || dt in duration_types
+          min_max? = numeric? or dt in datetime_types or dt in duration_types
 
           [
             {"count:#{c}", Series.count(x[c])},
@@ -5692,7 +5692,7 @@ defmodule Explorer.DataFrame do
         if df.dtypes[col] in numeric_types do
           {col, Enum.map(metrics, &metrics_row[&1])}
         else
-          {col, Enum.map(metrics, &"#{metrics_row[&1]}")}
+          {col, Enum.map(metrics, &(metrics_row[&1] && "#{metrics_row[&1]}"))}
         end
       end)
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5626,17 +5626,21 @@ defmodule Explorer.DataFrame do
       iex> df = Explorer.DataFrame.new(a: ["d", nil, "f"], b: [1, 2, 3], c: ["a", "b", "c"])
       iex> Explorer.DataFrame.describe(df)
       #Explorer.DataFrame<
-        Polars[9 x 2]
+        Polars[9 x 4]
         describe string ["count", "nil_count", "mean", "std", "min", ...]
+        a string ["2", "1", "", "", "", ...]
         b f64 [3.0, 0.0, 2.0, 1.0, 1.0, ...]
+        c string ["3", "0", "", "", "", ...]
       >
 
       iex> df = Explorer.DataFrame.new(a: ["d", nil, "f"], b: [1, 2, 3], c: ["a", "b", "c"])
       iex> Explorer.DataFrame.describe(df, percentiles: [0.3, 0.5, 0.8])
       #Explorer.DataFrame<
-        Polars[9 x 2]
+        Polars[9 x 4]
         describe string ["count", "nil_count", "mean", "std", "min", ...]
+        a string ["2", "1", "", "", "", ...]
         b f64 [3.0, 0.0, 2.0, 1.0, 1.0, ...]
+        c string ["3", "0", "", "", "", ...]
       >
   """
   @doc type: :single
@@ -5648,23 +5652,30 @@ defmodule Explorer.DataFrame do
       raise ArgumentError, "cannot describe a DataFrame without any columns"
     end
 
-    stat_cols = for {name, type} <- df.dtypes, type in Shared.numeric_types(), do: name
+    stat_cols = df.names
     percentiles = process_percentiles(opts[:percentiles])
+    numeric_types = Shared.numeric_types()
+    datetime_types = Shared.datetime_types()
+    duration_types = Shared.duration_types()
 
     metrics_df =
       summarise_with(df, fn x ->
         Enum.flat_map(stat_cols, fn c ->
+          dt = x[c].dtype
+          numeric? = dt in numeric_types
+          min_max? = numeric? || dt in datetime_types || dt in duration_types
+
           [
             {"count:#{c}", Series.count(x[c])},
             {"nil_count:#{c}", Series.nil_count(x[c])},
-            {"mean:#{c}", Series.mean(x[c])},
-            {"std:#{c}", Series.standard_deviation(x[c])},
-            {"min:#{c}", Series.min(x[c])}
+            {"mean:#{c}", if(numeric?, do: Series.mean(x[c]))},
+            {"std:#{c}", if(numeric?, do: Series.standard_deviation(x[c]))},
+            {"min:#{c}", if(min_max?, do: Series.min(x[c]))}
           ] ++
             for p <- percentiles do
-              {"#{trunc(p * 100)}%:#{c}", Series.quantile(x[c], p)}
+              {"#{trunc(p * 100)}%:#{c}", if(numeric?, do: Series.quantile(x[c], p))}
             end ++
-            [{"max:#{c}", Series.max(x[c])}]
+            [{"max:#{c}", if(min_max?, do: Series.max(x[c]))}]
         end)
       end)
 
@@ -5678,7 +5689,11 @@ defmodule Explorer.DataFrame do
       metrics_df.names
       |> Enum.chunk_every(length(metrics))
       |> Enum.zip_with(stat_cols, fn metrics, col ->
-        {col, Enum.map(metrics, &metrics_row[&1])}
+        if df.dtypes[col] in numeric_types do
+          {col, Enum.map(metrics, &metrics_row[&1])}
+        else
+          {col, Enum.map(metrics, &"#{metrics_row[&1]}")}
+        end
       end)
 
     new([{"describe", metrics} | data])

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3334,12 +3334,14 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.describe(df)
 
       assert df1.dtypes == %{
+               "a" => :string,
                "b" => {:f, 64},
                "c" => {:f, 64},
                "describe" => :string
              }
 
       assert DF.to_columns(df1, atom_keys: true) == %{
+               a: ["2", "1", "", "", "", "", "", "", ""],
                b: [3.0, 0.0, 2.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
                c: [3.0, 0.0, 20.0, 10.0, 10.0, 20.0, 20.0, 30.0, 30.0],
                describe: ["count", "nil_count", "mean", "std", "min", "25%", "50%", "75%", "max"]
@@ -3374,6 +3376,56 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df1, atom_keys: true) == %{
                b: [3.0, 0.0, 2.0, 1.0, 1.0, 3.0],
                describe: ["count", "nil_count", "mean", "std", "min", "max"]
+             }
+    end
+
+    test "describe columns - max, min columns" do
+      df =
+        DF.new(
+          number: [1, 2, nil, 3],
+          list: [[], [], [], []],
+          null: [nil, nil, nil, nil],
+          string: ["a", "b", "c", "nil"],
+          date: [~D[2021-01-01], ~D[1999-12-31], nil, ~D[2023-01-01]],
+          time: [~T[00:02:03.000212], ~T[00:05:04.000456], ~T[00:07:04.000776], nil],
+          datetime: [
+            nil,
+            ~N[2021-01-01 00:00:00],
+            ~N[1999-12-31 00:00:00],
+            ~N[2023-12-13 17:38:00]
+          ],
+          duration: [
+            nil,
+            ~N[2020-01-01 00:00:00],
+            ~N[1999-11-30 00:00:00],
+            ~N[2023-12-12 17:38:00]
+          ]
+        )
+
+      df = DF.mutate(df, duration: datetime - duration)
+      describe_df = DF.describe(df)
+
+      assert df.dtypes == %{
+               "date" => :date,
+               "datetime" => {:datetime, :microsecond},
+               "duration" => {:duration, :microsecond},
+               "list" => {:list, :null},
+               "null" => :null,
+               "number" => {:s, 64},
+               "string" => :string,
+               "time" => :time
+             }
+
+      assert describe_df.dtypes == %{
+               "date" => :string,
+               "datetime" => :string,
+               "describe" => :string,
+               "duration" => :string,
+               "list" => :string,
+               "null" => :string,
+               "number" => {:f, 64},
+               "string" => :string,
+               "time" => :string
              }
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3341,7 +3341,7 @@ defmodule Explorer.DataFrameTest do
              }
 
       assert DF.to_columns(df1, atom_keys: true) == %{
-               a: ["2", "1", "", "", "", "", "", "", ""],
+               a: ["2", "1", nil, nil, nil, nil, nil, nil, nil],
                b: [3.0, 0.0, 2.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
                c: [3.0, 0.0, 20.0, 10.0, 10.0, 20.0, 20.0, 30.0, 30.0],
                describe: ["count", "nil_count", "mean", "std", "min", "25%", "50%", "75%", "max"]
@@ -3426,6 +3426,28 @@ defmodule Explorer.DataFrameTest do
                "number" => {:f, 64},
                "string" => :string,
                "time" => :string
+             }
+
+      assert DF.to_columns(describe_df, atom_keys: true) == %{
+               date: ["3", "1", nil, nil, nil, nil, nil, nil, nil],
+               datetime: [
+                 "3",
+                 "1",
+                 nil,
+                 nil,
+                 "1999-12-31 00:00:00.000000",
+                 nil,
+                 nil,
+                 nil,
+                 "2023-12-13 17:38:00.000000"
+               ],
+               describe: ["count", "nil_count", "mean", "std", "min", "25%", "50%", "75%", "max"],
+               duration: ["3", "1", nil, nil, "1d", nil, nil, nil, "366d"],
+               list: ["4", "0", nil, nil, nil, nil, nil, nil, nil],
+               null: ["0", "4", nil, nil, nil, nil, nil, nil, nil],
+               number: [3.0, 1.0, 2.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
+               string: ["4", "0", nil, nil, nil, nil, nil, nil, nil],
+               time: ["3", "1", nil, nil, nil, nil, nil, nil, nil]
              }
     end
   end


### PR DESCRIPTION
use nil expression to generate output similar to Py Polars describe

```elixir
df =
  DF.new(
    number: [1, 2, nil, 3],
    list: [[], [], [], []],
    null: [nil, nil, nil, nil],
    string: ["a", "b", "c", "nil"],
    date: [~D[2021-01-01], ~D[1999-12-31], nil, ~D[2023-01-01]],
    time: [~T[00:02:03.000212], ~T[00:05:04.000456], ~T[00:07:04.000776], nil],
    datetime: [nil, ~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00], ~N[2023-12-13 17:38:00]],
    duration: [nil, ~N[2020-01-01 00:00:00], ~N[1999-11-30 00:00:00], ~N[2023-12-12 17:38:00]]
  )

df = DF.mutate(df, duration: datetime - duration)
DF.print(df)
+------------------------------------------------------------------------------------------------------------------------+
|                                       Explorer DataFrame: [rows: 4, columns: 8]                                        |
+--------+--------------+--------+----------+------------+-----------------+----------------------------+----------------+
| number |     list     |  null  |  string  |    date    |      time       |          datetime          |    duration    |
| <s64>  | <list[null]> | <null> | <string> |   <date>   |     <time>      |       <datetime[μs]>       | <duration[μs]> |
+========+==============+========+==========+============+=================+============================+================+
| 1      |              |        | a        | 2021-01-01 | 00:02:03.000212 |                            |                |
+--------+--------------+--------+----------+------------+-----------------+----------------------------+----------------+
| 2      |              |        | b        | 1999-12-31 | 00:05:04.000456 | 2021-01-01 00:00:00.000000 | 366d           |
+--------+--------------+--------+----------+------------+-----------------+----------------------------+----------------+
|        |              |        | c        |            | 00:07:04.000776 | 1999-12-31 00:00:00.000000 | 31d            |
+--------+--------------+--------+----------+------------+-----------------+----------------------------+----------------+
| 3      |              |        | nil      | 2023-01-01 |                 | 2023-12-13 17:38:00.000000 | 1d             |
+--------+--------------+--------+----------+------------+-----------------+----------------------------+----------------+


df = df |> DF.describe() |> DF.print(limit: 9)

+-------------------------------------------------------------------------------------------------------------------+
|                                     Explorer DataFrame: [rows: 9, columns: 9]                                     |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| describe  | number |   list   |   null   |  string  |   date   |   time   |          datetime          | duration |
| <string>  | <f64>  | <string> | <string> | <string> | <string> | <string> |          <string>          | <string> |
+===========+========+==========+==========+==========+==========+==========+============================+==========+
| count     | 3.0    | 4        | 0        | 4        | 3        | 3        | 3                          | 3        |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| nil_count | 1.0    | 0        | 4        | 0        | 1        | 1        | 1                          | 1        |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| mean      | 2.0    |          |          |          |          |          |                            |          |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| std       | 1.0    |          |          |          |          |          |                            |          |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| min       | 1.0    |          |          |          |          |          | 1999-12-31 00:00:00.000000 | 1d       |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| 25%       | 2.0    |          |          |          |          |          |                            |          |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| 50%       | 2.0    |          |          |          |          |          |                            |          |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| 75%       | 3.0    |          |          |          |          |          |                            |          |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+
| max       | 3.0    |          |          |          |          |          | 2023-12-13 17:38:00.000000 | 366d     |
+-----------+--------+----------+----------+----------+----------+----------+----------------------------+----------+


```