### PR TITLE
add json_path_match/2

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -1105,8 +1105,8 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def json_path_match(series, path) do
-    data = new(:json_path_match, [lazy_series!(series), path], :string)
+  def json_path_match(series, json_path) do
+    data = new(:json_path_match, [lazy_series!(series), json_path], :string)
 
     Backend.Series.new(data, :string)
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -127,6 +127,7 @@ defmodule Explorer.Backend.LazySeries do
     substring: 3,
     split: 2,
     json_decode: 2,
+    json_path_match: 2,
     # Float round
     round: 2,
     floor: 1,
@@ -1101,6 +1102,13 @@ defmodule Explorer.Backend.LazySeries do
     data = new(:json_decode, [lazy_series!(series), dtype], dtype)
 
     Backend.Series.new(data, dtype)
+  end
+
+  @impl true
+  def json_path_match(series, path) do
+    data = new(:json_path_match, [lazy_series!(series), path], :string)
+
+    Backend.Series.new(data, :string)
   end
 
   @remaining_non_lazy_operations [

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -287,6 +287,7 @@ defmodule Explorer.Backend.Series do
   @callback substring(s, integer(), non_neg_integer() | nil) :: s
   @callback split(s, String.t()) :: s
   @callback json_decode(s, dtype()) :: s
+  @callback json_path_match(s, String.t()) :: s
 
   # Date / DateTime
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -137,6 +137,7 @@ defmodule Explorer.PolarsBackend.Expression do
     substring: 3,
     split: 2,
     json_decode: 2,
+    json_path_match: 2,
 
     # Lists
     join: 2,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -451,7 +451,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   def s_field(_s, _name), do: err()
   def s_json_decode(_s, _dtype), do: err()
-  def s_json_path_match(_s, _path), do: err()
+  def s_json_path_match(_s, _json_path), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -451,6 +451,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   def s_field(_s, _name), do: err()
   def s_json_decode(_s, _dtype), do: err()
+  def s_json_path_match(_s, _path), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -743,6 +743,10 @@ defmodule Explorer.PolarsBackend.Series do
   def json_decode(series, dtype),
     do: Shared.apply_series(series, :s_json_decode, [dtype])
 
+  @impl true
+  def json_path_match(series, path),
+    do: Shared.apply_series(series, :s_json_path_match, [path])
+
   # Polars specific functions
 
   def name(series), do: Shared.apply_series(series, :s_name)

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -744,8 +744,8 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_series(series, :s_json_decode, [dtype])
 
   @impl true
-  def json_path_match(series, path),
-    do: Shared.apply_series(series, :s_json_path_match, [path])
+  def json_path_match(series, json_path),
+    do: Shared.apply_series(series, :s_json_path_match, [json_path])
 
   # Polars specific functions
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6118,6 +6118,36 @@ defmodule Explorer.Series do
     apply_series(series, :json_decode, [dtype])
   end
 
+  @doc """
+  Extracts a string series using a [`JSONPath`](https://goessner.net/articles/JsonPath/) from a series. 
+
+  ## Examples
+
+      iex> s = Series.from_list(["{\\"a\\":1}", "{\\"a\\":2}"])
+      iex> Series.json_path_match(s, "$.a")
+      #Explorer.Series<
+        Polars[2]
+        string [\"1\", \"2\"]
+      >
+
+  If `JSONPath` is not found or if the string is invalid JSON or `nil`, 
+  nil is returned for the given entry:
+
+      iex> s = Series.from_list(["{\\"a\\":1}", nil, "{\\"a\\":2}"])
+      iex> Series.json_path_match(s, "$.b")
+      #Explorer.Series<
+        Polars[3]
+        string [nil, nil, nil]
+      >
+
+  It raises an exception if the `JSONPath` is invalid.
+  """
+  @doc type: :string_wise
+  @spec json_path_match(Series.t(), String.t()) :: Series.t()
+  def json_path_match(%Series{dtype: :string} = series, path) do
+    apply_series(series, :json_path_match, [path])
+  end
+
   # Helpers
 
   defp apply_series(series, fun, args \\ []) do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6119,7 +6119,7 @@ defmodule Explorer.Series do
   end
 
   @doc """
-  Extracts a string series using a [`JSONPath`](https://goessner.net/articles/JsonPath/) from a series. 
+  Extracts a string series using a [`json_path`](https://goessner.net/articles/JsonPath/) from a series. 
 
   ## Examples
 
@@ -6144,8 +6144,8 @@ defmodule Explorer.Series do
   """
   @doc type: :string_wise
   @spec json_path_match(Series.t(), String.t()) :: Series.t()
-  def json_path_match(%Series{dtype: :string} = series, path) do
-    apply_series(series, :json_path_match, [path])
+  def json_path_match(%Series{dtype: :string} = series, json_path) do
+    apply_series(series, :json_path_match, [json_path])
   end
 
   # Helpers

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6130,7 +6130,7 @@ defmodule Explorer.Series do
         string [\"1\", \"2\"]
       >
 
-  If `JSONPath` is not found or if the string is invalid JSON or `nil`, 
+  If `json_path` is not found or if the string is invalid JSON or `nil`, 
   nil is returned for the given entry:
 
       iex> s = Series.from_list(["{\\"a\\":1}", nil, "{\\"a\\":2}"])
@@ -6140,7 +6140,7 @@ defmodule Explorer.Series do
         string [nil, nil, nil]
       >
 
-  It raises an exception if the `JSONPath` is invalid.
+  It raises an exception if the `json_path` is invalid.
   """
   @doc type: :string_wise
   @spec json_path_match(Series.t(), String.t()) :: Series.t()

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1086,8 +1086,8 @@ pub fn expr_json_decode(expr: ExExpr, ex_dtype: ExSeriesDtype) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_json_path_match(expr: ExExpr, path: &str) -> ExExpr {
-    let p = path.to_owned();
+pub fn expr_json_path_match(expr: ExExpr, json_path: &str) -> ExExpr {
+    let p = json_path.to_owned();
     let function = move |s: Series| {
         let ca = s.str()?;
         match ca.json_path_match(&p) {

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -4,6 +4,11 @@
 // or an expression and returns an expression that is
 // wrapped in an Elixir struct.
 
+use polars::error::PolarsError;
+
+use polars::prelude::{GetOutput, IntoSeries, Utf8JsonPathImpl};
+use polars::series::Series;
+
 use crate::datatypes::{
     ExCorrelationMethod, ExDate, ExDateTime, ExDuration, ExRankMethod, ExSeriesDtype, ExValidValue,
 };
@@ -1081,8 +1086,25 @@ pub fn expr_json_decode(expr: ExExpr, ex_dtype: ExSeriesDtype) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_json_path_match(expr: ExExpr, path: &str) -> ExExpr {
+    let p = path.to_owned();
+    let function = move |s: Series| {
+        let ca = s.str()?;
+        match ca.json_path_match(&p) {
+            Ok(ca) => Ok(Some(ca.into_series())),
+            Err(e) => Err(PolarsError::ComputeError(format!("{e:?}").into())),
+        }
+    };
+    let expr = expr
+        .clone_inner()
+        .map(function, GetOutput::from_type(DataType::String));
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
 pub fn expr_struct(ex_exprs: Vec<ExExpr>) -> ExExpr {
     let exprs = ex_exprs.iter().map(|e| e.clone_inner()).collect();
     let expr = dsl::as_struct(exprs);
+
     ExExpr::new(expr)
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -271,6 +271,7 @@ rustler::init!(
         expr_rstrip,
         expr_substring,
         expr_replace,
+        expr_json_path_match,
         // float round expressions
         expr_round,
         expr_floor,
@@ -484,6 +485,7 @@ rustler::init!(
         s_member,
         s_field,
         s_json_decode,
+        s_json_path_match
     ],
     load = on_load
 );

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1841,3 +1841,26 @@ pub fn s_json_decode(s: ExSeries, ex_dtype: ExSeriesDtype) -> Result<ExSeries, E
         .clone();
     Ok(ExSeries::new(s2))
 }
+
+#[rustler::nif]
+pub fn s_json_path_match(s: ExSeries, path: &str) -> Result<ExSeries, ExplorerError> {
+    let p = path.to_owned();
+    let function = move |s: Series| {
+        let ca = s.str()?;
+        match ca.json_path_match(&p) {
+            Ok(ca) => Ok(Some(ca.into_series())),
+            Err(e) => Err(PolarsError::ComputeError(format!("{e:?}").into())),
+        }
+    };
+    let s2 = s
+        .clone_inner()
+        .into_frame()
+        .lazy()
+        .select([col(s.name())
+            .map(function, GetOutput::from_type(DataType::String))
+            .alias(s.name())])
+        .collect()?
+        .column(s.name())?
+        .clone();
+    Ok(ExSeries::new(s2))
+}

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1843,8 +1843,8 @@ pub fn s_json_decode(s: ExSeries, ex_dtype: ExSeriesDtype) -> Result<ExSeries, E
 }
 
 #[rustler::nif]
-pub fn s_json_path_match(s: ExSeries, path: &str) -> Result<ExSeries, ExplorerError> {
-    let p = path.to_owned();
+pub fn s_json_path_match(s: ExSeries, json_path: &str) -> Result<ExSeries, ExplorerError> {
+    let p = json_path.to_owned();
     let function = move |s: Series| {
         let ca = s.str()?;
         match ca.json_path_match(&p) {


### PR DESCRIPTION
```elixir
s = Explorer.Series.from_list([~s({"a": 1}), ~s({"b": 1})])
#Explorer.Series<
  Polars[2]
  string ["{\"a\": 1}", "{\"b\": 1}"]
>
iex(3)> Explorer.Series.json_path_match(s, "$.a")
#Explorer.Series<
  Polars[2]
  string ["1", nil]
>
iex(4)> Explorer.Series.json_path_match(s, "$.")
** (RuntimeError) Polars Error: ComputeError(ErrString("error compiling JSONpath expression path error: \nEof\n"))
    (explorer 0.9.0-dev) lib/explorer/polars_backend/shared.ex:26: Explorer.PolarsBackend.Shared.apply_series/3
    iex:4: (file)
```