### PR TITLE
fix Series.from_list/2 bugs

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -251,6 +251,7 @@ defmodule Explorer.Series do
     * `:dtype` - Cast the series to a given `:dtype`. By default this is `nil`, which means
       that Explorer will infer the type from the values in the list.
       See the module docs for the list of valid dtypes and aliases.
+    * `:strict` - `boolean` defaults to `false`. When `true` infers exact data type of integers and raises on overflow and underflow
 
   ## Examples
 
@@ -406,12 +407,12 @@ defmodule Explorer.Series do
   @doc type: :conversion
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()
   def from_list(list, opts \\ []) do
-    opts = Keyword.validate!(opts, [:dtype, :backend])
+    opts = Keyword.validate!(opts, [:dtype, :backend, strict: false])
     backend = backend_from_options!(opts)
 
     normalised_dtype = if opts[:dtype], do: Shared.normalise_dtype!(opts[:dtype])
 
-    type = Shared.dtype_from_list!(list, normalised_dtype)
+    type = Shared.dtype_from_list!(list, normalised_dtype, opts[:strict])
     list = Shared.cast_numerics(list, type)
 
     series = backend.from_list(list, type)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -251,7 +251,7 @@ defmodule Explorer.Series do
     * `:dtype` - Cast the series to a given `:dtype`. By default this is `nil`, which means
       that Explorer will infer the type from the values in the list.
       See the module docs for the list of valid dtypes and aliases.
-    * `:strict` - `boolean` defaults to `false`. When `true` infers exact data type of integers and raises on overflow and underflow
+    * `:strict` - when `true` raises on overflow and underflow - defaults to `false`.
 
   ## Examples
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -275,9 +275,7 @@ defmodule Explorer.Shared do
   def dtype_from_list!(_list, :null, _strict), do: :null
 
   def dtype_from_list!(list, nil, strict) do
-    list
-    |> Enum.reduce(:null, &infer_type(&1, &2, nil, strict))
-    |> normalise_dtype!()
+    Enum.reduce(list, :null, &infer_type(&1, &2, nil, strict))
   end
 
   def dtype_from_list!(list, preferred_type, strict) do

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -410,7 +410,6 @@ defmodule Explorer.Shared do
     do: raise(ArgumentError, "unsupported datatype: #{inspect(item)}")
 
   defp infer_list(list, type, preferred, strict) do
-    # &infer_type/2)}
     preferred =
       case preferred do
         {:list, preferred} -> preferred

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -330,24 +330,11 @@ defmodule Explorer.Shared do
   end
 
   defp infer_type(item, type, preferred, strict) do
-    case {infer_type(item, preferred, strict), type} do
-      {{:u, 64}, {:s, 64}} ->
-        {:u, 64}
-
-      {{:u, 64}, {:s, -64}} ->
-        raise_mismatched_dtype!(item, {:s, 64})
-
-      {{:s, _}, {:s, -64}} ->
-        type
-
-      {{:s, -64}, {:s, _}} ->
-        {:s, -64}
-
-      {type, type} ->
-        type
-
-      _ ->
-        raise_mismatched_dtype!(item, type)
+    if infer_type(item, preferred, strict) == type do
+      type
+    else
+      raise ArgumentError,
+            "the value #{inspect(item)} does not match the inferred dtype #{inspect(type)}"
     end
   end
 
@@ -361,18 +348,10 @@ defmodule Explorer.Shared do
   defp infer_type(item, _, false) when is_integer(item), do: {:s, 64}
 
   defp infer_type(item, nil, true) when is_integer(item) do
-    cond do
-      item > -9_223_372_036_854_775_809 and item < 0 ->
-        {:s, -64}
-
-      item < 9_223_372_036_854_775_808 ->
-        {:s, 64}
-
-      item > -1 and item > 9_223_372_036_854_775_807 ->
-        {:u, 64}
-
-      true ->
-        raise_mismatched_dtype!(item, {:s, 64})
+    if item > 9_223_372_036_854_775_807 do
+      raise_mismatched_dtype!(item, {:s, 64})
+    else
+      {:s, 64}
     end
   end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -74,6 +74,7 @@ defmodule Explorer.Shared do
   def normalise_dtype(:u16), do: {:u, 16}
   def normalise_dtype(:u32), do: {:u, 32}
   def normalise_dtype(:u64), do: {:u, 64}
+  def normalise_dtype({:s, -64}), do: {:s, 64}
   def normalise_dtype(_dtype), do: nil
 
   @doc """
@@ -257,7 +258,9 @@ defmodule Explorer.Shared do
   Gets the `dtype` of a list or raise error if not possible.
   """
   def dtype_from_list!(list) do
-    Enum.reduce(list, :null, &infer_type/2)
+    list
+    |> Enum.reduce(:null, &infer_type/2)
+    |> normalise_dtype!()
   end
 
   @doc """
@@ -276,25 +279,34 @@ defmodule Explorer.Shared do
 
   def dtype_from_list!(list, preferred_type) do
     list
-    |> dtype_from_list!()
-    |> merge_preferred(preferred_type)
+    |> Enum.reduce(:null, &infer_type/2)
+    |> merge_preferred!(preferred_type, list)
   end
 
   @non_finite [:nan, :infinity, :neg_infinity]
 
   defp infer_type(nil, type), do: type
   defp infer_type(item, :null), do: infer_type(item)
+  defp infer_type(integer, {:u, 64}) when is_integer(integer) and integer > 0, do: {:u, 64}
   defp infer_type(integer, {:f, 64}) when is_integer(integer), do: {:f, 64}
-  defp infer_type(float, {:s, 64}) when is_float(float) or float in @non_finite, do: {:f, 64}
+  defp infer_type(float, {:u, _}) when is_float(float) or float in @non_finite, do: {:f, 64}
+  defp infer_type(float, {:s, _}) when is_float(float) or float in @non_finite, do: {:f, 64}
   defp infer_type(list, {:list, type}) when is_list(list), do: infer_list(list, type)
   defp infer_type(%{} = map, {:struct, inner}), do: infer_struct(map, inner)
 
   defp infer_type(item, type) do
-    if infer_type(item) == type do
-      type
-    else
-      raise ArgumentError,
-            "the value #{inspect(item)} does not match the inferred dtype #{inspect(type)}"
+    case {infer_type(item), type} do
+      {{:u, 64}, {:s, 64}} ->
+        {:u, 64}
+
+      {{:s, m}, {:s, n}} when m < 0 or n < 0 ->
+        type
+
+      {type, type} ->
+        type
+
+      _ ->
+        raise_infer_mismatch!(item, type)
     end
   end
 
@@ -302,7 +314,15 @@ defmodule Explorer.Shared do
   defp infer_type(%Time{} = _item), do: :time
   defp infer_type(%NaiveDateTime{} = _item), do: {:datetime, :microsecond}
   defp infer_type(%Explorer.Duration{precision: precision} = _item), do: {:duration, precision}
-  defp infer_type(item) when is_integer(item), do: {:s, 64}
+
+  defp infer_type(item) when is_integer(item) do
+    cond do
+      item < 0 -> {:s, -64}
+      item > 9_223_372_036_854_775_807 -> {:u, 64}
+      true -> {:s, 64}
+    end
+  end
+
   defp infer_type(item) when is_float(item) or item in @non_finite, do: {:f, 64}
   defp infer_type(item) when is_boolean(item), do: :boolean
   defp infer_type(item) when is_binary(item), do: :string
@@ -327,31 +347,102 @@ defmodule Explorer.Shared do
             {key, infer_type(value, type)}
 
           true ->
-            raise ArgumentError,
-                  "the value #{inspect(map)} does not match the inferred dtype #{inspect({:struct, types})}"
+            raise_infer_mismatch!(map, {:struct, types})
         end
       end
 
     {:struct, types}
   end
 
-  defp merge_preferred(type, type), do: type
-  defp merge_preferred(:null, type), do: type
-  defp merge_preferred({:s, 64}, {:s, _} = type), do: type
-  defp merge_preferred({:s, 64}, {:f, _} = type), do: type
-  defp merge_preferred({:f, 64}, {:f, _} = type), do: type
-  defp merge_preferred(:string, type) when type in [:binary, :string, :category], do: type
+  defp infer_as_uint_type!(nil, type), do: type
 
-  defp merge_preferred({:list, inferred}, {:list, preferred}) do
-    {:list, merge_preferred(inferred, preferred)}
+  defp infer_as_uint_type!(item, {:u, n} = type) do
+    cond do
+      item < 0 -> raise_infer_mismatch!(item, type)
+      n == 8 and item < 256 -> type
+      n == 16 and item < 2 ** 16 -> type
+      n == 32 and item < 2 ** 32 -> type
+      n == 64 and item < 2 ** 64 -> type
+      true -> raise_infer_mismatch!(item, type)
+    end
   end
 
-  defp merge_preferred({:struct, inferred}, {:struct, preferred}) do
-    {:struct, Map.merge(inferred, preferred, fn _, v1, v2 -> merge_preferred(v1, v2) end)}
+  defp infer_as_int_type!(nil, type), do: type
+
+  defp infer_as_int_type!(item, {:s, n} = type) do
+    cond do
+      item < -9_223_372_036_854_775_808 or item > 9_223_372_036_854_775_807 ->
+        raise_infer_mismatch!(item, type)
+
+      n == 8 and item > -129 and item < 128 ->
+        type
+
+      n == 16 and item > -32_769 and item < 32_768 ->
+        type
+
+      n == 32 and item > -2_147_483_649 and item < 2_147_483_648 ->
+        type
+
+      n == 64 and item > -9_223_372_036_854_775_809 and item < 9_223_372_036_854_775_808 ->
+        type
+
+      true ->
+        raise_infer_mismatch!(item, type)
+    end
   end
 
-  defp merge_preferred(inferred, _preferred) do
+  defp merge_preferred!(type, type, _list), do: type
+  defp merge_preferred!(:null, type, _list), do: type
+  defp merge_preferred!({t, 64}, {:f, _} = type, _list) when t in [:s, :u], do: type
+
+  defp merge_preferred!({:s, _}, {:s, _} = type, list) do
+    Enum.reduce(list, type, &infer_as_int_type!/2)
+  end
+
+  defp merge_preferred!({:s, _}, {:u, _} = type, list) do
+    Enum.reduce(list, type, &infer_as_uint_type!/2)
+  end
+
+  defp merge_preferred!({:u, _}, {:s, _} = type, list) do
+    Enum.reduce(list, type, &infer_as_int_type!/2)
+  end
+
+  defp merge_preferred!({:u, _}, {:u, _} = type, list) do
+    Enum.reduce(list, type, &infer_as_uint_type!/2)
+  end
+
+  defp merge_preferred!({:f, 64}, {:f, _} = type, _list), do: type
+  defp merge_preferred!(:string, type, _list) when type in [:binary, :string, :category], do: type
+
+  defp merge_preferred!({:list, {x, 64} = inferred}, {:list, {y, _} = preferred}, list)
+       when x in [:s, :u] or y in [:s, :u] do
+    result = Enum.reduce(list, preferred, fn l, acc -> merge_preferred!(inferred, acc, l) end)
+    {:list, result}
+  end
+
+  defp merge_preferred!({:list, inferred}, {:list, preferred}, list) do
+    {:list, merge_preferred!(inferred, preferred, list)}
+  end
+
+  defp merge_preferred!({:struct, inferred}, {:struct, preferred}, list) do
+    result =
+      Map.merge(inferred, preferred, fn k, v1, v2 ->
+        v_list = Enum.map(list, & &1[k])
+        merge_preferred!(v1, v2, v_list)
+      end)
+
+    {:struct, result}
+  end
+
+  defp merge_preferred!(inferred, _preferred, _list) do
     inferred
+  end
+
+  defp raise_infer_mismatch!(item, type) do
+    type = if type == {:s, -64}, do: {:s, 64}, else: type
+
+    raise ArgumentError,
+          "the value #{inspect(item)} does not match the inferred dtype #{inspect(type)}"
   end
 
   @doc """

--- a/test/explorer/series/list_test.exs
+++ b/test/explorer/series/list_test.exs
@@ -35,6 +35,46 @@ defmodule Explorer.Series.ListTest do
       assert Series.to_list(series) == [[[1]]]
     end
 
+    test "list of lists of one integer & one u64" do
+      series = Series.from_list([[1, 9_223_372_036_854_775_808]])
+
+      assert series.dtype == {:list, {:u, 64}}
+      assert series[0] == [1, 9_223_372_036_854_775_808]
+      assert Series.to_list(series) == [[1, 9_223_372_036_854_775_808]]
+    end
+
+    test "list of lists of one negative integer & one u64 " do
+      series = Series.from_list([[-1, 9_223_372_036_854_775_808]])
+
+      assert series.dtype == {:list, {:u, 64}}
+      assert series[0] == [-1, 9_223_372_036_854_775_808]
+      assert Series.to_list(series) == [[1, 9_223_372_036_854_775_808]]
+    end
+
+    test "list of lists of integers with one u64" do
+      series = Series.from_list([[0], [1], [2, 9_223_372_036_854_775_808], [3, nil, 4], nil, []])
+
+      assert series.dtype == {:list, {:u, 64}}
+      assert series[0] == [0]
+
+      assert Series.to_list(series) == [
+               [0],
+               [1],
+               [2, 9_223_372_036_854_775_808],
+               [3, nil, 4],
+               nil,
+               []
+             ]
+    end
+
+    test "list of lists of integers recursively - u64" do
+      series = Series.from_list([[[1, 9_223_372_036_854_775_808]]])
+
+      assert series.dtype == {:list, {:list, {:u, 64}}}
+      assert series[0] == [[1, 9_223_372_036_854_775_808]]
+      assert Series.to_list(series) == [[[1, 9_223_372_036_854_775_808]]]
+    end
+
     test "list of lists of floats recursively" do
       series = Series.from_list([[[1.52]]])
 

--- a/test/explorer/series/list_test.exs
+++ b/test/explorer/series/list_test.exs
@@ -36,7 +36,7 @@ defmodule Explorer.Series.ListTest do
     end
 
     test "list of lists of one integer & one u64" do
-      series = Series.from_list([[1, 9_223_372_036_854_775_808]])
+      series = Series.from_list([[1, 9_223_372_036_854_775_808]], dtype: {:list, {:u, 64}})
 
       assert series.dtype == {:list, {:u, 64}}
       assert series[0] == [1, 9_223_372_036_854_775_808]
@@ -47,12 +47,16 @@ defmodule Explorer.Series.ListTest do
       assert_raise ArgumentError,
                    "the value 9223372036854775808 does not match the inferred dtype {:s, 64}",
                    fn ->
-                     Series.from_list([[-1, 9_223_372_036_854_775_808]])
+                     Series.from_list([[-1, 9_223_372_036_854_775_808]], strict: true)
                    end
     end
 
     test "list of lists of integers with one u64" do
-      series = Series.from_list([[0], [1], [2, 9_223_372_036_854_775_808], [3, nil, 4], nil, []])
+      series =
+        Series.from_list([[0], [1], [2, 9_223_372_036_854_775_808], [3, nil, 4], nil, []],
+          dtype: {:list, {:u, 64}},
+          strict: true
+        )
 
       assert series.dtype == {:list, {:u, 64}}
       assert series[0] == [0]
@@ -68,7 +72,8 @@ defmodule Explorer.Series.ListTest do
     end
 
     test "list of lists of integers recursively - u64" do
-      series = Series.from_list([[[1, 9_223_372_036_854_775_808]]])
+      series =
+        Series.from_list([[[1, 9_223_372_036_854_775_808]]], dtype: {:list, {:list, {:u, 64}}})
 
       assert series.dtype == {:list, {:list, {:u, 64}}}
       assert series[0] == [[1, 9_223_372_036_854_775_808]]

--- a/test/explorer/series/list_test.exs
+++ b/test/explorer/series/list_test.exs
@@ -44,11 +44,11 @@ defmodule Explorer.Series.ListTest do
     end
 
     test "list of lists of one negative integer & one u64 " do
-      series = Series.from_list([[-1, 9_223_372_036_854_775_808]])
-
-      assert series.dtype == {:list, {:u, 64}}
-      assert series[0] == [-1, 9_223_372_036_854_775_808]
-      assert Series.to_list(series) == [[1, 9_223_372_036_854_775_808]]
+      assert_raise ArgumentError,
+                   "the value 9223372036854775808 does not match the inferred dtype {:s, 64}",
+                   fn ->
+                     Series.from_list([[-1, 9_223_372_036_854_775_808]])
+                   end
     end
 
     test "list of lists of integers with one u64" do

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -45,6 +45,32 @@ defmodule Explorer.Series.StructTest do
       assert Series.to_list(s) == [%{"a" => 9_223_372_036_854_775_808}, %{"a" => 3}, %{"a" => 5}]
     end
 
+    test "allows struct values - list of u64 integers" do
+      s = Series.from_list([%{a: [9_223_372_036_854_775_808]}, %{a: [3]}, %{a: [5]}])
+
+      assert s.dtype == {:struct, %{"a" => {:list, {:u, 64}}}}
+
+      assert Series.to_list(s) == [
+               %{"a" => [9_223_372_036_854_775_808]},
+               %{"a" => [3]},
+               %{"a" => [5]}
+             ]
+    end
+
+    test "allows struct values - list of u64 integers with dtype" do
+      dtype = {:struct, %{"a" => {:list, {:u, 64}}}}
+      list = [%{"a" => [9_223_372_036_854_775_802]}, %{"a" => [3]}, %{"a" => [5]}]
+      s = Series.from_list(list, dtype: dtype)
+
+      assert s.dtype == {:struct, %{"a" => {:list, {:u, 64}}}}
+
+      assert Series.to_list(s) == [
+               %{"a" => [9_223_372_036_854_775_802]},
+               %{"a" => [3]},
+               %{"a" => [5]}
+             ]
+    end
+
     test "allows struct values - integers with dtype u32" do
       s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, %{"a" => {:u, 32}}})
 

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -29,6 +29,46 @@ defmodule Explorer.Series.StructTest do
       assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
     end
 
+    test "allows struct values with dtype u64" do
+      s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, %{"a" => {:u, 64}}})
+
+      assert s.dtype == {:struct, %{"a" => {:u, 64}}}
+
+      assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+    end
+
+    test "allows struct values - u64 integers" do
+      s = Series.from_list([%{a: 9_223_372_036_854_775_808}, %{a: 3}, %{a: 5}])
+
+      assert s.dtype == {:struct, %{"a" => {:u, 64}}}
+
+      assert Series.to_list(s) == [%{"a" => 9_223_372_036_854_775_808}, %{"a" => 3}, %{"a" => 5}]
+    end
+
+    test "allows struct values - integers with dtype u32" do
+      s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, %{"a" => {:u, 32}}})
+
+      assert s.dtype == {:struct, %{"a" => {:u, 32}}}
+
+      assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+    end
+
+    test "allows struct values - integers with dtype s32" do
+      s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, %{"a" => {:s, 32}}})
+
+      assert s.dtype == {:struct, %{"a" => {:s, 32}}}
+
+      assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+    end
+
+    test "allows struct values - s64 integers with dtype u64" do
+      s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, %{"a" => {:u, 64}}})
+
+      assert s.dtype == {:struct, %{"a" => {:u, 64}}}
+
+      assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+    end
+
     test "allows structs with nil values" do
       s =
         Series.from_list([

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -38,20 +38,20 @@ defmodule Explorer.Series.StructTest do
     end
 
     test "allows struct values - u64 integers" do
-      s = Series.from_list([%{a: 9_223_372_036_854_775_808}, %{a: 3}, %{a: 5}])
+      s = Series.from_list([%{a: 9_223_372_036_854_775_806}, %{a: 3}, %{a: 5}])
 
-      assert s.dtype == {:struct, %{"a" => {:u, 64}}}
+      assert s.dtype == {:struct, %{"a" => {:s, 64}}}
 
-      assert Series.to_list(s) == [%{"a" => 9_223_372_036_854_775_808}, %{"a" => 3}, %{"a" => 5}]
+      assert Series.to_list(s) == [%{"a" => 9_223_372_036_854_775_806}, %{"a" => 3}, %{"a" => 5}]
     end
 
     test "allows struct values - list of u64 integers" do
-      s = Series.from_list([%{a: [9_223_372_036_854_775_808]}, %{a: [3]}, %{a: [5]}])
+      s = Series.from_list([%{a: [9_223_372_036_854_775_806]}, %{a: [3]}, %{a: [5]}])
 
-      assert s.dtype == {:struct, %{"a" => {:list, {:u, 64}}}}
+      assert s.dtype == {:struct, %{"a" => {:list, {:s, 64}}}}
 
       assert Series.to_list(s) == [
-               %{"a" => [9_223_372_036_854_775_808]},
+               %{"a" => [9_223_372_036_854_775_806]},
                %{"a" => [3]},
                %{"a" => [5]}
              ]

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -94,6 +94,14 @@ defmodule Explorer.SeriesTest do
                    end
     end
 
+    test "signed integers and u64 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 9223372036854775808 does not match the inferred dtype {:s, 64}",
+                   fn ->
+                     Series.from_list([-1, 9_223_372_036_854_775_808])
+                   end
+    end
+
     test "s16 integers with dtype s8 - raises error" do
       assert_raise ArgumentError,
                    "the value 32767 does not match the inferred dtype {:s, 8}",

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -52,21 +52,21 @@ defmodule Explorer.SeriesTest do
     end
 
     test "with u64 integers" do
-      s = Series.from_list([9_223_372_036_854_775_808])
+      s = Series.from_list([9_223_372_036_854_775_808], dtype: {:u, 64}, strict: true)
 
       assert Series.to_list(s) === [9_223_372_036_854_775_808]
       assert Series.dtype(s) == {:u, 64}
     end
 
     test "with integers (u64 at end)" do
-      s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808])
+      s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808], dtype: {:u, 64}, strict: true)
 
       assert Series.to_list(s) === [1, 2, 3, 9_223_372_036_854_775_808]
       assert Series.dtype(s) == {:u, 64}
     end
 
     test "with integers (u64 at start)" do
-      s = Series.from_list([9_223_372_036_854_775_808, 1, 2, 3])
+      s = Series.from_list([9_223_372_036_854_775_808, 1, 2, 3], dtype: {:u, 64})
 
       assert Series.to_list(s) === [9_223_372_036_854_775_808, 1, 2, 3]
       assert Series.dtype(s) == {:u, 64}
@@ -80,7 +80,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "with u64 integers and floats" do
-      s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808, 5.0])
+      s =
+        Series.from_list([1, 2, 3, 9_223_372_036_854_775_808, 5.0], dtype: {:f, 64})
 
       assert Series.to_list(s) === [1.0, 2.0, 3.0, 9.223372036854776e18, 5.0]
       assert Series.dtype(s) == {:f, 64}
@@ -90,7 +91,7 @@ defmodule Explorer.SeriesTest do
       assert_raise ArgumentError,
                    "the value -1 does not match the inferred dtype {:u, 64}",
                    fn ->
-                     Series.from_list([-1, 2, 3], dtype: {:u, 64})
+                     Series.from_list([-1, 2, 3], dtype: {:u, 64}, strict: true)
                    end
     end
 
@@ -98,7 +99,7 @@ defmodule Explorer.SeriesTest do
       assert_raise ArgumentError,
                    "the value 9223372036854775808 does not match the inferred dtype {:s, 64}",
                    fn ->
-                     Series.from_list([-1, 9_223_372_036_854_775_808])
+                     Series.from_list([-1, 9_223_372_036_854_775_808], strict: true)
                    end
     end
 
@@ -106,9 +107,7 @@ defmodule Explorer.SeriesTest do
       assert_raise ArgumentError,
                    "the value 32767 does not match the inferred dtype {:s, 8}",
                    fn ->
-                     Series.from_list([32_767, 32_766],
-                       dtype: {:s, 8}
-                     )
+                     Series.from_list([32_767, 32_766], dtype: {:s, 8}, strict: true)
                    end
     end
 
@@ -117,7 +116,8 @@ defmodule Explorer.SeriesTest do
                    "the value 2147483647 does not match the inferred dtype {:s, 16}",
                    fn ->
                      Series.from_list([2_147_483_647, 2_147_483_646],
-                       dtype: {:s, 16}
+                       dtype: {:s, 16},
+                       strict: true
                      )
                    end
     end
@@ -127,7 +127,8 @@ defmodule Explorer.SeriesTest do
                    "the value 9223372036854775807 does not match the inferred dtype {:s, 32}",
                    fn ->
                      Series.from_list([9_223_372_036_854_775_807, 9_223_372_036_854_775_806],
-                       dtype: {:s, 32}
+                       dtype: {:s, 32},
+                       strict: true
                      )
                    end
     end
@@ -136,9 +137,7 @@ defmodule Explorer.SeriesTest do
       assert_raise ArgumentError,
                    "the value 32768 does not match the inferred dtype {:u, 8}",
                    fn ->
-                     Series.from_list([32768, 32767],
-                       dtype: {:u, 8}
-                     )
+                     Series.from_list([32768, 32767], dtype: {:u, 8}, strict: true)
                    end
     end
 
@@ -147,7 +146,8 @@ defmodule Explorer.SeriesTest do
                    "the value 9223372036854775807 does not match the inferred dtype {:u, 16}",
                    fn ->
                      Series.from_list([9_223_372_036_854_775_807, 9_223_372_036_854_775_806],
-                       dtype: {:u, 16}
+                       dtype: {:u, 16},
+                       strict: true
                      )
                    end
     end
@@ -157,7 +157,8 @@ defmodule Explorer.SeriesTest do
                    "the value 9223372036854775808 does not match the inferred dtype {:u, 32}",
                    fn ->
                      Series.from_list([9_223_372_036_854_775_808, 9_223_372_036_854_775_809],
-                       dtype: {:u, 32}
+                       dtype: {:u, 32},
+                       strict: true
                      )
                    end
     end
@@ -167,7 +168,8 @@ defmodule Explorer.SeriesTest do
                    "the value 9223372036854775808 does not match the inferred dtype {:s, 64}",
                    fn ->
                      Series.from_list([9_223_372_036_854_775_808, 9_223_372_036_854_775_809],
-                       dtype: {:s, 64}
+                       dtype: {:s, 64},
+                       strict: true
                      )
                    end
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -51,6 +51,119 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s) == {:s, 64}
     end
 
+    test "with u64 integers" do
+      s = Series.from_list([9_223_372_036_854_775_808])
+
+      assert Series.to_list(s) === [9_223_372_036_854_775_808]
+      assert Series.dtype(s) == {:u, 64}
+    end
+
+    test "with integers (u64 at end)" do
+      s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808])
+
+      assert Series.to_list(s) === [1, 2, 3, 9_223_372_036_854_775_808]
+      assert Series.dtype(s) == {:u, 64}
+    end
+
+    test "with integers (u64 at start)" do
+      s = Series.from_list([9_223_372_036_854_775_808, 1, 2, 3])
+
+      assert Series.to_list(s) === [9_223_372_036_854_775_808, 1, 2, 3]
+      assert Series.dtype(s) == {:u, 64}
+    end
+
+    test "with u64 integers with dtype u64" do
+      s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808], dtype: {:u, 64})
+
+      assert Series.to_list(s) === [1, 2, 3, 9_223_372_036_854_775_808]
+      assert Series.dtype(s) == {:u, 64}
+    end
+
+    test "with u64 integers and floats" do
+      s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808, 5.0])
+
+      assert Series.to_list(s) === [1.0, 2.0, 3.0, 9.223372036854776e18, 5.0]
+      assert Series.dtype(s) == {:f, 64}
+    end
+
+    test "signed integers with dtype u64 - raises error" do
+      assert_raise ArgumentError,
+                   "the value -1 does not match the inferred dtype {:u, 64}",
+                   fn ->
+                     Series.from_list([-1, 2, 3], dtype: {:u, 64})
+                   end
+    end
+
+    test "s16 integers with dtype s8 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 32767 does not match the inferred dtype {:s, 8}",
+                   fn ->
+                     Series.from_list([32_767, 32_766],
+                       dtype: {:s, 8}
+                     )
+                   end
+    end
+
+    test "s32 integers with dtype s16 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 2147483647 does not match the inferred dtype {:s, 16}",
+                   fn ->
+                     Series.from_list([2_147_483_647, 2_147_483_646],
+                       dtype: {:s, 16}
+                     )
+                   end
+    end
+
+    test "s64 integers with dtype s32 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 9223372036854775807 does not match the inferred dtype {:s, 32}",
+                   fn ->
+                     Series.from_list([9_223_372_036_854_775_807, 9_223_372_036_854_775_806],
+                       dtype: {:s, 32}
+                     )
+                   end
+    end
+
+    test "u16 integers with dtype u8 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 32768 does not match the inferred dtype {:u, 8}",
+                   fn ->
+                     Series.from_list([32768, 32767],
+                       dtype: {:u, 8}
+                     )
+                   end
+    end
+
+    test "u32 integers with dtype u16 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 9223372036854775807 does not match the inferred dtype {:u, 16}",
+                   fn ->
+                     Series.from_list([9_223_372_036_854_775_807, 9_223_372_036_854_775_806],
+                       dtype: {:u, 16}
+                     )
+                   end
+    end
+
+    test "u64 integers with dtype u32 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 9223372036854775808 does not match the inferred dtype {:u, 32}",
+                   fn ->
+                     Series.from_list([9_223_372_036_854_775_808, 9_223_372_036_854_775_809],
+                       dtype: {:u, 32}
+                     )
+                   end
+    end
+
+    test "u64 integers with dtype s64 - raises error" do
+      assert_raise ArgumentError,
+                   "the value 9223372036854775808 does not match the inferred dtype {:s, 64}",
+                   fn ->
+                     Series.from_list([9_223_372_036_854_775_808, 9_223_372_036_854_775_809],
+                       dtype: {:s, 64}
+                     )
+                   end
+    end
+
     test "with floats" do
       s = Series.from_list([1, 2.4, 3])
       assert Series.to_list(s) === [1.0, 2.4, 3.0]


### PR DESCRIPTION
Read this comment for information. https://github.com/elixir-explorer/explorer/pull/826#issuecomment-1898777688

Added some tests as i could not create a series with u64 value

```elixir
s = Series.from_list([9_223_372_036_854_775_807, 9_223_372_036_854_775_806, 9_223_372_036_854_775_808], dtype: {:s, 32}) # error

s = Series.from_list([9_223_372_036_854_775_808]) # inferred as s64 and fails

s = Series.from_list([1, 2, 3, 9_223_372_036_854_775_808]) # mismatch s64 and u64

s = Series.from_list([9_223_372_036_854_775_808, 1, 2, 3]) # mismatch u64 and s64 

s = Series.from_list([1, 2, 3], dtype: {:u, 64}) # as u64 fails

s = Series.from_list([-1, 2, 3], dtype: {:u, 64}) 
```