### PR TITLE
add field/2 for extracting field from struct

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -141,7 +141,9 @@ defmodule Explorer.Backend.LazySeries do
     # List functions
     join: 2,
     lengths: 1,
-    member: 3
+    member: 3,
+    # Struct functions
+    field: 2
   ]
 
   @comparison_operations [:equal, :not_equal, :greater, :greater_equal, :less, :less_equal]
@@ -1082,6 +1084,14 @@ defmodule Explorer.Backend.LazySeries do
     data = new(:member, [lazy_series!(series), value, inner_dtype], :boolean)
 
     Backend.Series.new(data, :boolean)
+  end
+
+  @impl true
+  def field(%Series{dtype: {:struct, inner_dtype}} = series, name) do
+    dtype = inner_dtype[name]
+    data = new(:field, [lazy_series!(series), name], dtype)
+
+    Backend.Series.new(data, dtype)
   end
 
   @remaining_non_lazy_operations [

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -303,6 +303,9 @@ defmodule Explorer.Backend.Series do
   @callback lengths(s) :: s
   @callback member?(s, valid_types()) :: s
 
+  # Struct
+  @callback field(s, String.t()) :: s
+
   # Functions
 
   @doc """

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -139,7 +139,10 @@ defmodule Explorer.PolarsBackend.Expression do
     # Lists
     join: 2,
     lengths: 1,
-    member: 3
+    member: 3,
+
+    # Structs
+    field: 2
   ]
 
   @custom_expressions [

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -448,5 +448,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_lengths(_s), do: err()
   def s_member(_s, _value, _inner_dtype), do: err()
 
+  def s_field(_s, _name), do: err()
+
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -734,6 +734,10 @@ defmodule Explorer.PolarsBackend.Series do
   def member?(%Series{dtype: {:list, inner_dtype}} = series, value),
     do: Shared.apply_series(series, :s_member, [value, inner_dtype])
 
+  @impl true
+  def field(%Series{dtype: {:struct, _inner_dtype}} = series, name),
+    do: Shared.apply_series(series, :s_field, [name])
+
   # Polars specific functions
 
   def name(series), do: Shared.apply_series(series, :s_name)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6020,6 +6020,29 @@ defmodule Explorer.Series do
     apply_series(series, :transform, [fun])
   end
 
+  @doc """
+  Extracts a field from a struct series
+
+  ## Examples
+
+      iex> s = Series.from_list([%{a: 1}, %{a: 2}])
+      iex> Series.field(s, "a")
+      #Explorer.Series<
+        Polars[2]
+        s64 [1, 2]
+      >
+  """
+  @doc type: :list_wise
+  @spec field(Series.t(), Explorer.Backend.Series.valid_types()) :: Series.t()
+  def field(%Series{dtype: {:struct, dtype}} = series, name) do
+    if Map.has_key?(dtype, name) do
+      apply_series(series, :field, [name])
+    else
+      raise ArgumentError,
+            "field #{inspect(name)} not found in fields #{inspect(Map.keys(dtype))}"
+    end
+  end
+
   # Helpers
 
   defp apply_series(series, fun, args \\ []) do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6033,8 +6033,8 @@ defmodule Explorer.Series do
       >
   """
   @doc type: :struct_wise
-  @spec field(Series.t(), Explorer.Backend.Series.valid_types()) :: Series.t()
-  def field(%Series{dtype: {:struct, dtype}} = series, name) do
+  @spec field(Series.t(), String.t()) :: Series.t()
+  def field(%Series{dtype: {:struct, dtype}} = series, name) when is_binary(name) do
     if Map.has_key?(dtype, name) do
       apply_series(series, :field, [name])
     else

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6032,7 +6032,7 @@ defmodule Explorer.Series do
         s64 [1, 2]
       >
   """
-  @doc type: :list_wise
+  @doc type: :struct_wise
   @spec field(Series.t(), Explorer.Backend.Series.valid_types()) :: Series.t()
   def field(%Series{dtype: {:struct, dtype}} = series, name) do
     if Map.has_key?(dtype, name) do

--- a/mix.exs
+++ b/mix.exs
@@ -93,6 +93,7 @@ defmodule Explorer.MixProject do
         "Functions: Float ops": &(&1[:type] == :float_wise),
         "Functions: String ops": &(&1[:type] == :string_wise),
         "Functions: List ops": &(&1[:type] == :list_wise),
+        "Functions: Struct ops": &(&1[:type] == :struct_wise),
         "Functions: Introspection": &(&1[:type] == :introspection),
         "Functions: IO": &(&1[:type] == :io),
         "Functions: Shape": &(&1[:type] == :shape),

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1059,3 +1059,9 @@ pub fn expr_member(expr: ExExpr, value: ExValidValue, inner_dtype: ExSeriesDtype
             .contains(value.lit_with_matching_precision(&inner_dtype)),
     )
 }
+
+#[rustler::nif]
+pub fn expr_field(expr: ExExpr, name: &str) -> ExExpr {
+    let expr = expr.clone_inner().struct_().field_by_name(name);
+    ExExpr::new(expr)
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -278,6 +278,8 @@ rustler::init!(
         expr_join,
         expr_lengths,
         expr_member,
+        // struct expressions
+        expr_field,
         // lazyframe
         lf_collect,
         lf_describe_plan,
@@ -477,6 +479,7 @@ rustler::init!(
         s_join,
         s_lengths,
         s_member,
+        s_field,
     ],
     load = on_load
 );

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1811,3 +1811,16 @@ fn s_member(
 
     Ok(ExSeries::new(s2))
 }
+
+#[rustler::nif]
+pub fn s_field(s: ExSeries, name: &str) -> Result<ExSeries, ExplorerError> {
+    let s2 = s
+        .clone_inner()
+        .into_frame()
+        .lazy()
+        .select([col(s.name()).struct_().field_by_name(name).alias(name)])
+        .collect()?
+        .column(name)?
+        .clone();
+    Ok(ExSeries::new(s2))
+}

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -660,6 +660,21 @@ defmodule Explorer.DataFrameTest do
       assert df1.names == ["a", "b"]
       assert df1.dtypes == %{"a" => {:f, 64}, "b" => :string}
     end
+
+    test "extracts a field from struct to new column" do
+      df = DF.new([%{a: %{n: 1}}, %{a: %{n: 1}}])
+      df2 = DF.mutate(df, n: field(a, "n"))
+      assert df.dtypes == %{"a" => {:struct, %{"n" => {:s, 64}}}}
+      assert df2.dtypes == %{"a" => {:struct, %{"n" => {:s, 64}}}, "n" => {:s, 64}}
+    end
+
+    test "throws error when a field is not found in struct" do
+      df = DF.new([%{a: %{n: 1}}, %{a: %{n: 1}}])
+
+      assert_raise ArgumentError, "field \"m\" not found in fields [\"n\"]", fn ->
+        DF.mutate(df, n: field(a, "m"))
+      end
+    end
   end
 
   describe "mutate/2" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -23,7 +23,8 @@ defmodule Explorer.SeriesTest do
           :float_wise,
           :string_wise,
           :datetime_wise,
-          :list_wise
+          :list_wise,
+          :struct_wise
         ] do
       flunk("invalid @doc type: #{inspect(metadata[:type])} for #{name}/#{arity}")
     end
@@ -5846,6 +5847,23 @@ defmodule Explorer.SeriesTest do
 
       assert Series.dtype(peaks) == :boolean
       assert Series.to_list(peaks) == [false, true, false, true, false]
+    end
+  end
+
+  describe "field/2" do
+    test "extract field" do
+      s = Series.from_list([%{a: 1}, %{a: 2}])
+      a = Series.field(s, "a")
+      assert s.dtype == {:struct, %{"a" => {:s, 64}}}
+      assert a.dtype == {:s, 64}
+    end
+
+    test "raise error - invalid field" do
+      s = Series.from_list([%{a: 1}, %{a: 2}])
+
+      assert_raise ArgumentError, "field \"m\" not found in fields [\"a\"]", fn ->
+        Series.field(s, "m")
+      end
     end
   end
 end


### PR DESCRIPTION
```elixir
iex> s = Series.from_list([%{a: 1}, %{a: 2}])
iex> Series.field(s, "a")
#Explorer.Series<
  Polars[2]
  s64 [1, 2]
>
iex> Series.field(s, "b")
* (ArgumentError) field "b" not found in fields ["a"]
    (explorer 0.9.0-dev) lib/explorer/series.ex:6041: Explorer.Series.field/2
    iex:3: (file)

iex> df = DF.new([%{a: %{n: 1}}, %{a: %{n: 1}}])
iex> DF.mutate(df, n: field(a, "n"))
#Explorer.DataFrame<
  Polars[2 x 2]
  a struct[1] [%{"n" => 1}, %{"n" => 1}]
  n s64 [1, 1]
>
iex> DF.mutate(df, n: field(a, "m"))
** (ArgumentError) field "m" not found in fields ["n"]
    (explorer 0.9.0-dev) lib/explorer/series.ex:6041: Explorer.Series.field/2
    iex:3: (file)
    iex:3: (file)
```