### PR TITLE
Series.row_index/1

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -146,9 +146,7 @@ defmodule Explorer.Backend.LazySeries do
     lengths: 1,
     member: 3,
     # Struct functions
-    field: 2,
-    # ?
-    len: 0
+    field: 2
   ]
 
   @comparison_operations [:equal, :not_equal, :greater, :greater_equal, :less, :less_equal]
@@ -1113,14 +1111,8 @@ defmodule Explorer.Backend.LazySeries do
     Backend.Series.new(data, :string)
   end
 
-  def len() do
-    data = new(:len, [], {:u, 32})
-
-    Backend.Series.new(data, {:u, 32})
-  end
-
-  def row_index() do
-    data = new(:row_index, [], {:u, 32})
+  def row_index(series) do
+    data = new(:row_index, [lazy_series!(series)], {:u, 32})
 
     Backend.Series.new(data, {:u, 32})
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -116,6 +116,7 @@ defmodule Explorer.Backend.LazySeries do
     covariance: 3,
     all: 1,
     any: 1,
+    row_index: 1,
     # Strings
     contains: 2,
     replace: 3,
@@ -1111,39 +1112,11 @@ defmodule Explorer.Backend.LazySeries do
     Backend.Series.new(data, :string)
   end
 
+  @impl true
   def row_index(series) do
     data = new(:row_index, [lazy_series!(series)], {:u, 32})
 
     Backend.Series.new(data, {:u, 32})
-  end
-
-  def int_range(start, end_, step \\ 1) do
-    # TODO check boundaries?
-
-    # ** (RuntimeError) Polars Error: lengths don't match: unable to add a column of length 2 to
-    # a DataFrame of height 3
-
-    # TODO Should we also accept a Series? or only LazySeries?
-    {start, end_} =
-      case {start, end_} do
-        {%Series{}, %Series{}} ->
-          {lazy_series!(start), lazy_series!(end_)}
-
-        {%Series{}, _} ->
-          {lazy_series!(start), end_}
-
-        {_, %Series{}} ->
-          {start, lazy_series!(end_)}
-
-        {v1, v2} when is_integer(v1) and is_integer(v2) ->
-          {v1, v2}
-
-        {_, _} ->
-          raise ArgumentError, "invalid arguments"
-      end
-
-    data = new(:int_range, [start, end_, step], {:s, 64})
-    Backend.Series.new(data, {:s, 64})
   end
 
   @remaining_non_lazy_operations [

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -146,7 +146,9 @@ defmodule Explorer.Backend.LazySeries do
     lengths: 1,
     member: 3,
     # Struct functions
-    field: 2
+    field: 2,
+    # ?
+    len: 0
   ]
 
   @comparison_operations [:equal, :not_equal, :greater, :greater_equal, :less, :less_equal]
@@ -1109,6 +1111,47 @@ defmodule Explorer.Backend.LazySeries do
     data = new(:json_path_match, [lazy_series!(series), json_path], :string)
 
     Backend.Series.new(data, :string)
+  end
+
+  def len() do
+    data = new(:len, [], {:u, 32})
+
+    Backend.Series.new(data, {:u, 32})
+  end
+
+  def row_index() do
+    data = new(:row_index, [], {:u, 32})
+
+    Backend.Series.new(data, {:u, 32})
+  end
+
+  def int_range(start, end_, step \\ 1) do
+    # TODO check boundaries?
+
+    # ** (RuntimeError) Polars Error: lengths don't match: unable to add a column of length 2 to
+    # a DataFrame of height 3
+
+    # TODO Should we also accept a Series? or only LazySeries?
+    {start, end_} =
+      case {start, end_} do
+        {%Series{}, %Series{}} ->
+          {lazy_series!(start), lazy_series!(end_)}
+
+        {%Series{}, _} ->
+          {lazy_series!(start), end_}
+
+        {_, %Series{}} ->
+          {start, lazy_series!(end_)}
+
+        {v1, v2} when is_integer(v1) and is_integer(v2) ->
+          {v1, v2}
+
+        {_, _} ->
+          raise ArgumentError, "invalid arguments"
+      end
+
+    data = new(:int_range, [start, end_, step], {:s, 64})
+    Backend.Series.new(data, {:s, 64})
   end
 
   @remaining_non_lazy_operations [

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -93,6 +93,7 @@ defmodule Explorer.Backend.Series do
   @callback covariance(s, s, ddof :: non_neg_integer()) :: float() | non_finite() | lazy_s() | nil
   @callback all?(s) :: boolean() | lazy_s()
   @callback any?(s) :: boolean() | lazy_s()
+  @callback row_index(s) :: s | lazy_s()
 
   # Cumulative
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -162,7 +162,6 @@ defmodule Explorer.PolarsBackend.Expression do
     slice: 2,
     slice: 3,
     row_index: 1,
-    int_range: 4,
     concat: 1,
     column: 1,
     correlation: 4,
@@ -299,16 +298,8 @@ defmodule Explorer.PolarsBackend.Expression do
   end
 
   def to_expr(%LazySeries{op: :row_index, args: [lazy_series]}) do
-    size = Native.expr_size(to_expr(lazy_series))
-    Native.expr_int_range(to_expr(0), size, 1, {:u, 32})
-  end
-
-  def to_expr(%LazySeries{
-        op: :int_range,
-        args: [start, end_, step],
-        dtype: dtype
-      }) do
-    Native.expr_int_range(to_expr(start), to_expr(end_), step, dtype)
+    size_expr = Native.expr_size(to_expr(lazy_series))
+    Native.expr_int_range(to_expr(0), size_expr, 1, {:u, 32})
   end
 
   for {op, arity} <- @all_expressions do

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -161,8 +161,7 @@ defmodule Explorer.PolarsBackend.Expression do
     shift: 3,
     slice: 2,
     slice: 3,
-    row_index: 0,
-    len: 0,
+    row_index: 1,
     int_range: 4,
     concat: 1,
     column: 1,
@@ -299,12 +298,9 @@ defmodule Explorer.PolarsBackend.Expression do
     end
   end
 
-  def to_expr(%LazySeries{op: :len, args: []}) do
-    Native.expr_len()
-  end
-
-  def to_expr(%LazySeries{op: :row_index, args: []}) do
-    Native.expr_int_range(to_expr(0), Native.expr_len(), 1, {:u, 32})
+  def to_expr(%LazySeries{op: :row_index, args: [lazy_series]}) do
+    size = Native.expr_size(to_expr(lazy_series))
+    Native.expr_int_range(to_expr(0), size, 1, {:u, 32})
   end
 
   def to_expr(%LazySeries{

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -161,6 +161,9 @@ defmodule Explorer.PolarsBackend.Expression do
     shift: 3,
     slice: 2,
     slice: 3,
+    row_index: 0,
+    len: 0,
+    int_range: 4,
     concat: 1,
     column: 1,
     correlation: 4,
@@ -294,6 +297,22 @@ defmodule Explorer.PolarsBackend.Expression do
       {_, _} ->
         expr
     end
+  end
+
+  def to_expr(%LazySeries{op: :len, args: []}) do
+    Native.expr_len()
+  end
+
+  def to_expr(%LazySeries{op: :row_index, args: []}) do
+    Native.expr_int_range(to_expr(0), Native.expr_len(), 1, {:u, 32})
+  end
+
+  def to_expr(%LazySeries{
+        op: :int_range,
+        args: [start, end_, step],
+        dtype: dtype
+      }) do
+    Native.expr_int_range(to_expr(start), to_expr(end_), step, dtype)
   end
 
   for {op, arity} <- @all_expressions do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -383,6 +383,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_rename(_s, _name), do: err()
   def s_reverse(_s), do: err()
   def s_round(_s, _decimals), do: err()
+  def s_row_index(_s), do: err()
   def s_floor(_s), do: err()
   def s_ceil(_s), do: err()
   def s_rstrip(_s, _string), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -210,11 +210,10 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_describe_filter_plan(_df, _expr), do: err()
   def expr_float(_number), do: err()
   def expr_integer(_number), do: err()
+  def expr_int_range(_start, _end, _step, _dtype), do: err()
   def expr_series(_series), do: err()
   def expr_string(_string), do: err()
   def expr_struct(_map), do: err()
-
-  def expr_int_range(_start, _end, _step, _dtype), do: err()
 
   # LazyFrame
   def lf_collect(_df), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -214,6 +214,8 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_string(_string), do: err()
   def expr_struct(_map), do: err()
 
+  def expr_int_range(_start, _end, _step, _dtype), do: err()
+
   # LazyFrame
   def lf_collect(_df), do: err()
   def lf_describe_plan(_df, _optimized), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -236,6 +236,13 @@ defmodule Explorer.PolarsBackend.Series do
   @impl true
   def any?(series), do: Shared.apply_series(series, :s_any)
 
+  @impl true
+  def row_index(series) do
+    Explorer.DataFrame.new(series: series)
+    |> Explorer.DataFrame.mutate_with(&[row_index: Series.row_index(&1[:series])])
+    |> Explorer.DataFrame.pull(:row_index)
+  end
+
   # Cumulative
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -237,11 +237,7 @@ defmodule Explorer.PolarsBackend.Series do
   def any?(series), do: Shared.apply_series(series, :s_any)
 
   @impl true
-  def row_index(series) do
-    Explorer.DataFrame.new(series: series)
-    |> Explorer.DataFrame.mutate_with(&[row_index: Series.row_index(&1[:series])])
-    |> Explorer.DataFrame.pull(:row_index)
-  end
+  def row_index(series), do: Shared.apply_series(series, :s_row_index)
 
   # Cumulative
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2909,6 +2909,44 @@ defmodule Explorer.Series do
   def any?(%Series{dtype: :boolean} = series), do: apply_series(series, :any?)
   def any?(%Series{dtype: dtype}), do: dtype_error("any?/1", dtype, [:boolean])
 
+  @doc """
+
+  Returns a series of N consecutive numbers, starting from 0.
+
+  ## Examples
+      iex> s = Series.from_list([nil, true, true])
+      iex> Series.row_index(s)
+      #Explorer.Series<
+        Polars[3]
+        u32 [0, 1, 2]
+      >
+
+  Can be used to add a row index as the first column in the DataFrame.
+  The resulting column does not have any special properties. It is a regular column of type
+  UInt32.
+
+      iex> require Explorer.DataFrame, as: DF
+      iex> df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
+      iex> DF.mutate(df, index: row_index(a)) |> DF.relocate("index", before: 0)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        index u32 [0, 1, 2]
+        a s64 [1, 3, 5]
+        b s64 [2, 4, 6]
+      >
+      iex> df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
+      iex> DF.mutate(df, id: row_index(a) + 1000)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        a s64 [1, 3, 5]
+        b s64 [2, 4, 6]
+        id s64 [1000, 1001, 1002]
+      >
+  """
+  @doc type: :shape
+  @spec row_index(Series.t()) :: Series.t()
+  def row_index(%Series{} = series), do: apply_series(series, :row_index)
+
   # Cumulative
 
   @doc """
@@ -6023,14 +6061,6 @@ defmodule Explorer.Series do
 
   def member?(%Series{dtype: dtype}, _value),
     do: dtype_error("member?/2", dtype, [{:list, :_}])
-
-  def row_index(%Series{} = series) do
-    apply_series(series, :row_index)
-  end
-
-  def int_range(start, end_, step \\ 1) do
-    Explorer.Backend.LazySeries.int_range(start, end_, step)
-  end
 
   # Escape hatch
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2910,10 +2910,10 @@ defmodule Explorer.Series do
   def any?(%Series{dtype: dtype}), do: dtype_error("any?/1", dtype, [:boolean])
 
   @doc """
-
-  Returns a series of N consecutive numbers, starting from 0.
+  Returns a series of indexes for each item (row) in the series, starting from 0.
 
   ## Examples
+
       iex> s = Series.from_list([nil, true, true])
       iex> Series.row_index(s)
       #Explorer.Series<
@@ -2921,9 +2921,8 @@ defmodule Explorer.Series do
         u32 [0, 1, 2]
       >
 
-  Can be used to add a row index as the first column in the DataFrame.
-  The resulting column does not have any special properties. It is a regular column of type
-  UInt32.
+  This function can be used to add a row index as the first column of a dataframe.
+  The resulting column is a regular column of type `:u32`.
 
       iex> require Explorer.DataFrame, as: DF
       iex> df = DF.new(a: [1, 3, 5], b: [2, 4, 6])

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6024,6 +6024,18 @@ defmodule Explorer.Series do
   def member?(%Series{dtype: dtype}, _value),
     do: dtype_error("member?/2", dtype, [{:list, :_}])
 
+  def len() do
+    Explorer.Backend.LazySeries.len()
+  end
+
+  def row_index() do
+    Explorer.Backend.LazySeries.row_index()
+  end
+
+  def int_range(start, end_, step \\ 1) do
+    Explorer.Backend.LazySeries.int_range(start, end_, step)
+  end
+
   # Escape hatch
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -6024,12 +6024,8 @@ defmodule Explorer.Series do
   def member?(%Series{dtype: dtype}, _value),
     do: dtype_error("member?/2", dtype, [{:list, :_}])
 
-  def len() do
-    Explorer.Backend.LazySeries.len()
-  end
-
-  def row_index() do
-    Explorer.Backend.LazySeries.row_index()
+  def row_index(%Series{} = series) do
+    apply_series(series, :row_index)
   end
 
   def int_range(start, end_, step \\ 1) do

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -80,6 +80,7 @@ features = [
   "product",
   "peaks",
   "moment",
+  "range",
   "rank",
   "propagate_nans",
   "extract_jsonpath"

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1065,12 +1065,6 @@ pub fn expr_int_range(start: ExExpr, end: ExExpr, step: i64, dtype: ExSeriesDtyp
 }
 
 #[rustler::nif]
-pub fn expr_len() -> ExExpr {
-    let expr = dsl::count();
-    ExExpr::new(expr)
-}
-
-#[rustler::nif]
 pub fn expr_lengths(expr: ExExpr) -> ExExpr {
     let expr = expr.clone_inner();
 

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1055,6 +1055,22 @@ pub fn expr_join(expr: ExExpr, sep: String) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_int_range(start: ExExpr, end: ExExpr, step: i64, dtype: ExSeriesDtype) -> ExExpr {
+    let start = start.clone_inner();
+    let end = end.clone_inner();
+    let dtype = DataType::try_from(&dtype).unwrap();
+    let expr = dsl::int_range(start, end, step, dtype);
+
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_len() -> ExExpr {
+    let expr = dsl::count();
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
 pub fn expr_lengths(expr: ExExpr) -> ExExpr {
     let expr = expr.clone_inner();
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -166,6 +166,8 @@ rustler::init!(
         expr_float,
         expr_head,
         expr_integer,
+        expr_int_range,
+        expr_len,
         expr_peaks,
         expr_rank,
         expr_unary_not,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -440,6 +440,7 @@ rustler::init!(
         s_rename,
         s_replace,
         s_reverse,
+        s_row_index,
         s_rstrip,
         s_sample_n,
         s_sample_frac,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -167,7 +167,6 @@ rustler::init!(
         expr_head,
         expr_integer,
         expr_int_range,
-        expr_len,
         expr_peaks,
         expr_rank,
         expr_unary_not,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1864,3 +1864,10 @@ pub fn s_json_path_match(s: ExSeries, json_path: &str) -> Result<ExSeries, Explo
         .clone();
     Ok(ExSeries::new(s2))
 }
+
+#[rustler::nif]
+pub fn s_row_index(series: ExSeries) -> Result<ExSeries, ExplorerError> {
+    let len = u32::try_from(series.len())?;
+    let s = Series::new("row_index", 0..len);
+    Ok(ExSeries::new(s))
+}

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4453,43 +4453,24 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
-  describe "row_index/2" do
-    test "int_range" do
+  describe "row_index/1" do
+    test "works as row_count(), including offset" do
       df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
-
-      df1 = DF.mutate(df, x: size(a))
+      df1 = DF.mutate(df, index: row_index(a))
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 3, 5],
                b: [2, 4, 6],
-               x: [3, 3, 3]
+               index: [0, 1, 2]
              }
 
-      df2 = DF.mutate(df, x: int_range(0, 15, 5))
+      df2 = DF.mutate(df, id: row_index(a) + 1000)
 
       assert DF.to_columns(df2, atom_keys: true) == %{
                a: [1, 3, 5],
                b: [2, 4, 6],
-               x: [0, 5, 10]
+               id: [1000, 1001, 1002]
              }
-    end
-
-    test "works" do
-      df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
-
-      df2 = DF.mutate(df, id: row_index(a)) |> DF.collect()
-
-      assert DF.to_columns(df2, atom_keys: true) == %{
-               a: [1, 3, 5],
-               b: [2, 4, 6],
-               id: [0, 1, 2]
-             }
-
-      df3 = DF.mutate(df, id: int_range(0, size(a)))
-      assert DF.to_columns(df3) == DF.to_columns(df2)
-
-      df4 = DF.mutate_with(df, fn ldf -> [id: Series.row_index(ldf["a"])] end)
-      assert DF.to_columns(df4) == DF.to_columns(df2)
     end
   end
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4454,10 +4454,10 @@ defmodule Explorer.DataFrameTest do
   end
 
   describe "row_index/2" do
-    test "len, int_range" do
+    test "int_range" do
       df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
 
-      df1 = DF.mutate(df, x: len())
+      df1 = DF.mutate(df, x: size(a))
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 3, 5],
@@ -4477,7 +4477,7 @@ defmodule Explorer.DataFrameTest do
     test "works" do
       df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
 
-      df2 = DF.mutate(df, id: row_index()) |> DF.collect()
+      df2 = DF.mutate(df, id: row_index(a)) |> DF.collect()
 
       assert DF.to_columns(df2, atom_keys: true) == %{
                a: [1, 3, 5],
@@ -4485,10 +4485,10 @@ defmodule Explorer.DataFrameTest do
                id: [0, 1, 2]
              }
 
-      df3 = DF.mutate(df, id: int_range(0, len()))
+      df3 = DF.mutate(df, id: int_range(0, size(a)))
       assert DF.to_columns(df3) == DF.to_columns(df2)
 
-      df4 = DF.mutate_with(df, fn _ -> [id: Series.row_index()] end)
+      df4 = DF.mutate_with(df, fn ldf -> [id: Series.row_index(ldf["a"])] end)
       assert DF.to_columns(df4) == DF.to_columns(df2)
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4452,4 +4452,44 @@ defmodule Explorer.DataFrameTest do
              }
     end
   end
+
+  describe "row_index/2" do
+    test "len, int_range" do
+      df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
+
+      df1 = DF.mutate(df, x: len())
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 3, 5],
+               b: [2, 4, 6],
+               x: [3, 3, 3]
+             }
+
+      df2 = DF.mutate(df, x: int_range(0, 15, 5))
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               a: [1, 3, 5],
+               b: [2, 4, 6],
+               x: [0, 5, 10]
+             }
+    end
+
+    test "works" do
+      df = DF.new(a: [1, 3, 5], b: [2, 4, 6])
+
+      df2 = DF.mutate(df, id: row_index()) |> DF.collect()
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               a: [1, 3, 5],
+               b: [2, 4, 6],
+               id: [0, 1, 2]
+             }
+
+      df3 = DF.mutate(df, id: int_range(0, len()))
+      assert DF.to_columns(df3) == DF.to_columns(df2)
+
+      df4 = DF.mutate_with(df, fn _ -> [id: Series.row_index()] end)
+      assert DF.to_columns(df4) == DF.to_columns(df2)
+    end
+  end
 end


### PR DESCRIPTION
>  Interesting. So what if we:
> 
> 1. Add a `Series.row_index()`
> 2. Make it raise for the default backend saying it is only supported in dataframes
> 3. Implement it properly for expressions
> 
> Would that work? Perhaps we try that as a separate PR so we can compare them side by side?

_Originally posted by @josevalim in https://github.com/elixir-explorer/explorer/issues/833#issuecomment-1902213418_

@josevalim is this what you had in mind? I think it's the first `/0` function in Series; I'm also not sure on the implementation.

Should we rename `len()` to `size()` for consistency?


cc @cigrainger