### PR TITLE
Wrap join on with list

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4935,7 +4935,7 @@ defmodule Explorer.DataFrame do
     end
 
     {on, how} =
-      case {opts[:on], opts[:how]} do
+      case {List.wrap(opts[:on]), opts[:how]} do
         {[], :cross} ->
           {[], :cross}
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4751,7 +4751,7 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `:on` - The columns to join on. Defaults to overlapping columns. Does not apply to cross join.
+    * `:on` - The column(s) to join on. Defaults to overlapping columns. Does not apply to cross join.
     * `:how` - One of the join types (as an atom) described above. Defaults to `:inner`.
 
   ## Examples

--- a/lib/explorer/query.ex
+++ b/lib/explorer/query.ex
@@ -696,7 +696,7 @@ defmodule Explorer.Query do
   It is equivalent to `df[name]` but inside a query.
 
   This can also be used if you want to access a column
-  programatically, for example:
+  programmatically, for example:
 
       iex> df = Explorer.DataFrame.new(nums: [1, 2, 3])
       iex> name = :nums
@@ -706,7 +706,7 @@ defmodule Explorer.Query do
         nums s64 [3]
       >
 
-  For traversing multiple columns programatically,
+  For traversing multiple columns programmatically,
   see `across/0` and `across/1`.
   """
   defmacro col(name) do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2291,6 +2291,19 @@ defmodule Explorer.DataFrameTest do
       assert_raise ArgumentError, msg, fn -> DF.join(left, right, how: :inner_join) end
     end
 
+    test "with matching column indexes as single value" do
+      left = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      right = DF.new(a: [1, 2, 2], c: ["d", "e", "f"])
+
+      df = DF.join(left, right, on: 0)
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               a: [1, 2, 2],
+               b: ["a", "b", "b"],
+               c: ["d", "e", "f"]
+             }
+    end
+
     test "with matching column indexes" do
       left = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
       right = DF.new(a: [1, 2, 2], c: ["d", "e", "f"])


### PR DESCRIPTION
## Overview
Use `List.wrap/1` to wrap the `:on` option to `join/3` allowing users to give a single column without raising a match error from the case within `join/3`.

Fixes #865 