### PR TITLE
Add more options for cacertfile including custom file supplied by user

### DIFF
--- a/lib/explorer/fss/utils.ex
+++ b/lib/explorer/fss/utils.ex
@@ -161,7 +161,7 @@ defmodule Explorer.FSS.Utils do
     # Use secure options, see https://gist.github.com/jonatanklosko/5e20ca84127f6b31bbe3906498e1a1d7
     [
       verify: :verify_peer,
-      cacertfile: CAStore.file_path() |> String.to_charlist(),
+      cacertfile: certificate_store(),
       # We need to increase depth because the default value is 1.
       # See: https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
       depth: 3,
@@ -169,5 +169,62 @@ defmodule Explorer.FSS.Utils do
         match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
       ]
     ]
+  end
+
+  @static_certificate_locations [
+    # Debian/Ubuntu/Gentoo etc.
+    "/etc/ssl/certs/ca-certificates.crt",
+    # Fedora/RHEL 6
+    "/etc/pki/tls/certs/ca-bundle.crt",
+    # OpenSUSE
+    "/etc/ssl/ca-bundle.pem",
+    # OpenELEC
+    "/etc/pki/tls/cacert.pem",
+    # CentOS/RHEL 7
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+    # Open SSL on MacOS
+    "/usr/local/etc/openssl/cert.pem",
+    # MacOS & Alpine Linux
+    "/etc/ssl/cert.pem"
+  ]
+
+  defp dynamic_certificate_locations do
+    [
+      # Configured cacertfile
+      Application.get_env(:explorer, :cacertfile),
+
+      # Populated if hex package CAStore is configured
+      if(Code.ensure_loaded?(CAStore), do: apply(CAStore, :file_path, [])),
+
+      # Populated if hex package certfi is configured
+      if(Code.ensure_loaded?(:certifi), do: apply(:certifi, :cacertfile, []) |> List.to_string())
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def certificate_locations() do
+    dynamic_certificate_locations() ++ @static_certificate_locations
+  end
+
+  @doc false
+  defp certificate_store do
+    certificate_locations()
+    |> Enum.find(&File.exists?/1)
+    |> raise_if_no_cacertfile!
+    |> :erlang.binary_to_list()
+  end
+
+  defp raise_if_no_cacertfile!(nil) do
+    raise RuntimeError, """
+    No certificate trust store was found.
+    Tried looking for: #{inspect(certificate_locations())}
+
+    You can specify the location of a certificate trust store
+       by configuring it in `config.exs` or `runtime.exs`:
+
+       config :explorer, cacertfile: "/path/to/cacertfile",
+         ...
+
+    """
   end
 end


### PR DESCRIPTION
The existing code was failing for me due to being behind corporate proxy.

I shamelessly borrowed most of this from here -https://github.com/elixir-cldr/cldr_utils/blob/2fcfefb729e1ff3fa06a4cb9d531846c2056bcf2/lib/cldr/http/http.ex#L330 - so if kipcole9 could get credit that would be great.

I haven't been able to verify it works due to other build issues but it has worked as far as I've been able to test it.

I'll keep trying to test it on my end and report back. 