### PR TITLE
Add DataFrame.with_row_count/2

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -213,11 +213,11 @@ defmodule Explorer.Backend.DataFrame do
   @callback unnest(df, out_df :: df(), columns :: [column_name()]) :: df()
   @callback correlation(df, out_df :: df(), ddof :: integer(), method :: atom()) :: df()
   @callback covariance(df, out_df :: df(), ddof :: integer()) :: df()
-  @callback with_row_count(
+  @callback with_row_index(
               df,
               out_df :: df(),
-              option(column_name()),
-              offset :: option(integer())
+              name :: option(column_name()),
+              offset :: option(non_neg_integer())
             ) ::
               df
 

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -213,6 +213,13 @@ defmodule Explorer.Backend.DataFrame do
   @callback unnest(df, out_df :: df(), columns :: [column_name()]) :: df()
   @callback correlation(df, out_df :: df(), ddof :: integer(), method :: atom()) :: df()
   @callback covariance(df, out_df :: df(), ddof :: integer()) :: df()
+  @callback with_row_count(
+              df,
+              out_df :: df(),
+              option(column_name()),
+              offset :: option(integer())
+            ) ::
+              df
 
   # Two or more table verbs
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4721,6 +4721,51 @@ defmodule Explorer.DataFrame do
     %{out_df | groups: Enum.filter(df.groups, &(&1 in id_columns))}
   end
 
+  @doc """
+  Add a row index as the first column in the DataFrame.
+
+  The resulting column does not have any special properties. It is a regular
+  column of type UInt32.
+
+  ## Options
+
+    * `:name` - Name of the column to add.
+    * `:offset` - Start the row count at this offset. Defaults to 0.
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.new(a: [1, 3, 5], b: [2, 4, 6])
+      iex> Explorer.DataFrame.with_row_count(df)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        row_nr u32 [0, 1, 2]
+        a s64 [1, 3, 5]
+        b s64 [2, 4, 6]
+      >
+
+      iex> df = Explorer.DataFrame.new(a: [1, 3, 5], b: [2, 4, 6])
+      iex> Explorer.DataFrame.with_row_count(df, name: "id", offset: 1000)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        id u32 [1000, 1001, 1002]
+        a s64 [1, 3, 5]
+        b s64 [2, 4, 6]
+      >
+
+  """
+  @doc type: :single
+  @spec with_row_count(df :: DataFrame.t(), opts :: Keyword.t()) :: DataFrame.t()
+  def with_row_count(%DataFrame{} = df, opts \\ []) do
+    opts = Keyword.validate!(opts, name: "row_nr", offset: 0)
+    name = opts[:name]
+
+    new_names = [name | df.names]
+    new_dtypes = Map.put(df.dtypes, name, {:s, 32})
+
+    out_df = %{df | names: new_names, dtypes: new_dtypes}
+    Shared.apply_impl(df, :with_row_count, [out_df, name, opts[:offset]])
+  end
+
   # Two table verbs
 
   @valid_join_types [:inner, :left, :right, :outer, :cross]

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4738,7 +4738,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.with_row_index(df)
       #Explorer.DataFrame<
         Polars[3 x 3]
-        row_nr u32 [0, 1, 2]
+        index u32 [0, 1, 2]
         a s64 [1, 3, 5]
         b s64 [2, 4, 6]
       >
@@ -4756,7 +4756,7 @@ defmodule Explorer.DataFrame do
   @doc type: :single
   @spec with_row_index(df :: DataFrame.t(), opts :: Keyword.t()) :: DataFrame.t()
   def with_row_index(%DataFrame{} = df, opts \\ []) do
-    opts = Keyword.validate!(opts, name: "row_nr", offset: 0)
+    opts = Keyword.validate!(opts, name: "index", offset: 0)
     name = opts[:name]
     offset = opts[:offset]
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -724,6 +724,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
     Shared.apply_dataframe(df, df, :df_slice_by_series, [row_indices.data, df.groups])
   end
 
+  @impl true
+  def with_row_count(%DataFrame{} = df, %DataFrame{} = out_df, name, offset) do
+    Shared.apply_dataframe(df, out_df, :df_with_row_count, [name, offset])
+  end
+
   # TODO: If we expose group_indices at the Explorer.DataFrame level,
   # then we can implement this in pure Elixir.
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -725,7 +725,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def with_row_count(%DataFrame{} = df, %DataFrame{} = out_df, name, offset) do
+  def with_row_index(%DataFrame{} = df, %DataFrame{} = out_df, name, offset) do
     Shared.apply_dataframe(df, out_df, :df_with_row_count, [name, offset])
   end
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -726,7 +726,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def with_row_index(%DataFrame{} = df, %DataFrame{} = out_df, name, offset) do
-    Shared.apply_dataframe(df, out_df, :df_with_row_count, [name, offset])
+    Shared.apply_dataframe(df, out_df, :df_with_row_index, [name, offset])
   end
 
   # TODO: If we expose group_indices at the Explorer.DataFrame level,

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -443,7 +443,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
   @impl true
   def with_row_index(%DF{} = df, %DF{} = out_df, name, offset) do
-    Shared.apply_dataframe(df, out_df, :lf_with_row_count, [name, offset])
+    Shared.apply_dataframe(df, out_df, :lf_with_row_index, [name, offset])
   end
 
   # Groups

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -442,7 +442,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     do: Shared.apply_dataframe(df, out_df, :lf_unnest, [columns])
 
   @impl true
-  def with_row_count(%DF{} = df, %DF{} = out_df, name, offset) do
+  def with_row_index(%DF{} = df, %DF{} = out_df, name, offset) do
     Shared.apply_dataframe(df, out_df, :lf_with_row_count, [name, offset])
   end
 

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -441,6 +441,11 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   def unnest(%DF{} = df, %DF{} = out_df, columns),
     do: Shared.apply_dataframe(df, out_df, :lf_unnest, [columns])
 
+  @impl true
+  def with_row_count(%DF{} = df, %DF{} = out_df, name, offset) do
+    Shared.apply_dataframe(df, out_df, :lf_with_row_count, [name, offset])
+  end
+
   # Groups
 
   @impl true

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -182,7 +182,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_nil_count(_df), do: err()
   def df_explode(_df, _columns), do: err()
   def df_unnest(_df, _columns), do: err()
-  def df_with_row_count(_df, _name, _offset), do: err()
+  def df_with_row_index(_df, _name, _offset), do: err()
 
   # Expressions (for lazy queries)
   @multi_arity_expressions [slice: 2, slice: 3, log: 1, log: 2]
@@ -272,7 +272,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_to_parquet(_df, _filename, _compression, _streaming), do: err()
   def lf_to_parquet_cloud(_df, _filename, _compression), do: err()
   def lf_to_ipc(_df, _filename, _compression, _streaming), do: err()
-  def lf_with_row_count(_df, _name, _offset), do: err()
+  def lf_with_row_index(_df, _name, _offset), do: err()
 
   # Series
   def s_as_str(_s), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -182,6 +182,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_nil_count(_df), do: err()
   def df_explode(_df, _columns), do: err()
   def df_unnest(_df, _columns), do: err()
+  def df_with_row_count(_df, _name, _offset), do: err()
 
   # Expressions (for lazy queries)
   @multi_arity_expressions [slice: 2, slice: 3, log: 1, log: 2]
@@ -271,6 +272,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_to_parquet(_df, _filename, _compression, _streaming), do: err()
   def lf_to_parquet_cloud(_df, _filename, _compression), do: err()
   def lf_to_ipc(_df, _filename, _compression, _streaming), do: err()
+  def lf_with_row_count(_df, _name, _offset), do: err()
 
   # Series
   def s_as_str(_s), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -659,7 +659,7 @@ pub fn df_lazy(df: ExDataFrame) -> Result<ExLazyFrame, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn df_with_row_count(
+pub fn df_with_row_index(
     df: ExDataFrame,
     name: &str,
     offset: Option<IdxSize>,

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -657,3 +657,13 @@ pub fn df_lazy(df: ExDataFrame) -> Result<ExLazyFrame, ExplorerError> {
     let new_lf = df.clone_inner().lazy();
     Ok(ExLazyFrame::new(new_lf))
 }
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn df_with_row_count(
+    df: ExDataFrame,
+    name: &str,
+    offset: Option<IdxSize>,
+) -> Result<ExDataFrame, ExplorerError> {
+    let new_df = df.clone_inner().with_row_count(name, offset)?;
+    Ok(ExDataFrame::new(new_df))
+}

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -284,7 +284,7 @@ pub fn lf_concat_columns(
 }
 
 #[rustler::nif]
-pub fn lf_with_row_count(
+pub fn lf_with_row_index(
     data: ExLazyFrame,
     name: &str,
     offset: Option<IdxSize>,

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -282,3 +282,13 @@ pub fn lf_concat_columns(
 
     Ok(ExLazyFrame::new(out_df.drop_columns([id_column])))
 }
+
+#[rustler::nif]
+pub fn lf_with_row_count(
+    data: ExLazyFrame,
+    name: &str,
+    offset: Option<IdxSize>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let lf = data.clone_inner();
+    Ok(ExLazyFrame::new(lf.with_row_count(name, offset)))
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -140,6 +140,7 @@ rustler::init!(
         df_to_parquet_cloud,
         df_unnest,
         df_width,
+        df_with_row_count,
         // expressions
         expr_nil,
         expr_atom,
@@ -310,6 +311,7 @@ rustler::init!(
         lf_to_parquet,
         lf_to_parquet_cloud,
         lf_to_ipc,
+        lf_with_row_count,
         // series
         s_as_str,
         s_abs,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -140,7 +140,7 @@ rustler::init!(
         df_to_parquet_cloud,
         df_unnest,
         df_width,
-        df_with_row_count,
+        df_with_row_index,
         // expressions
         expr_nil,
         expr_atom,
@@ -311,7 +311,7 @@ rustler::init!(
         lf_to_parquet,
         lf_to_parquet_cloud,
         lf_to_ipc,
-        lf_with_row_count,
+        lf_with_row_index,
         // series
         s_as_str,
         s_abs,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4235,7 +4235,7 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
-  describe "with_row_count/2" do
+  describe "with_row_index/2" do
     test "basic example" do
       require Explorer.DataFrame, as: DF
 
@@ -4245,7 +4245,7 @@ defmodule Explorer.DataFrameTest do
           b: [2, 4, 6]
         )
 
-      df1 = DF.with_row_count(df)
+      df1 = DF.with_row_index(df)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                row_nr: [0, 1, 2],
@@ -4263,7 +4263,7 @@ defmodule Explorer.DataFrameTest do
           b: [2, 4, 6]
         )
 
-      df1 = DF.with_row_count(df, name: "id", offset: 1000)
+      df1 = DF.with_row_index(df, name: "id", offset: 1000)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                id: [1000, 1001, 1002],
@@ -4272,4 +4272,24 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "raises on bad offset" do
+      require Explorer.DataFrame, as: DF
+
+      df =
+        DF.new(
+          a: [1, 3, 5],
+          b: [2, 4, 6]
+        )
+
+      assert_raise ArgumentError, "offset cannot be negative", fn ->
+        DF.with_row_index(df, offset: -1)
+      end
+
+      error_message = "offset cannot be cannot be greater than the maximum index value of 2^32"
+
+      assert_raise ArgumentError, error_message, fn ->
+        DF.with_row_index(df, offset: 2 ** 32)
+      end
+    end
+  end
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4234,4 +4234,42 @@ defmodule Explorer.DataFrameTest do
              }
     end
   end
+
+  describe "with_row_count/2" do
+    test "basic example" do
+      require Explorer.DataFrame, as: DF
+
+      df =
+        DF.new(
+          a: [1, 3, 5],
+          b: [2, 4, 6]
+        )
+
+      df1 = DF.with_row_count(df)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               row_nr: [0, 1, 2],
+               a: [1, 3, 5],
+               b: [2, 4, 6]
+             }
+    end
+
+    test "name and offset" do
+      require Explorer.DataFrame, as: DF
+
+      df =
+        DF.new(
+          a: [1, 3, 5],
+          b: [2, 4, 6]
+        )
+
+      df1 = DF.with_row_count(df, name: "id", offset: 1000)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               id: [1000, 1001, 1002],
+               a: [1, 3, 5],
+               b: [2, 4, 6]
+             }
+    end
+
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4248,7 +4248,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.with_row_index(df)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
-               row_nr: [0, 1, 2],
+               index: [0, 1, 2],
                a: [1, 3, 5],
                b: [2, 4, 6]
              }


### PR DESCRIPTION
Do note that `with_row_count` was renamed in polars/main to `with_row_index` (ref https://github.com/pola-rs/polars/pull/13494), so perhaps we should wait for a new polars release?