### PR TITLE
remove  deprecated funcs from docs

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1622,7 +1622,7 @@ defmodule Explorer.DataFrame do
   def lazy(df), do: Shared.apply_impl(df, :lazy)
 
   @deprecated "Use lazy/1 instead"
-  @doc type: :deprecated
+  @doc false
   def to_lazy(df), do: Shared.apply_impl(df, :lazy)
 
   @doc """
@@ -3173,7 +3173,7 @@ defmodule Explorer.DataFrame do
   end
 
   @deprecated "Use sort_by/3 instead"
-  @doc type: :deprecated
+  @doc false
   defmacro arrange(df, query, opts \\ []) do
     quote do
       Explorer.DataFrame.sort_by(unquote(df), unquote(query), unquote(opts))
@@ -3299,7 +3299,7 @@ defmodule Explorer.DataFrame do
   end
 
   @deprecated "Use sort_with/3 instead"
-  @doc type: :deprecated
+  @doc false
   def arrange_with(df, fun, opts \\ []), do: sort_with(df, fun, opts)
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -97,8 +97,7 @@ defmodule Explorer.MixProject do
         "Functions: Introspection": &(&1[:type] == :introspection),
         "Functions: IO": &(&1[:type] == :io),
         "Functions: Shape": &(&1[:type] == :shape),
-        "Functions: Window": &(&1[:type] == :window),
-        "Functions: Deprecated": &(&1[:type] == :deprecated)
+        "Functions: Window": &(&1[:type] == :window)
       ],
       extras: ["notebooks/exploring_explorer.livemd", "CHANGELOG.md"],
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"]


### PR DESCRIPTION
Edit: Removed from docs 

Original: 
Deprecated function docs  do not have links - the names  are just displayed as text. 

https://hexdocs.pm/explorer/Explorer.DataFrame.html#functions-deprecated

