### PR TITLE
add DataFrame.transpose/2

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -201,6 +201,12 @@ defmodule Explorer.Backend.DataFrame do
               names_to :: column_name(),
               values_to :: column_name()
             ) :: df
+  @callback transpose(
+              df,
+              out_df :: df(),
+              keep_names_as :: column_name(),
+              new_column_names :: [column_name()]
+            ) :: df
   @callback put(df, out_df :: df(), column_name(), series()) :: df
   @callback nil_count(df) :: df()
   @callback explode(df, out_df :: df(), columns :: [column_name()]) :: df()

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4253,7 +4253,6 @@ defmodule Explorer.DataFrame do
     header =
       case opts[:header] do
         false -> false
-        nil -> nil
         true -> "column"
         header -> to_column_name(header)
       end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -777,6 +777,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
+  def transpose(df, out_df, keep_names_as, new_col_names) do
+    Shared.apply_dataframe(df, out_df, :df_transpose, [keep_names_as, new_col_names])
+  end
+
+  @impl true
   def explode(df, out_df, columns) do
     Shared.apply_dataframe(df, out_df, :df_explode, [columns])
   end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -523,7 +523,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     to_ipc_stream: 3,
     to_ndjson: 2,
     to_rows: 2,
-    to_rows_stream: 3
+    to_rows_stream: 3,
+    transpose: 4
   ]
 
   for {fun, arity} <- not_available_funs do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -165,6 +165,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_slice_by_series(_df, _series, _groups), do: err()
   def df_summarise_with_exprs(_df, _groups_exprs, _aggs_pairs), do: err()
   def df_tail(_df, _length, _groups), do: err()
+  def df_transpose(_df, _keep_names_as, _new_col_names), do: err()
   def df_to_csv(_df, _filename, _has_headers, _delimiter), do: err()
   def df_to_csv_cloud(_df, _ex_entry, _has_headers, _delimiter), do: err()
   def df_to_dummies(_df, _columns), do: err()

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -419,6 +419,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "either",
  "mimalloc",
  "object_store",
  "polars",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,6 +19,7 @@ rand_pcg = "0.3"
 rustler = { version = "0.29", default-features = false, features = ["derive"] }
 thiserror = "1"
 smartstring = "1"
+either = "1"
 
 # Deps necessary for cloud features.
 tokio = { version = "1.35", default-features = false, features = [

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -9,6 +9,7 @@ use std::result::Result;
 use crate::datatypes::ExSeriesDtype;
 use crate::ex_expr_to_exprs;
 use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExSeries, ExplorerError};
+use either::Either;
 use smartstring::alias::String as SmartString;
 
 // Loads the IO functions for read/writing CSV, NDJSON, Parquet, etc.
@@ -20,6 +21,17 @@ fn to_string_names(names: Vec<&str>) -> Vec<String> {
 
 pub fn to_smart_strings(slices: Vec<&str>) -> Vec<SmartString> {
     slices.into_iter().map(|s| s.into()).collect()
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn df_transpose(
+    df: ExDataFrame,
+    keep_names_as: Option<&str>,
+    new_col_names: Option<Vec<String>>,
+) -> Result<ExDataFrame, ExplorerError> {
+    let column_names = new_col_names.map(Either::Right);
+    let new_df = df.clone_inner().transpose(keep_names_as, column_names)?;
+    Ok(ExDataFrame::new(new_df))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -125,6 +125,7 @@ rustler::init!(
         df_slice_by_series,
         df_summarise_with_exprs,
         df_tail,
+        df_transpose,
         df_to_csv,
         df_to_csv_cloud,
         df_to_dummies,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2740,7 +2740,7 @@ defmodule Explorer.DataFrameTest do
 
     test "header column without name " do
       df = Explorer.DataFrame.new(a: [32.0, 33.0], b: [1, 2], c: ["a", "b"])
-      dft = DF.transpose(df, include_header: true)
+      dft = DF.transpose(df, header: true)
       assert DF.shape(df) == {2, 3}
       assert DF.shape(dft) == {3, 3}
       assert df.dtypes == %{"a" => {:f, 64}, "b" => {:s, 64}, "c" => :string}
@@ -2755,7 +2755,7 @@ defmodule Explorer.DataFrameTest do
 
     test "header column with name " do
       df = Explorer.DataFrame.new(a: [32.0, 33.0], b: [1, 2], c: ["a", "b"])
-      dft = DF.transpose(df, include_header: true, header_name: "name")
+      dft = DF.transpose(df, header: "name")
       assert DF.shape(df) == {2, 3}
       assert DF.shape(dft) == {3, 3}
       assert df.dtypes == %{"a" => {:f, 64}, "b" => {:s, 64}, "c" => :string}
@@ -2770,7 +2770,7 @@ defmodule Explorer.DataFrameTest do
 
     test "with column names" do
       df = Explorer.DataFrame.new(a: [32.0, 33.0], b: [1, 2], c: ["a", "b"])
-      dft = DF.transpose(df, include_header: true, header_name: "name", column_names: ["x", "y"])
+      dft = DF.transpose(df, header: "name", columns: ["x", "y"])
       assert DF.shape(df) == {2, 3}
       assert DF.shape(dft) == {3, 3}
       assert df.dtypes == %{"a" => {:f, 64}, "b" => {:s, 64}, "c" => :string}
@@ -2791,9 +2791,8 @@ defmodule Explorer.DataFrameTest do
                    "Polars Error: lengths don't match: Length of new column names must be the same as the row count",
                    fn ->
                      DF.transpose(df,
-                       include_header: true,
-                       header_name: "name",
-                       column_names: ["x"]
+                       header: "name",
+                       columns: ["x"]
                      )
                    end
     end


### PR DESCRIPTION
```elixir
df = Explorer.DataFrame.new(a: [32.0, 33.0], b: [1, 2], c: ["a", "b"])
DF.print(df)
dft = DF.transpose(df, include_header: true, header_name: "names", column_names: ["x", "y"]) #, 

+--------------------------------------------+
| Explorer DataFrame: [rows: 3, columns: 3]  |
+--------------+--------------+--------------+
|    names     |      x       |      y       |
|   <string>   |   <string>   |   <string>   |
+==============+==============+==============+
| a            | 32.0         | 33.0         |
+--------------+--------------+--------------+
| b            | 1            | 2            |
+--------------+--------------+--------------+
| c            | a            | b            |
+--------------+--------------+--------------+


```