### PR TITLE
Fix `DF.concat_rows/2` to consider new numeric dtypes

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2107,7 +2107,7 @@ defmodule Explorer.Series do
         dtypes ->
           dtype =
             Enum.reduce(dtypes, fn left, right ->
-              cast_numeric(left, right) ||
+              Shared.merge_dtypes(left, right) ||
                 raise ArgumentError,
                       "cannot concatenate series with mismatched dtypes: #{inspect(dtypes)}. " <>
                         "First cast the series to the desired dtype."
@@ -3182,17 +3182,7 @@ defmodule Explorer.Series do
   defp cast_to_add({:datetime, p}, {:duration, p}), do: {:datetime, p}
   defp cast_to_add({:duration, p}, {:datetime, p}), do: {:datetime, p}
   defp cast_to_add({:duration, p}, {:duration, p}), do: {:duration, p}
-  defp cast_to_add(left, right), do: cast_numeric(left, right)
-
-  defp cast_numeric({int_type, left}, {int_type, right}) when K.in(int_type, [:s, :u]),
-    do: {int_type, max(left, right)}
-
-  defp cast_numeric({:s, s_size}, {:u, u_size}), do: {:s, max(min(64, u_size * 2), s_size)}
-  defp cast_numeric({:u, s_size}, {:s, u_size}), do: {:s, max(min(64, u_size * 2), s_size)}
-  defp cast_numeric({int_type, _}, {:f, _} = float) when K.in(int_type, [:s, :u]), do: float
-  defp cast_numeric({:f, _} = float, {int_type, _}) when K.in(int_type, [:s, :u]), do: float
-  defp cast_numeric({:f, left}, {:f, right}), do: {:f, max(left, right)}
-  defp cast_numeric(_, _), do: nil
+  defp cast_to_add(left, right), do: Shared.merge_dtypes(left, right)
 
   @doc """
   Subtracts right from left, element-wise.
@@ -3256,7 +3246,7 @@ defmodule Explorer.Series do
   defp cast_to_subtract({:datetime, p}, {:datetime, p}), do: {:duration, p}
   defp cast_to_subtract({:datetime, p}, {:duration, p}), do: {:datetime, p}
   defp cast_to_subtract({:duration, p}, {:duration, p}), do: {:duration, p}
-  defp cast_to_subtract(left, right), do: cast_numeric(left, right)
+  defp cast_to_subtract(left, right), do: Shared.merge_dtypes(left, right)
 
   @doc """
   Multiplies left and right, element-wise.
@@ -3308,7 +3298,7 @@ defmodule Explorer.Series do
   defp cast_to_multiply({:duration, p}, {:s, _}), do: {:duration, p}
   defp cast_to_multiply({:f, _}, {:duration, p}), do: {:duration, p}
   defp cast_to_multiply({:duration, p}, {:f, _}), do: {:duration, p}
-  defp cast_to_multiply(left, right), do: cast_numeric(left, right)
+  defp cast_to_multiply(left, right), do: Shared.merge_dtypes(left, right)
 
   @doc """
   Divides left by right, element-wise.

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2448,7 +2448,7 @@ defmodule Explorer.DataFrameTest do
 
       df3 = DF.concat_rows(df1, df2)
 
-      assert DF.dtypes(df3) == %{"x" => {:u, 64}, "y" => :string}
+      assert DF.dtypes(df3) == %{"x" => {:u, 32}, "y" => :string}
 
       assert Series.to_list(df3["x"]) == [1, 2, 3, 4, 5, 6]
     end
@@ -2462,7 +2462,7 @@ defmodule Explorer.DataFrameTest do
 
       df3 = DF.concat_rows(df1, df2)
 
-      assert DF.dtypes(df3) == %{"x" => {:s, 64}, "y" => :string}
+      assert DF.dtypes(df3) == %{"x" => {:s, 32}, "y" => :string}
 
       assert Series.to_list(df3["x"]) == [1, 2, 3, 4, 5, 6]
     end


### PR DESCRIPTION
Related to https://github.com/elixir-explorer/explorer/issues/794