### PR TITLE
Add optional `x-amz-security-token` header to S3 request

### DIFF
--- a/lib/explorer/fss/s3.ex
+++ b/lib/explorer/fss/s3.ex
@@ -54,6 +54,11 @@ defimpl Explorer.FSS, for: FSS.S3.Entry do
     %{host: host} = URI.parse(url)
     headers = [{"Host", host} | headers]
 
+    headers =
+      if entry.config.token,
+        do: [{"x-amz-security-token", entry.config.token} | headers],
+        else: headers
+
     :aws_signature.sign_v4(
       entry.config.access_key_id,
       entry.config.secret_access_key,


### PR DESCRIPTION
The following works as expected:

```elixir
  Explorer.DataFrame.from_parquet("s3://some-bucket/test.parquet",
    config: [
      access_key_id: conf.access_key_id,
      secret_access_key: conf.secret_access_key,
      token: conf.security_token
    ]
  )
``` 

This fails with a 403 response:

```elixir
  Explorer.DataFrame.from_csv("s3://some-bucket/test.csv",
    config: [
      access_key_id: conf.access_key_id,
      secret_access_key: conf.secret_access_key,
      token: conf.security_token
    ]
  )
```

This looks to be due to the `x-amz-security-token` header missing in the request from Explorer.FSS.headers/5 function. I've added a quick conditional to see if the token is set and if so to add it as a header.