### PR TITLE
add support for map as expression

### DIFF
--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -323,6 +323,15 @@ defmodule Explorer.PolarsBackend.Expression do
   def to_expr(%Explorer.Duration{} = duration), do: Native.expr_duration(duration)
   def to_expr(%PolarsSeries{} = polars_series), do: Native.expr_series(polars_series)
 
+  def to_expr(map) when is_map(map) do
+    expr_list =
+      Enum.map(map, fn {name, series} ->
+        series |> to_expr() |> alias_expr(name)
+      end)
+
+    Native.expr_struct(expr_list)
+  end
+
   # Used by Explorer.PolarsBackend.DataFrame
   def alias_expr(%__MODULE__{} = expr, alias_name) when is_binary(alias_name) do
     Native.expr_alias(expr, alias_name)

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -212,6 +212,7 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_integer(_number), do: err()
   def expr_series(_series), do: err()
   def expr_string(_string), do: err()
+  def expr_struct(_map), do: err()
 
   # LazyFrame
   def lf_collect(_df), do: err()

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -4,17 +4,17 @@
 // or an expression and returns an expression that is
 // wrapped in an Elixir struct.
 
-use polars::prelude::{
-    col, concat_str, cov, pearson_corr, spearman_rank_corr, when, IntoLazy, LiteralValue,
-    SortOptions,
-};
-use polars::prelude::{DataType, EWMOptions, Expr, Literal, StrptimeOptions, TimeUnit};
-
 use crate::datatypes::{
     ExCorrelationMethod, ExDate, ExDateTime, ExDuration, ExRankMethod, ExSeriesDtype, ExValidValue,
 };
 use crate::series::{cast_str_to_f64, ewm_opts, rolling_opts};
 use crate::{ExDataFrame, ExExpr, ExSeries};
+use polars::lazy::dsl;
+use polars::prelude::{
+    col, concat_str, cov, pearson_corr, spearman_rank_corr, when, IntoLazy, LiteralValue,
+    SortOptions,
+};
+use polars::prelude::{DataType, EWMOptions, Expr, Literal, StrptimeOptions, TimeUnit};
 
 // Useful to get an ExExpr vec into a vec of expressions.
 pub fn ex_expr_to_exprs(ex_exprs: Vec<ExExpr>) -> Vec<Expr> {
@@ -1077,5 +1077,12 @@ pub fn expr_field(expr: ExExpr, name: &str) -> ExExpr {
 pub fn expr_json_decode(expr: ExExpr, ex_dtype: ExSeriesDtype) -> ExExpr {
     let dtype = DataType::try_from(&ex_dtype).unwrap();
     let expr = expr.clone_inner().str().json_decode(Some(dtype), None);
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_struct(ex_exprs: Vec<ExExpr>) -> ExExpr {
+    let exprs = ex_exprs.iter().map(|e| e.clone_inner()).collect();
+    let expr = dsl::as_struct(exprs);
     ExExpr::new(expr)
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -282,6 +282,7 @@ rustler::init!(
         // struct expressions
         expr_field,
         expr_json_decode,
+        expr_struct,
         // lazyframe
         lf_collect,
         lf_describe_plan,


### PR DESCRIPTION
Add `struct` equivalent

```elixir
iex(2)> df = DF.new(%{a: [1, nil, 3], b: ["a", "b", nil]})
#Explorer.DataFrame<
  Polars[3 x 2]
  a s64 [1, nil, 3]
  b string ["a", "b", nil]
>
iex(3)> DF.mutate(df, c: %{a: a, b: b, lit: 1, null: is_nil(a)})
#Explorer.DataFrame<
  Polars[3 x 3]
  a s64 [1, nil, 3]
  b string ["a", "b", nil]
  c struct[4] [
    %{"a" => 1, "b" => "a", "lit" => 1, "null" => false},
    %{"a" => nil, "b" => "b", "lit" => 1, ...},
    %{"a" => 3, "b" => nil, ...}
  ]
>
```

Note: Hiding original text as it is stale as per https://github.com/elixir-explorer/explorer/pull/855#issuecomment-1937523811
<details>
  <summary>Original text</summary>
Add `struct` expression.

```elixir 
df = DF.new(%{a: [1, 2, 3], b: ["a", "b", "c"]})
#Explorer.DataFrame<
  Polars[3 x 2]
  a s64 [1, 2, 3]
  b string ["a", "b", "c"]
>
DF.mutate(df, c: struct([a: a, b: b]))
#Explorer.DataFrame<
  Polars[3 x 3]
  a s64 [1, 2, 3]
  b string ["a", "b", "c"]
  c struct[2] [
    %{"a" => 1, "b" => "a"},
    %{"a" => 2, "b" => "b"},
    %{"a" => 3, "b" => "c"}
  ]
>

Explorer.Series.struct(a: df["a"], b: df["b"])
#Explorer.Series<
  Polars[3]
  struct[2] [
    %{"a" => 1, "b" => "a"},
    %{"a" => 2, "b" => "b"},
    %{"a" => 3, "b" => "c"}
  ]
>
```
</details>