### PR TITLE
Implements Series.split_into/3

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -127,6 +127,7 @@ defmodule Explorer.Backend.LazySeries do
     downcase: 1,
     substring: 3,
     split: 2,
+    split_into: 3,
     json_decode: 2,
     json_path_match: 2,
     # Float round
@@ -1051,6 +1052,13 @@ defmodule Explorer.Backend.LazySeries do
     data = new(:split, [lazy_series!(series), by], :string)
 
     Backend.Series.new(data, {:list, :string})
+  end
+
+  @impl true
+  def split_into(series, by, fields) do
+    data = new(:split_into, [lazy_series!(series), by, fields], :string)
+
+    Backend.Series.new(data, {:list, :struct})
   end
 
   @impl true

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -1058,7 +1058,7 @@ defmodule Explorer.Backend.LazySeries do
   def split_into(series, by, fields) do
     data = new(:split_into, [lazy_series!(series), by, fields], :string)
 
-    Backend.Series.new(data, {:list, :struct})
+    Backend.Series.new(data, {:struct, Enum.map(fields, &{&1, :string})})
   end
 
   @impl true

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -287,6 +287,7 @@ defmodule Explorer.Backend.Series do
   @callback rstrip(s, String.t() | nil) :: s
   @callback substring(s, integer(), non_neg_integer() | nil) :: s
   @callback split(s, String.t()) :: s
+  @callback split_into(s, String.t(), list(String.t() | atom())) :: s
   @callback json_decode(s, dtype()) :: s
   @callback json_path_match(s, String.t()) :: s
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -136,6 +136,7 @@ defmodule Explorer.PolarsBackend.Expression do
     upcase: 1,
     substring: 3,
     split: 2,
+    split_into: 3,
     json_decode: 2,
     json_path_match: 2,
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -413,6 +413,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_cut(_s, _bins, _labels, _break_point_label, _category_label), do: err()
   def s_substring(_s, _offset, _length), do: err()
   def s_split(_s, _by), do: err()
+  def s_split_into(_s, _by, _num_fields), do: err()
 
   def s_qcut(_s, _quantiles, _labels, _break_point_label, _category_label),
     do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -694,6 +694,10 @@ defmodule Explorer.PolarsBackend.Series do
   def split(series, by),
     do: Shared.apply_series(series, :s_split, [by])
 
+  @impl true
+  def split_into(series, by, fields),
+    do: Shared.apply_series(series, :s_split_into, [by, fields])
+
   # Float round
   @impl true
   def round(series, decimals),

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -5651,6 +5651,14 @@ defmodule Explorer.Series do
   def split(%Series{dtype: dtype}, _by),
     do: dtype_error("split/2", dtype, [:string])
 
+  @doc type: :string_wise
+  @spec split_into(Series.t(), String.t(), list(String.t() | atom())) :: Series.t()
+  def split_into(%Series{dtype: :string} = series, by, fields) when is_binary(by),
+    do: apply_series(series, :split_into, [by, fields])
+
+  def split_into(%Series{dtype: dtype}, _by, _fields),
+    do: dtype_error("split_into/3", dtype, [:string])
+
   # Float
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -5651,6 +5651,23 @@ defmodule Explorer.Series do
   def split(%Series{dtype: dtype}, _by),
     do: dtype_error("split/2", dtype, [:string])
 
+  @doc """
+  Split a string Series into a struct with fields determined by the list of
+  field names provided.  The length of the field names list determines how
+  many fields the resulting struct will have.  If the string cannot be split
+  into that many separate strings, null values will be provided for the
+  remaining fields.
+
+  ## Examples
+
+      iex> s = Series.from_list(["Smith, John", "Jones, Jane"])
+      iex> Series.split_into(s, ", ", ["Last Name", "First Name"])
+      #Explorer.Series<
+        Polars[2]
+        struct[2] [%{"First Name" => "John", "Last Name" => "Smith"}, %{"First Name" => "Jane", "Last Name" => "Jones"}]
+      >
+
+  """
   @doc type: :string_wise
   @spec split_into(Series.t(), String.t(), list(String.t() | atom())) :: Series.t()
   def split_into(%Series{dtype: :string} = series, by, fields) when is_binary(by),

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -5653,7 +5653,7 @@ defmodule Explorer.Series do
 
   @doc """
   Split a string Series into a struct of string `fields`.
-  
+
   The length of the field names list determines how many times the
   string will be split at most. If the string cannot be split into that
   many separate strings, null values will be provided for the
@@ -5671,10 +5671,10 @@ defmodule Explorer.Series do
   """
   @doc type: :string_wise
   @spec split_into(Series.t(), String.t(), list(String.t() | atom())) :: Series.t()
-  def split_into(%Series{dtype: :string} = series, by, fields) when is_binary(by),
-    do: apply_series(series, :split_into, [by, fields])
+  def split_into(%Series{dtype: :string} = series, by, [_ | _] = fields) when is_binary(by),
+    do: apply_series(series, :split_into, [by, Enum.map(fields, &to_string/1)])
 
-  def split_into(%Series{dtype: dtype}, _by, _fields),
+  def split_into(%Series{dtype: dtype}, by, [_ | _]) when is_binary(by),
     do: dtype_error("split_into/3", dtype, [:string])
 
   # Float

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -5652,10 +5652,11 @@ defmodule Explorer.Series do
     do: dtype_error("split/2", dtype, [:string])
 
   @doc """
-  Split a string Series into a struct with fields determined by the list of
-  field names provided.  The length of the field names list determines how
-  many fields the resulting struct will have.  If the string cannot be split
-  into that many separate strings, null values will be provided for the
+  Split a string Series into a struct of string `fields`.
+  
+  The length of the field names list determines how many times the
+  string will be split at most. If the string cannot be split into that
+  many separate strings, null values will be provided for the
   remaining fields.
 
   ## Examples

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -3,7 +3,6 @@
 // to the Rust side. Each function receives a basic type
 // or an expression and returns an expression that is
 // wrapped in an Elixir struct.
-
 use polars::error::PolarsError;
 
 use polars::prelude::{GetOutput, IntoSeries, Utf8JsonPathImpl};
@@ -1112,6 +1111,18 @@ pub fn expr_json_path_match(expr: ExExpr, json_path: &str) -> ExExpr {
     let expr = expr
         .clone_inner()
         .map(function, GetOutput::from_type(DataType::String));
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_split_into(expr: ExExpr, by: &str, names: Vec<String>) -> ExExpr {
+    let expr = expr
+        .clone_inner()
+        .str()
+        .splitn(by.into(), names.len())
+        .struct_()
+        .rename_fields(names);
+
     ExExpr::new(expr)
 }
 

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -3,6 +3,7 @@
 // to the Rust side. Each function receives a basic type
 // or an expression and returns an expression that is
 // wrapped in an Elixir struct.
+
 use polars::error::PolarsError;
 
 use polars::prelude::{GetOutput, IntoSeries, Utf8JsonPathImpl};

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1115,11 +1115,11 @@ pub fn expr_json_path_match(expr: ExExpr, json_path: &str) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_split_into(expr: ExExpr, by: &str, names: Vec<String>) -> ExExpr {
+pub fn expr_split_into(expr: ExExpr, by: String, names: Vec<String>) -> ExExpr {
     let expr = expr
         .clone_inner()
         .str()
-        .splitn(by.into(), names.len())
+        .splitn(by.lit(), names.len())
         .struct_()
         .rename_fields(names);
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -456,6 +456,7 @@ rustler::init!(
         s_strip,
         s_substring,
         s_split,
+        s_split_into,
         s_subtract,
         s_sum,
         s_tail,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -273,6 +273,7 @@ rustler::init!(
         expr_substring,
         expr_replace,
         expr_json_path_match,
+        expr_split_into,
         // float round expressions
         expr_round,
         expr_floor,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1568,6 +1568,26 @@ pub fn s_split(s1: ExSeries, by: &str) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_split_into(s1: ExSeries, by: &str, names: Vec<String>) -> Result<ExSeries, ExplorerError> {
+    let fields = s1
+        .str()?
+        .splitn(&ChunkedArray::new("a", &[by]), names.len())?
+        .fields()
+        .iter()
+        .zip(names.iter())
+        .map(|(s, name)| {
+            let mut s = s.clone();
+            s.rename(name);
+            s
+        })
+        .collect::<Vec<_>>();
+
+    let result = StructChunked::new(s1.name(), &fields).map(|ca| ca.into_series())?;
+
+    Ok(ExSeries::new(result))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_round(s: ExSeries, decimals: u32) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.round(decimals)?.into_series()))
 }

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -5320,6 +5320,18 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "split_into" do
+    test "split_into/3 exclusive" do
+      series = Series.from_list(["Smith, John", "Jones, Jane"])
+      split_series = series |> Series.split_into(", ", ["Last Name", "First Name"])
+
+      assert Series.to_list(split_series) == [
+               %{"First Name" => "John", "Last Name" => "Smith"},
+               %{"First Name" => "Jane", "Last Name" => "Jones"}
+             ]
+    end
+  end
+
   describe "strptime/2 and strftime/2" do
     test "parse datetime from string" do
       series = Series.from_list(["2023-01-05 12:34:56", "XYZ", nil])

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -5321,13 +5321,23 @@ defmodule Explorer.SeriesTest do
   end
 
   describe "split_into" do
-    test "split_into/3 exclusive" do
+    test "split_into/3 produces the correct number of fields in a struct" do
       series = Series.from_list(["Smith, John", "Jones, Jane"])
       split_series = series |> Series.split_into(", ", ["Last Name", "First Name"])
 
       assert Series.to_list(split_series) == [
                %{"First Name" => "John", "Last Name" => "Smith"},
                %{"First Name" => "Jane", "Last Name" => "Jones"}
+             ]
+    end
+
+    test "split_into/3 produces a nil field when string cannot be split for every field" do
+      series = Series.from_list(["Smith-John", "Jones-Jane"])
+      split_series = series |> Series.split_into("-", ["Last Name", "First Name", "Middle Name"])
+
+      assert Series.to_list(split_series) == [
+               %{"First Name" => "John", "Last Name" => "Smith", "Middle Name" => nil},
+               %{"First Name" => "Jane", "Last Name" => "Jones", "Middle Name" => nil}
              ]
     end
   end


### PR DESCRIPTION
Implements the `Series.split_into/3` function, which closes #871.  String columns can be split into a struct with multiple fields.