### PR TITLE
fix for Series.concat/2  for null series

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2096,13 +2096,15 @@ defmodule Explorer.Series do
   @doc type: :shape
   @spec concat([Series.t()]) :: Series.t()
   def concat([%Series{} | _t] = series) do
+    dtypes = series |> Enum.map(& &1.dtype) |> Enum.uniq()
+
     series =
-      case series |> Enum.map(& &1.dtype) |> Enum.uniq() |> List.delete(:null) do
+      case dtypes |> List.delete(:null) do
         [] ->
           series
 
-        [_] ->
-          series
+        [dtype] ->
+          if Enum.member?(dtypes, :null), do: Enum.map(series, &cast(&1, dtype)), else: series
 
         dtypes ->
           dtype =

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2099,7 +2099,7 @@ defmodule Explorer.Series do
     dtypes = series |> Enum.map(& &1.dtype) |> Enum.uniq()
 
     series =
-      case dtypes |> List.delete(:null) do
+      case List.delete(dtypes, :null) do
         [] ->
           series
 


### PR DESCRIPTION
```  
1) test concat/1 concat null with {:s, 8} (Explorer.SeriesTest)
     test/explorer/series_test.exs:3866
     ** (RuntimeError) Polars Error: data types don't match: cannot extend/append Null with Int8
     code: sr = Series.concat([sn, s1])
     stacktrace:
       (explorer 0.8.0-dev) lib/explorer/polars_backend/shared.ex:17: Explorer.PolarsBackend.Shared.apply/2
       (explorer 0.8.0-dev) lib/explorer/polars_backend/series.ex:145: Explorer.PolarsBackend.Series.concat/1
       test/explorer/series_test.exs:3870: (test)
```