### PR TITLE
Rewrite from_list

### DIFF
--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -283,11 +283,14 @@ defmodule Explorer.Shared do
 
   def dtype_from_list!(list, nil), do: dtype_from_list!(list)
 
-  def dtype_from_list!(list, preferred_type) do
+  def dtype_from_list!(list, {prefix, _} = preferred_type) when prefix in [:list, :struct] do
     list
     |> dtype_from_list!()
     |> merge_preferred(preferred_type)
   end
+
+  # Skip Elixir-side checking for all but lists and structs
+  def dtype_from_list!(_list, preferred_type), do: preferred_type
 
   @non_finite [:nan, :infinity, :neg_infinity]
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -67,7 +67,12 @@ mod atoms {
         calendar,
         nan,
         infinity,
-        neg_infinity
+        neg_infinity,
+        ok,
+        error,
+        nil,
+        true_ = "true",
+        false_ = "false",
     }
 }
 


### PR DESCRIPTION
The idea here is to minimise our (de)serialisation overhead. We are traversing a list multiple times right now to go from an Elixir list to a Polars series.

This PR aims to:
- [ ] Remove the list traversal on the Elixir side entirely
- [ ] Minimise traversals on the Rust side

The latter requires a little explanation: we currently traverse the list when decoding, then again when we call `from_vec`. This moves it into a single traversal over `Term`s, and accumulates a `Series` directly from the iterator over the `Term`, decoding as we go. This allows us to pass an `{:error, reason}` tuple from the `from_list` function if there is an invalid type in the list, which gives us the nice error message we want and for which we're currently making a pass in Elixir.

Left to do:
- [ ] Finish implementing this pattern for all `from_list` functions in `series.rs`
- [ ] Implement a generic `from_list` with type inference in `series.rs`
- [ ] Remove the type checking Elixir-side

Blockers:
- ~This might have to wait on #861 as Polars 0.36.2 can't build a string series from `Option<&str>` or `Option<String>`. We can also just leave strings as inefficient and come back and fix that after.~ Polars 0.37 can't either. I've raised this PR https://github.com/pola-rs/polars/pull/14625.