### PR TITLE
Fix mismatched types in `Series.pow`

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -146,8 +146,8 @@ defmodule Explorer.Backend.LazySeries do
 
   @comparison_operations [:equal, :not_equal, :greater, :greater_equal, :less, :less_equal]
 
-  @basic_arithmetic_operations [:add, :subtract, :multiply, :divide]
-  @other_arithmetic_operations [:pow, :quotient, :remainder]
+  @basic_arithmetic_operations [:add, :subtract, :multiply, :divide, :pow]
+  @other_arithmetic_operations [:quotient, :remainder]
 
   @aggregation_operations [
     :sum,

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -114,7 +114,7 @@ defmodule Explorer.Backend.Series do
   @callback divide(out_dtype :: dtype(), s, s) :: s
   @callback quotient(s, s) :: s
   @callback remainder(s, s) :: s
-  @callback pow(s, s) :: s
+  @callback pow(out_dtype :: dtype(), s, s) :: s
   @callback log(argument :: s) :: s
   @callback log(argument :: s, base :: float()) :: s
   @callback exp(s) :: s

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2747,7 +2747,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["a", "b", "c"]
-        b s64 [1, 4, 9]
+        b f64 [1.0, 4.0, 9.0]
       >
 
   It's possible to "reuse" a variable for different computations:

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2747,7 +2747,7 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[3 x 2]
         a string ["a", "b", "c"]
-        b f64 [1.0, 4.0, 9.0]
+        b s64 [1, 4, 9]
       >
 
   It's possible to "reuse" a variable for different computations:

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -373,7 +373,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_peak_max(_s), do: err()
   def s_peak_min(_s), do: err()
   def s_select(_pred, _on_true, _on_false), do: err()
-  def s_pow(_s, _other), do: err()
+  def s_pow(_s, _s_dtype, _other, _other_dtype), do: err()
   def s_log_natural(_s_argument), do: err()
   def s_log(_s_argument, _base_as_float), do: err()
   def s_quantile(_s, _quantile, _strategy), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -373,7 +373,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_peak_max(_s), do: err()
   def s_peak_min(_s), do: err()
   def s_select(_pred, _on_true, _on_false), do: err()
-  def s_pow(_s, _s_dtype, _other, _other_dtype), do: err()
+  def s_pow(_s, _other), do: err()
   def s_log_natural(_s_argument), do: err()
   def s_log(_s_argument, _base_as_float), do: err()
   def s_quantile(_s, _quantile, _strategy), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -373,7 +373,6 @@ defmodule Explorer.PolarsBackend.Native do
   def s_peak_max(_s), do: err()
   def s_peak_min(_s), do: err()
   def s_select(_pred, _on_true, _on_false), do: err()
-  def s_pow(_s, _other), do: err()
   def s_log_natural(_s_argument), do: err()
   def s_log(_s_argument, _base_as_float), do: err()
   def s_quantile(_s, _quantile, _strategy), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -314,12 +314,7 @@ defmodule Explorer.PolarsBackend.Series do
 
   @impl true
   def pow(left, right),
-    do:
-      Shared.apply_series(matching_size!(left, right), :s_pow, [
-        left.dtype,
-        right.data,
-        right.dtype
-      ])
+    do: Shared.apply_series(matching_size!(left, right), :s_pow, [right.data])
 
   @impl true
   def log(%Series{} = argument), do: Shared.apply_series(argument, :s_log_natural, [])

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -313,8 +313,24 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(matching_size!(left, right), :s_remainder, [right.data])
 
   @impl true
-  def pow(left, right),
-    do: Shared.apply_series(matching_size!(left, right), :s_pow, [right.data])
+  def pow(left, right) do
+    _ = matching_size!(left, right)
+    left_lazy = Explorer.Backend.LazySeries.new(:column, ["base"], left.dtype)
+    right_lazy = Explorer.Backend.LazySeries.new(:column, ["exponent"], right.dtype)
+
+    {df_args, pow_args} =
+      case {size(left), size(right)} do
+        {n, n} -> {[{"base", left}, {"exponent", right}], [left_lazy, right_lazy]}
+        {1, _} -> {[{"exponent", right}], [Explorer.Series.at(left, 0), right_lazy]}
+        {_, 1} -> {[{"base", left}], [left_lazy, Explorer.Series.at(right, 0)]}
+      end
+
+    df = Explorer.PolarsBackend.DataFrame.from_series(df_args)
+    pow = Explorer.Backend.LazySeries.new(:pow, pow_args, nil)
+
+    Explorer.PolarsBackend.DataFrame.mutate_with(df, df, [{"pow", pow}])
+    |> Explorer.PolarsBackend.DataFrame.pull("pow")
+  end
 
   @impl true
   def log(%Series{} = argument), do: Shared.apply_series(argument, :s_log_natural, [])

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -314,7 +314,12 @@ defmodule Explorer.PolarsBackend.Series do
 
   @impl true
   def pow(left, right),
-    do: Shared.apply_series(matching_size!(left, right), :s_pow, [right.data])
+    do:
+      Shared.apply_series(matching_size!(left, right), :s_pow, [
+        left.dtype,
+        right.data,
+        right.dtype
+      ])
 
   @impl true
   def log(%Series{} = argument), do: Shared.apply_series(argument, :s_log_natural, [])

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -318,6 +318,10 @@ defmodule Explorer.PolarsBackend.Series do
   @impl true
   def pow(out_dtype, left, right) do
     _ = matching_size!(left, right)
+
+    # We need to pre-cast or we may lose precision.
+    left = Explorer.Series.cast(left, out_dtype)
+
     left_lazy = Explorer.Backend.LazySeries.new(:column, ["base"], left.dtype)
     right_lazy = Explorer.Backend.LazySeries.new(:column, ["exponent"], right.dtype)
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -313,7 +313,7 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(matching_size!(left, right), :s_remainder, [right.data])
 
   @impl true
-  def pow(left, right) do
+  def pow(out_dtype, left, right) do
     _ = matching_size!(left, right)
     left_lazy = Explorer.Backend.LazySeries.new(:column, ["base"], left.dtype)
     right_lazy = Explorer.Backend.LazySeries.new(:column, ["exponent"], right.dtype)
@@ -326,7 +326,7 @@ defmodule Explorer.PolarsBackend.Series do
       end
 
     df = Explorer.PolarsBackend.DataFrame.from_series(df_args)
-    pow = Explorer.Backend.LazySeries.new(:pow, pow_args, nil)
+    pow = Explorer.Backend.LazySeries.new(:pow, pow_args, out_dtype)
 
     Explorer.PolarsBackend.DataFrame.mutate_with(df, df, [{"pow", pow}])
     |> Explorer.PolarsBackend.DataFrame.pull("pow")

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3772,8 +3772,6 @@ defmodule Explorer.Series do
   def atan(%Series{dtype: dtype}),
     do: dtype_error("atan/1", dtype, [{:f, 32}, {:f, 64}])
 
-  defp basic_numeric_operation(operation, left, right, args \\ [])
-
   defp basic_numeric_operation(operation, %Series{} = left, right, args) when is_numeric(right),
     do: basic_numeric_operation(operation, left, from_same_value(left, right), args)
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3402,7 +3402,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.pow(s, 3)
       #Explorer.Series<
         Polars[3]
-        s64 [8, 64, 216]
+        f64 [8.0, 64.0, 216.0]
       >
 
       iex> s = [2, 4, 6] |> Explorer.Series.from_list()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3428,19 +3428,7 @@ defmodule Explorer.Series do
   """
   @doc type: :element_wise
   @spec pow(left :: Series.t() | number(), right :: Series.t() | number()) :: Series.t()
-  def pow(left, right) do
-    if K.or(match?(%Series{}, left), match?(%Series{}, right)) do
-      apply_series_list(:pow, [cast_for_pow(left), cast_for_pow(right)])
-    else
-      raise ArgumentError, "at least one input must be a series"
-    end
-  end
-
-  @non_finite [:nan, :infinity, :neg_infinity]
-  defp cast_for_pow(%Series{} = series), do: series
-  defp cast_for_pow(u) when K.and(is_integer(u), u >= 0), do: from_list([u], dtype: {:u, 64})
-  defp cast_for_pow(s) when K.and(is_integer(s), s < 0), do: from_list([s], dtype: {:s, 64})
-  defp cast_for_pow(f) when K.or(is_float(f), K.in(f, @non_finite)), do: from_list([f])
+  def pow(left, right), do: basic_numeric_operation(:pow, left, right)
 
   @doc """
   Calculates the natural logarithm.
@@ -3763,6 +3751,8 @@ defmodule Explorer.Series do
 
   def atan(%Series{dtype: dtype}),
     do: dtype_error("atan/1", dtype, [{:f, 32}, {:f, 64}])
+
+  defp basic_numeric_operation(operation, left, right, args \\ [])
 
   defp basic_numeric_operation(operation, %Series{} = left, right, args) when is_numeric(right),
     do: basic_numeric_operation(operation, left, from_same_value(left, right), args)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3766,8 +3766,6 @@ defmodule Explorer.Series do
   def atan(%Series{dtype: dtype}),
     do: dtype_error("atan/1", dtype, [{:f, 32}, {:f, 64}])
 
-  defp basic_numeric_operation(operation, left, right, args \\ [])
-
   defp basic_numeric_operation(operation, %Series{} = left, right, args) when is_numeric(right),
     do: basic_numeric_operation(operation, left, from_same_value(left, right), args)
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3429,8 +3429,6 @@ defmodule Explorer.Series do
   @doc type: :element_wise
   @spec pow(left :: Series.t() | number(), right :: Series.t() | number()) :: Series.t()
   def pow(left, right) do
-    # TODO: revert back to `basic_numeric_operation(:pow, left, right)` if/when we start inferring
-    # unsigned integer types from lists.
     if K.or(match?(%Series{}, left), match?(%Series{}, right)) do
       apply_series_list(:pow, [cast_for_pow(left), cast_for_pow(right)])
     else

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3441,16 +3441,12 @@ defmodule Explorer.Series do
     end
   end
 
-  # TODO: ensure these types are correct.
   defp cast_to_pow({:u, l}, {:u, r}), do: {:u, max(l, r)}
-  defp cast_to_pow({:u, _}, {:s, _}), do: {:f, 64}
-  defp cast_to_pow({:u, _}, {:f, f}), do: {:f, f}
   defp cast_to_pow({:s, s}, {:u, u}), do: {:s, min(64, max(2 * u, s))}
-  defp cast_to_pow({:s, _}, {:s, _}), do: {:f, 64}
-  defp cast_to_pow({:s, _}, {:f, f}), do: {:f, f}
-  defp cast_to_pow({:f, f}, {:u, _}), do: {:f, f}
-  defp cast_to_pow({:f, f}, {:s, _}), do: {:f, f}
-  defp cast_to_pow({:f, f}, {:f, _}), do: {:f, f}
+  defp cast_to_pow({:f, l}, {:f, r}), do: {:f, max(l, r)}
+  defp cast_to_pow({:f, l}, {n, _}) when K.in(n, [:u, :s]), do: {:f, l}
+  defp cast_to_pow({n, _}, {:f, r}) when K.in(n, [:u, :s]), do: {:f, r}
+  defp cast_to_pow({n, _}, {:s, _}) when K.in(n, [:u, :s]), do: {:f, 64}
   defp cast_to_pow(_, _), do: nil
 
   @doc """

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -426,7 +426,6 @@ rustler::init!(
         s_peak_max,
         s_peak_min,
         s_select,
-        s_pow,
         s_quantile,
         s_quotient,
         s_rank,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1261,7 +1261,7 @@ pub fn s_pow(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 fn first(exseries: ExSeries) -> LiteralValue {
-    let dtype = DataType::try_from(exseries.dtype().clone()).unwrap();
+    let dtype = exseries.dtype().clone();
 
     match dtype {
         DataType::UInt8 => LiteralValue::UInt8(exseries.u8().unwrap().get(0).unwrap()),

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1260,8 +1260,8 @@ pub fn s_pow(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(result))
 }
 
-fn first(s: ExSeries) -> LiteralValue {
-    match s.dtype() {
+fn first(exseries: ExSeries) -> LiteralValue {
+    match exseries.dtype() {
         DataType::UInt8 => LiteralValue::UInt8(exseries.u8().unwrap().get(0).unwrap()),
         DataType::UInt16 => LiteralValue::UInt16(exseries.u16().unwrap().get(0).unwrap()),
         DataType::UInt32 => LiteralValue::UInt32(exseries.u32().unwrap().get(0).unwrap()),

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1257,7 +1257,7 @@ pub fn s_pow(
             .lazy()
             .with_column((col("base").pow(exponent.lit())).alias("result"))
     } else {
-        panic!("adsf")
+        panic!("both series must have the same length or one must have length 1")
     };
 
     let result = df_with_result.collect()?.column("result")?.clone();
@@ -1279,7 +1279,7 @@ fn first(exseries: ExSeries, exdtype: ExSeriesDtype) -> LiteralValue {
         DataType::Int64 => LiteralValue::Int64(exseries.i64().unwrap().get(0).unwrap()),
         DataType::Float32 => LiteralValue::Float32(exseries.f32().unwrap().get(0).unwrap()),
         DataType::Float64 => LiteralValue::Float64(exseries.f64().unwrap().get(0).unwrap()),
-        _ => panic!("asdf"),
+        _ => panic!("unsupported dtype for pow: must be integer or float subtype"),
     }
 }
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1260,10 +1260,8 @@ pub fn s_pow(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(result))
 }
 
-fn first(exseries: ExSeries) -> LiteralValue {
-    let dtype = exseries.dtype().clone();
-
-    match dtype {
+fn first(s: ExSeries) -> LiteralValue {
+    match s.dtype() {
         DataType::UInt8 => LiteralValue::UInt8(exseries.u8().unwrap().get(0).unwrap()),
         DataType::UInt16 => LiteralValue::UInt16(exseries.u16().unwrap().get(0).unwrap()),
         DataType::UInt32 => LiteralValue::UInt32(exseries.u32().unwrap().get(0).unwrap()),

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -299,7 +299,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 
       message =
-        "expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type {:s, 64}"
+        "expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type {:f, 64}"
 
       assert_raise ArgumentError, message, fn ->
         DF.filter_with(df, fn ldf ->
@@ -819,7 +819,7 @@ defmodule Explorer.DataFrameTest do
                "calc2" => {:s, 64},
                "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => {:s, 64},
+               "calc5" => {:f, 64},
                "calc6" => {:s, 64},
                "calc7" => {:s, 64},
                "calc8" => {:f, 64},

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -861,8 +861,7 @@ defmodule Explorer.DataFrameTest do
                "calc2" => {:s, 64},
                "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               # TODO: This should be float after #374 is resolved
-               "calc5" => {:s, 64},
+               "calc5" => {:f, 64},
                "calc5_1" => {:f, 64},
                "calc6" => {:s, 64},
                "calc7" => {:s, 64}

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -883,7 +883,7 @@ defmodule Explorer.DataFrameTest do
           calc7: remainder(a, ^series)
         )
 
-      assert DF.to_columns(df1, atom_keys: true) == %{
+      assert DF.to_columns(df1, atom_keys: true) === %{
                a: [1, 2, 4],
                calc1: [3, 3, 6],
                calc2: [-1, 1, 2],
@@ -900,7 +900,7 @@ defmodule Explorer.DataFrameTest do
                "calc2" => {:s, 64},
                "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => {:s, 64},
+               "calc5" => {:f, 64},
                "calc6" => {:s, 64},
                "calc7" => {:s, 64}
              }
@@ -921,7 +921,7 @@ defmodule Explorer.DataFrameTest do
           calc7: remainder(^series, a)
         )
 
-      assert DF.to_columns(df1, atom_keys: true) == %{
+      assert DF.to_columns(df1, atom_keys: true) === %{
                a: [2, 1, 2],
                calc1: [3, 3, 6],
                calc2: [-1, 1, 2],
@@ -938,7 +938,7 @@ defmodule Explorer.DataFrameTest do
                "calc2" => {:s, 64},
                "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => {:s, 64},
+               "calc5" => {:f, 64},
                "calc6" => {:s, 64},
                "calc7" => {:s, 64}
              }
@@ -958,7 +958,7 @@ defmodule Explorer.DataFrameTest do
           calc7: remainder(b, c)
         )
 
-      assert DF.to_columns(df1, atom_keys: true) == %{
+      assert DF.to_columns(df1, atom_keys: true) === %{
                a: [1, 2, 3],
                b: [20, 40, 60],
                c: [10, 0, 8],
@@ -981,7 +981,7 @@ defmodule Explorer.DataFrameTest do
                "calc2" => {:s, 64},
                "calc3" => {:s, 64},
                "calc4" => {:f, 64},
-               "calc5" => {:s, 64},
+               "calc5" => {:f, 64},
                "calc6" => {:s, 64},
                "calc7" => {:s, 64}
              }

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -799,7 +799,7 @@ defmodule Explorer.DataFrameTest do
           calc10: is_nan(divide(a * 0.0, 0.0))
         )
 
-      assert DF.to_columns(df1, atom_keys: true) == %{
+      assert DF.to_columns(df1, atom_keys: true) === %{
                a: [1, 2, 4],
                calc1: [3, 4, 6],
                calc2: [-1, 0, 2],
@@ -843,7 +843,7 @@ defmodule Explorer.DataFrameTest do
           calc7: remainder(2, a)
         )
 
-      assert DF.to_columns(df1, atom_keys: true) == %{
+      assert DF.to_columns(df1, atom_keys: true) === %{
                a: [1, 2, 4],
                calc1: [3, 4, 6],
                calc2: [1, 0, -2],

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2048,6 +2048,18 @@ defmodule Explorer.SeriesTest do
       end
     end
 
+    test "pow(uint, sint) == float64" do
+      for u_base <- [8, 16, 32, 64], s_power <- [8, 16, 32, 64] do
+        base = Series.from_list([1, 2, 3], dtype: {:u, u_base})
+        power = Series.from_list([3, 2, 1], dtype: {:s, s_power})
+
+        result = Series.pow(base, power)
+
+        assert result.dtype == {:f, 64}
+        assert Series.to_list(result) == [1, 4, 3]
+      end
+    end
+
     test "pow(sint, uint) == sint" do
       for s_base <- [8, 16, 32, 64], u_power <- [8, 16, 32, 64] do
         base = Series.from_list([1, 2, 3], dtype: {:s, s_base})
@@ -2060,7 +2072,7 @@ defmodule Explorer.SeriesTest do
       end
     end
 
-    test "pow(sint, sint) == float" do
+    test "pow(sint, sint) == float64" do
       for s_base <- [8, 16, 32, 64], s_power <- [8, 16, 32, 64] do
         base = Series.from_list([1, 2, 3], dtype: {:s, s_base})
         power = Series.from_list([3, 2, 1], dtype: {:s, s_power})

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2217,7 +2217,7 @@ defmodule Explorer.SeriesTest do
 
         result = Series.pow(base, power)
 
-        assert result.dtype == {:u, u_base}
+        assert result.dtype == {:u, max(u_base, u_power)}
         assert Series.to_list(result) == [1, 4, 3]
       end
     end
@@ -2241,7 +2241,8 @@ defmodule Explorer.SeriesTest do
 
         result = Series.pow(base, power)
 
-        assert result.dtype == {:s, s_base}
+        # Unsigned integers have twice the precision as signed integers.
+        assert result.dtype == {:s, min(64, max(s_base, 2 * u_power))}
         assert Series.to_list(result) == [1, 4, 3]
       end
     end
@@ -2277,7 +2278,7 @@ defmodule Explorer.SeriesTest do
 
         result = Series.pow(base, power)
 
-        assert result.dtype == {:f, 64}
+        assert result.dtype == {:f, f_power}
         assert Series.to_list(result) === [1.0, 4.0, 3.0]
       end
     end
@@ -2289,7 +2290,7 @@ defmodule Explorer.SeriesTest do
 
         result = Series.pow(base, power)
 
-        assert result.dtype == {:f, f_base}
+        assert result.dtype == {:f, max(f_base, f_power)}
         assert Series.to_list(result) === [1.0, 4.0, 3.0]
       end
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2185,7 +2185,7 @@ defmodule Explorer.SeriesTest do
 
       result = Series.pow(s1, 2)
 
-      assert result.dtype == {:s, 64}
+      assert result.dtype == {:f, 64}
       assert Series.to_list(result) == [1, 4, 9]
     end
 


### PR DESCRIPTION
Fixes:

* https://github.com/elixir-explorer/explorer/issues/374

New dtype handling as of Rust Polars 0.36.2:

```
pow(uint,  uint)  = uint
pow(uint,  sint)  = float
pow(sint,  uint)  = sint
pow(sint,  sint)  = float
pow(float, *int)  = float
pow(*int,  float) = float
pow(float, float) = float
```