### PR TITLE
Check duplicate keys dataframe rename column

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3635,11 +3635,10 @@ defmodule Explorer.DataFrame do
   end
 
   defp maybe_raise_column_duplicate(pairs) when is_column_pairs(pairs) do
-    Enum.reduce(pairs, MapSet.new(), fn {col, _val}, seen ->
-      case col in seen do
-        true -> raise ArgumentError, "duplicate column name \"#{col}\" in rename"
-        false -> MapSet.put(seen, col)
-      end
+    Enum.reduce(pairs, [], fn {col, _val}, seen ->
+      if col in seen, do: raise(ArgumentError, "duplicate column name \"#{col}\" in rename")
+
+      [col | seen]
     end)
   end
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3609,8 +3609,11 @@ defmodule Explorer.DataFrame do
         df
 
       pairs ->
-        maybe_raise_column_duplicate(pairs)
         pairs_map = Map.new(pairs)
+
+        if Enum.count(pairs) != map_size(pairs_map),
+          do: raise(ArgumentError, "duplicate source column for rename")
+
         old_dtypes = df.dtypes
 
         for {name, _} <- pairs do
@@ -3632,14 +3635,6 @@ defmodule Explorer.DataFrame do
         out_df = %{df | names: new_names, dtypes: Map.new(new_dtypes), groups: new_groups}
         Shared.apply_impl(df, :rename, [out_df, pairs])
     end
-  end
-
-  defp maybe_raise_column_duplicate(pairs) when is_column_pairs(pairs) do
-    Enum.reduce(pairs, [], fn {col, _val}, seen ->
-      if col in seen, do: raise(ArgumentError, "duplicate column name \"#{col}\" in rename")
-
-      [col | seen]
-    end)
   end
 
   defp check_new_names_length!(df, names) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3609,6 +3609,7 @@ defmodule Explorer.DataFrame do
         df
 
       pairs ->
+        maybe_raise_column_duplicate(pairs)
         pairs_map = Map.new(pairs)
         old_dtypes = df.dtypes
 
@@ -3631,6 +3632,15 @@ defmodule Explorer.DataFrame do
         out_df = %{df | names: new_names, dtypes: Map.new(new_dtypes), groups: new_groups}
         Shared.apply_impl(df, :rename, [out_df, pairs])
     end
+  end
+
+  defp maybe_raise_column_duplicate(pairs) when is_column_pairs(pairs) do
+    Enum.reduce(pairs, MapSet.new(), fn {col, _val}, seen ->
+      case col in seen do
+        true -> raise ArgumentError, "duplicate column name \"#{col}\" in rename"
+        false -> MapSet.put(seen, col)
+      end
+    end)
   end
 
   defp check_new_names_length!(df, names) do

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -533,7 +533,7 @@ pub fn df_rename_columns(
 ) -> Result<ExDataFrame, ExplorerError> {
     let mut df = df.clone();
     for (original, new_name) in renames {
-        df.rename(original, new_name).expect("should rename");
+        df.rename(original, new_name)?;
     }
 
     Ok(ExDataFrame::new(df))

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2766,8 +2766,24 @@ defmodule Explorer.DataFrameTest do
     test "with keyword and a column that is duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      assert_raise ArgumentError, ~r"duplicate column name \"a\"", fn ->
+      assert_raise ArgumentError, ~r"duplicate source or target column for rename", fn ->
         DF.rename(df, a: "first", a: "second")
+      end
+    end
+
+    test "with mix of column names and indices" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      assert_raise ArgumentError, ~r"duplicate source or target column for rename", fn ->
+        DF.rename(df, [{"a", "first"}, {0, "g"}])
+      end
+    end
+
+    test "with binary tuples and a column that is duplicated" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      assert_raise ArgumentError, ~r"duplicate source or target column for rename", fn ->
+        DF.rename(df, [{"a", "first"}, {"a", "second"}])
       end
     end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2763,6 +2763,14 @@ defmodule Explorer.DataFrameTest do
       end
     end
 
+    test "with keyword and a column that is duplicated" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      assert_raise ArgumentError, ~r"duplicate column name \"g\"", fn ->
+        DF.rename(df, a: "first", a: "second")
+      end
+    end
+
     test "with a map and a column that doesn't exist" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2771,7 +2771,7 @@ defmodule Explorer.DataFrameTest do
       end
     end
 
-    test "with mix of column names and indices" do
+    test "with mix of column name and index that is duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
       assert_raise ArgumentError, ~r"duplicate source column for rename", fn ->
@@ -2779,7 +2779,7 @@ defmodule Explorer.DataFrameTest do
       end
     end
 
-    test "with binary tuples and a column that is duplicated" do
+    test "with string column names that are duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
       assert_raise ArgumentError, ~r"duplicate source column for rename", fn ->
@@ -2787,7 +2787,7 @@ defmodule Explorer.DataFrameTest do
       end
     end
 
-    test "with binary tuples and a target column that is duplicated" do
+    test "with string column names and a target that is duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
       assert_raise RuntimeError, ~r"duplicate column names found", fn ->

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2766,7 +2766,7 @@ defmodule Explorer.DataFrameTest do
     test "with keyword and a column that is duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      assert_raise ArgumentError, ~r"duplicate source or target column for rename", fn ->
+      assert_raise ArgumentError, ~r"duplicate source column for rename", fn ->
         DF.rename(df, a: "first", a: "second")
       end
     end
@@ -2774,7 +2774,7 @@ defmodule Explorer.DataFrameTest do
     test "with mix of column names and indices" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      assert_raise ArgumentError, ~r"duplicate source or target column for rename", fn ->
+      assert_raise ArgumentError, ~r"duplicate source column for rename", fn ->
         DF.rename(df, [{"a", "first"}, {0, "g"}])
       end
     end
@@ -2782,8 +2782,16 @@ defmodule Explorer.DataFrameTest do
     test "with binary tuples and a column that is duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      assert_raise ArgumentError, ~r"duplicate source or target column for rename", fn ->
+      assert_raise ArgumentError, ~r"duplicate source column for rename", fn ->
         DF.rename(df, [{"a", "first"}, {"a", "second"}])
+      end
+    end
+
+    test "with binary tuples and a target column that is duplicated" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      assert_raise RuntimeError, ~r"duplicate column names found", fn ->
+        DF.rename(df, [{"a", "first"}, {"b", "first"}])
       end
     end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2766,7 +2766,7 @@ defmodule Explorer.DataFrameTest do
     test "with keyword and a column that is duplicated" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      assert_raise ArgumentError, ~r"duplicate column name \"g\"", fn ->
+      assert_raise ArgumentError, ~r"duplicate column name \"a\"", fn ->
         DF.rename(df, a: "first", a: "second")
       end
     end


### PR DESCRIPTION
Adds a column pair check to the rename function prior to passing to Polars. Fixes #848 

The root cause of the NIF panic was that Polars is unable to find the column a second time. So when given a rename with the same column name, the second parameter will always fail with `ColumnNotFound`. 

That could be something that is fixed from within Polars, or we could mirror the error message more directly. Though I don't think that would work well as an error without being able to report the partially updated column names which are stuck down in the Rust code at that point.

I opted for a simple argument error which raises when a duplicated column is found. I assume that there are few enough parameters passed to a rename that iterating them isn't a performance hit in any way that matters.

Performing the check after the column pairs are parsed makes things simplest. I'm not sure if this is something that bears abstracting into the `Shared` module, but I named the function according to the patterns I saw there.

I'm not sold on my error message. If there's a consistent way that error messages are written, please advise on that.

I wrote a test for the case of a keyword list only, as the case of a map given to rename will raise a warning to the user alerting them to the duplicate key and it will be overwritten such that this error doesn't occur.