### PR TITLE
Change inner dtypes of structs to tuple lists

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -1090,7 +1090,7 @@ defmodule Explorer.Backend.LazySeries do
 
   @impl true
   def field(%Series{dtype: {:struct, inner_dtype}} = series, name) do
-    dtype = inner_dtype[name]
+    {^name, dtype} = List.keyfind!(inner_dtype, name, 0)
     data = new(:field, [lazy_series!(series), name], dtype)
 
     Backend.Series.new(data, dtype)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5612,8 +5612,8 @@ defmodule Explorer.DataFrame do
       columns
       |> Enum.zip(dtypes)
       |> Enum.reduce({%{}, %{}}, fn {column, {:struct, inner_dtypes}}, {new_dtypes, new_names} ->
-        new_dtypes = Map.merge(new_dtypes, inner_dtypes)
-        new_names = Map.put(new_names, column, Map.keys(inner_dtypes))
+        new_dtypes = Map.merge(new_dtypes, Map.new(inner_dtypes))
+        new_names = Map.put(new_names, column, Enum.map(inner_dtypes, &elem(&1, 0)))
 
         {new_dtypes, new_names}
       end)

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -130,7 +130,7 @@ defmodule Explorer.PolarsBackend.Shared do
     series =
       for {column, values} <- Table.to_columns(list) do
         column = to_string(column)
-        inner_type = Map.fetch!(fields, column)
+        {^column, inner_type} = List.keyfind!(fields, column, 0)
         from_list(values, inner_type, column)
       end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -53,13 +53,21 @@ defmodule Explorer.Shared do
     inner_types
     |> Enum.reduce_while([], fn {key, dtype}, normalized_dtypes ->
       case normalise_dtype(dtype) do
-        nil -> {:halt, nil}
-        dtype -> {:cont, List.keystore(normalized_dtypes, key, 0, {key, dtype})}
+        nil ->
+          {:halt, nil}
+
+        dtype ->
+          key = to_string(key)
+          {:cont, List.keystore(normalized_dtypes, key, 0, {key, dtype})}
       end
     end)
     |> then(fn
-      nil -> nil
-      normalized_dtypes -> {:struct, normalized_dtypes}
+      nil ->
+        nil
+
+      normalized_dtypes ->
+        {:struct,
+         if(is_map(inner_types), do: Enum.sort(normalized_dtypes), else: normalized_dtypes)}
     end)
   end
 
@@ -74,11 +82,6 @@ defmodule Explorer.Shared do
   def normalise_dtype(:u16), do: {:u, 16}
   def normalise_dtype(:u32), do: {:u, 32}
   def normalise_dtype(:u64), do: {:u, 64}
-
-  def normalise_dtype({:struct, enum}) do
-    normalized = Enum.map(enum, fn {k, v} -> {to_string(k), normalize_dtype(v)} end)
-    {:struct, if(is_map(enum), do: Enum.sort(normalized), else: normalized)}
-  end
 
   def normalise_dtype(_dtype), do: nil
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -75,8 +75,10 @@ defmodule Explorer.Shared do
   def normalise_dtype(:u32), do: {:u, 32}
   def normalise_dtype(:u64), do: {:u, 64}
 
-  def normalise_dtype({:struct, map}) when is_map(map),
-    do: {:struct, map |> Map.to_list() |> List.keysort(0)}
+  def normalise_dtype({:struct, enum}) do
+    normalized = Enum.map(enum, fn {k, v} -> {to_string(k), normalize_dtype(v)} end)
+    {:struct, if(is_map(enum), do: Enum.sort(normalized), else: normalized)}
+  end
 
   def normalise_dtype(_dtype), do: nil
 

--- a/native/explorer/src/datatypes/ex_dtypes.rs
+++ b/native/explorer/src/datatypes/ex_dtypes.rs
@@ -114,8 +114,6 @@ impl TryFrom<&DataType> for ExSeriesDtype {
                         .push((field.name().to_string(), Self::try_from(field.data_type())?));
                 }
 
-                struct_fields.sort_by(|(a, _), (b, _)| a.cmp(b));
-
                 Ok(ExSeriesDtype::Struct(struct_fields))
             }
 

--- a/test/explorer/data_frame/ndjson_test.exs
+++ b/test/explorer/data_frame/ndjson_test.exs
@@ -125,6 +125,24 @@ defmodule Explorer.DataFrame.NDJSONTest do
       assert_ndjson({:struct, %{"a" => {:s, 64}}}, [%{a: 1}], %{"a" => 1})
     end
 
+    test "infers correctly ordered dtype from ordered source" do
+      df =
+        """
+        {"col": {"b": "b", "a": "a"}}
+        """
+        |> DF.load_ndjson!()
+
+      assert df["col"].dtype == {:struct, [{"b", :string}, {"a", :string}]}
+
+      df1 =
+        """
+        {"col": {"a": "a", "b": "b"}}
+        """
+        |> DF.load_ndjson!()
+
+      assert df1["col"].dtype == {:struct, [{"a", :string}, {"b", :string}]}
+    end
+
     # test "date" do
     #   assert_ndjson(:date, "19327", ~D[2022-12-01])
     #   assert_ndjson(:date, "-3623", ~D[1960-01-31])

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -664,8 +664,8 @@ defmodule Explorer.DataFrameTest do
     test "extracts a field from struct to new column" do
       df = DF.new([%{a: %{n: 1}}, %{a: %{n: 1}}])
       df2 = DF.mutate(df, n: field(a, "n"))
-      assert df.dtypes == %{"a" => {:struct, %{"n" => {:s, 64}}}}
-      assert df2.dtypes == %{"a" => {:struct, %{"n" => {:s, 64}}}, "n" => {:s, 64}}
+      assert df.dtypes == %{"a" => {:struct, [{"n", {:s, 64}}]}}
+      assert df2.dtypes == %{"a" => {:struct, [{"n", {:s, 64}}]}, "n" => {:s, 64}}
     end
 
     test "throws error when a field is not found in struct" do
@@ -4297,7 +4297,7 @@ defmodule Explorer.DataFrameTest do
                "dt" => {:datetime, :microsecond},
                "f" => {:f, 64},
                "l" => {:list, {:s, 64}},
-               "st" => {:struct, %{"n" => {:s, 64}}}
+               "st" => {:struct, [{"n", {:s, 64}}]}
              }
 
       assert df1 |> DF.collect() |> DF.to_columns() == %{

--- a/test/explorer/series/list_test.exs
+++ b/test/explorer/series/list_test.exs
@@ -171,18 +171,28 @@ defmodule Explorer.Series.ListTest do
 
     test "list of structs" do
       series =
-        Series.from_list([[%{"a" => 42}], []], dtype: {:list, {:struct, %{"a" => :integer}}})
+        Series.from_list([[%{"a" => 42}], []], dtype: {:list, {:struct, [{"a", :integer}]}})
 
-      assert Series.dtype(series) == {:list, {:struct, %{"a" => {:s, 64}}}}
+      assert Series.dtype(series) == {:list, {:struct, [{"a", {:s, 64}}]}}
       assert Series.to_list(series) == [[%{"a" => 42}], []]
     end
 
     test "list of structs with first empty" do
       series =
-        Series.from_list([[], [%{"a" => 42}], []], dtype: {:list, {:struct, %{"a" => :integer}}})
+        Series.from_list([[], [%{"a" => 42}], []], dtype: {:list, {:struct, [{"a", :integer}]}})
 
-      assert Series.dtype(series) == {:list, {:struct, %{"a" => {:s, 64}}}}
+      assert Series.dtype(series) == {:list, {:struct, [{"a", {:s, 64}}]}}
       assert Series.to_list(series) == [[], [%{"a" => 42}], []]
+    end
+
+    test "list of structs and multiple fields" do
+      series =
+        Series.from_list([[], [%{"a" => 42, "b" => "f"}], []],
+          dtype: {:list, {:struct, [{"a", :integer}, {"b", :string}]}}
+        )
+
+      assert Series.dtype(series) == {:list, {:struct, [{"a", {:s, 64}}, {"b", :string}]}}
+      assert Series.to_list(series) == [[], [%{"a" => 42, "b" => "f"}], []]
     end
   end
 

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -85,6 +85,18 @@ defmodule Explorer.Series.StructTest do
       assert Series.to_list(series) == [[%{"a" => 1}, %{"a" => 2}], [%{"a" => 3}]]
     end
 
+    test "allows custom dtype for struct values" do
+      s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, a: :u8})
+      assert s.dtype == {:struct, [{"a", {:u, 8}}]}
+
+      assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+
+      s1 = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}], dtype: {:struct, %{"a" => :s16}})
+      assert s1.dtype == {:struct, [{"a", {:s, 16}}]}
+
+      assert Series.to_list(s1) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
+    end
+
     test "preserves manually provided dtype order" do
       series =
         Series.from_list(

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -85,6 +85,24 @@ defmodule Explorer.Series.StructTest do
       assert Series.to_list(series) == [[%{"a" => 1}, %{"a" => 2}], [%{"a" => 3}]]
     end
 
+    test "preserves manually provided dtype order" do
+      series =
+        Series.from_list(
+          [%{"a" => "a", "b" => "b"}, %{"b" => "b", "a" => "a"}],
+          dtype: {:struct, [{"b", :string}, {"a", :string}]}
+        )
+
+      assert series.dtype == {:struct, [{"b", :string}, {"a", :string}]}
+
+      series1 =
+        Series.from_list(
+          [%{"a" => "a", "b" => "b"}, %{"b" => "b", "a" => "a"}],
+          dtype: {:struct, [{"a", :string}, {"b", :string}]}
+        )
+
+      assert series1.dtype == {:struct, [{"a", :string}, {"b", :string}]}
+    end
+
     test "errors when structs have mismatched types" do
       assert_raise ArgumentError,
                    "the value \"a\" does not match the inferred dtype {:s, 64}",
@@ -136,6 +154,16 @@ defmodule Explorer.Series.StructTest do
              ]
 
       assert Series.dtype(s1) == {:struct, [{"a", {:datetime, :microsecond}}]}
+    end
+
+    test "can cast dtype order" do
+      series =
+        Series.from_list([%{"a" => "a", "b" => "b"}, %{"b" => "b", "a" => "a"}],
+          dtype: {:struct, [{"a", :string}, {"b", :string}]}
+        )
+
+      casted = Series.cast(series, {:struct, [{"b", :string}, {"a", :string}]})
+      assert casted.dtype == {:struct, [{"b", :string}, {"a", :string}]}
     end
 
     test "errors when casting to invalid nested types" do

--- a/test/explorer/series/struct_test.exs
+++ b/test/explorer/series/struct_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.Series.StructTest do
           %{a: 5, b: nil}
         ])
 
-      assert s.dtype == {:struct, %{"a" => {:s, 64}, "b" => :null}}
+      assert s.dtype == {:struct, [{"a", {:s, 64}}, {"b", :null}]}
 
       assert Series.to_list(s) == [
                %{"a" => nil, "b" => nil},
@@ -24,7 +24,7 @@ defmodule Explorer.Series.StructTest do
     test "allows struct values" do
       s = Series.from_list([%{a: 1}, %{a: 3}, %{a: 5}])
 
-      assert s.dtype == {:struct, %{"a" => {:s, 64}}}
+      assert s.dtype == {:struct, [{"a", {:s, 64}}]}
 
       assert Series.to_list(s) == [%{"a" => 1}, %{"a" => 3}, %{"a" => 5}]
     end
@@ -37,7 +37,7 @@ defmodule Explorer.Series.StructTest do
           %{a: 5, b: 6}
         ])
 
-      assert s.dtype == {:struct, %{"a" => {:s, 64}, "b" => {:s, 64}}}
+      assert s.dtype == {:struct, [{"a", {:s, 64}}, {"b", {:s, 64}}]}
 
       assert Series.to_list(s) == [
                %{"a" => nil, "b" => 2},
@@ -54,7 +54,7 @@ defmodule Explorer.Series.StructTest do
           %{a: %{b: 3}}
         ])
 
-      assert s.dtype == {:struct, %{"a" => {:struct, %{"b" => {:s, 64}}}}}
+      assert s.dtype == {:struct, [{"a", {:struct, [{"b", {:s, 64}}]}}]}
 
       assert Series.to_list(s) == [
                %{"a" => %{"b" => 1}},
@@ -66,7 +66,7 @@ defmodule Explorer.Series.StructTest do
     test "allows structs structs with special float values" do
       series = Series.from_list([%{a: :nan, b: :infinity, c: :neg_infinity}])
 
-      assert series.dtype == {:struct, %{"a" => {:f, 64}, "b" => {:f, 64}, "c" => {:f, 64}}}
+      assert series.dtype == {:struct, [{"a", {:f, 64}}, {"b", {:f, 64}}, {"c", {:f, 64}}]}
       assert series[0] == %{"a" => :nan, "b" => :infinity, "c" => :neg_infinity}
       assert Series.to_list(series) == [%{"a" => :nan, "b" => :infinity, "c" => :neg_infinity}]
     end
@@ -74,14 +74,14 @@ defmodule Explorer.Series.StructTest do
     test "allows structs mixing integers and floats" do
       series = Series.from_list([%{a: 1, b: 2.4}, %{a: 1.5, b: 2}])
 
-      assert series.dtype == {:struct, %{"a" => {:f, 64}, "b" => {:f, 64}}}
+      assert series.dtype == {:struct, [{"a", {:f, 64}}, {"b", {:f, 64}}]}
       assert Series.to_list(series) == [%{"a" => 1.0, "b" => 2.4}, %{"a" => 1.5, "b" => 2.0}]
     end
 
     test "allows nested lists with structs" do
       series = Series.from_list([[%{a: 1}, %{a: 2}], [%{a: 3}]])
 
-      assert series.dtype == {:list, {:struct, %{"a" => {:s, 64}}}}
+      assert series.dtype == {:list, {:struct, [{"a", {:s, 64}}]}}
       assert Series.to_list(series) == [[%{"a" => 1}, %{"a" => 2}], [%{"a" => 3}]]
     end
 
@@ -91,7 +91,7 @@ defmodule Explorer.Series.StructTest do
                    fn -> Series.from_list([%{a: 1}, %{a: "a"}]) end
 
       assert_raise ArgumentError,
-                   "the value %{b: 1} does not match the inferred dtype {:struct, %{\"a\" => {:s, 64}}}",
+                   "the value %{b: 1} does not match the inferred dtype {:struct, [{\"a\", {:s, 64}}]}",
                    fn -> Series.from_list([%{a: 1}, %{b: 1}]) end
 
       assert_raise ArgumentError,
@@ -103,18 +103,18 @@ defmodule Explorer.Series.StructTest do
   describe "cast/2" do
     test "struct with integers to struct with floats" do
       s = Series.from_list([%{a: 1}, %{a: 2}])
-      s1 = Series.cast(s, {:struct, %{"a" => {:f, 64}}})
+      s1 = Series.cast(s, {:struct, [{"a", {:f, 64}}]})
 
       assert Series.to_list(s1) == [%{"a" => 1.0}, %{"a" => 2.0}]
-      assert Series.dtype(s1) == {:struct, %{"a" => {:f, 64}}}
+      assert Series.dtype(s1) == {:struct, [{"a", {:f, 64}}]}
     end
 
     test "nested structs with integers to nested structs with floats" do
       s = Series.from_list([%{a: %{b: 1}}, %{a: %{b: 2}}])
-      s1 = Series.cast(s, {:struct, %{"a" => {:struct, %{"b" => {:f, 64}}}}})
+      s1 = Series.cast(s, {:struct, [{"a", {:struct, [{"b", {:f, 64}}]}}]})
 
       assert Series.to_list(s1) == [%{"a" => %{"b" => 1.0}}, %{"a" => %{"b" => 2.0}}]
-      assert Series.dtype(s1) == {:struct, %{"a" => {:struct, %{"b" => {:f, 64}}}}}
+      assert Series.dtype(s1) == {:struct, [{"a", {:struct, [{"b", {:f, 64}}]}}]}
     end
 
     test "structs with integers to structs with datetimes" do
@@ -126,7 +126,7 @@ defmodule Explorer.Series.StructTest do
           %{a: 1_649_883_642 * 1_000 * 1_000}
         ])
 
-      s1 = Series.cast(s, {:struct, %{"a" => {:datetime, :microsecond}}})
+      s1 = Series.cast(s, {:struct, [{"a", {:datetime, :microsecond}}]})
 
       assert Series.to_list(s1) == [
                %{"a" => ~N[1970-01-01 00:00:00.000001]},
@@ -135,7 +135,7 @@ defmodule Explorer.Series.StructTest do
                %{"a" => ~N[2022-04-13 21:00:42.000000]}
              ]
 
-      assert Series.dtype(s1) == {:struct, %{"a" => {:datetime, :microsecond}}}
+      assert Series.dtype(s1) == {:struct, [{"a", {:datetime, :microsecond}}]}
     end
 
     test "errors when casting to invalid nested types" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -5585,7 +5585,7 @@ defmodule Explorer.SeriesTest do
       series = Series.from_list([%{a: 1}, %{a: 2}])
 
       assert_raise ArgumentError,
-                   ~S'cannot convert series of dtype {:struct, %{"a" => {:s, 64}}} into iovec',
+                   ~S'cannot convert series of dtype {:struct, [{"a", {:s, 64}}]} into iovec',
                    fn -> Series.to_iovec(series) end
     end
   end
@@ -5854,7 +5854,7 @@ defmodule Explorer.SeriesTest do
     test "extract field" do
       s = Series.from_list([%{a: 1}, %{a: 2}])
       a = Series.field(s, "a")
-      assert s.dtype == {:struct, %{"a" => {:s, 64}}}
+      assert s.dtype == {:struct, [{"a", {:s, 64}}]}
       assert a.dtype == {:s, 64}
     end
 
@@ -5886,7 +5886,7 @@ defmodule Explorer.SeriesTest do
     test "extracts struct from json with dtype" do
       s = Series.from_list(["{\"n\": 1}"])
       sj = Series.json_decode(s, {:struct, %{"n" => {:f, 64}}})
-      assert sj.dtype == {:struct, %{"n" => {:f, 64}}}
+      assert sj.dtype == {:struct, [{"n", {:f, 64}}]}
       assert Series.to_list(sj) == [%{"n" => 1.0}]
     end
   end


### PR DESCRIPTION
This change is necessary to keep the position of fields predictable.

This is related to #847 