### PR TITLE
Fix for Float Overflow resulting in VM Crash

### DIFF
--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -64,6 +64,16 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s) == {:f, 64}
     end
 
+    test "float 32 overflow" do
+      assert_raise ArgumentError,
+                   "argument error",
+                   fn ->
+                     Series.from_list([1_055_028_234_663_852_885_981_170_418_348_451_692_544.0],
+                       dtype: {:f, 32}
+                     )
+                   end
+    end
+
     test "with nan" do
       s = Series.from_list([:nan, :nan, :nan])
       assert Series.to_list(s) === [:nan, :nan, :nan]


### PR DESCRIPTION
Before
```elixir
Series.from_list([1_055_028_234_663_852_885_981_170_418_348_451_692_544.0], dtype: {:f, 32})
thread '<unnamed>' panicked at src/series.rs:86:1:
called `Result::unwrap()` on an `Err` value: {error, badarg}
stack backtrace:
libunwind: stepWithCompactEncoding - invalid compact unwind encoding
Abort trap: 6
```

After
```elixir
Explorer.Series.from_list([1_055_028_234_663_852_885_981_170_418_348_451_692_544.0], dtype: {:f, 32})
** (ArgumentError) argument error
    (explorer 0.9.0-dev) Explorer.PolarsBackend.Native.s_from_list_f32("", [1.0550282346638529e39])
    (explorer 0.9.0-dev) lib/explorer/polars_backend/series.ex:24: Explorer.PolarsBackend.Series.from_list/2
    (explorer 0.9.0-dev) lib/explorer/series.ex:417: Explorer.Series.from_list/2
    iex:1: (file)
```