### PR TITLE
Fix `DF.sort_by/3` with groups to respect `:nils` option

### DIFF
--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -354,8 +354,17 @@ pub fn df_sort_by(
             multithreaded,
         )?
     } else {
-        df.group_by_stable(groups)?
-            .apply(|df| df.sort(by_columns.clone(), reverse.clone(), maintain_order))?
+        df.group_by_stable(groups)?.apply(|df| {
+            let by_columns = df.select_series(&by_columns)?;
+            df.sort_impl(
+                by_columns,
+                reverse.clone(),
+                nulls_last,
+                maintain_order,
+                None,
+                multithreaded,
+            )
+        })?
     };
 
     Ok(ExDataFrame::new(new_df))

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -472,7 +472,7 @@ defmodule Explorer.DataFrame.GroupedTest do
       with_nil =
         DF.new(%{
           id: [1, 1, 1, 2, 2, 2, 3, 3, 3],
-          data: [0.5, 1, nil, 0.7, 1, 0.9, 0.2, 0.2, 0.3]
+          data: [1, 0.5, nil, 0.7, 1, 0.9, 0.2, 0.2, 0.3]
         })
 
       grouped = DF.group_by(with_nil, :id)

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -467,6 +467,21 @@ defmodule Explorer.DataFrame.GroupedTest do
              |> DF.pull("total")
              |> Series.first() == 2175
     end
+
+    test "sorts by group keeping nils last" do
+      with_nil =
+        DF.new(%{
+          id: [1, 1, 1, 2, 2, 2, 3, 3, 3],
+          data: [0.5, 1, nil, 0.7, 1, 0.9, 0.2, 0.2, 0.3]
+        })
+
+      grouped = DF.group_by(with_nil, :id)
+
+      assert grouped |> DF.sort_by(data, nils: :last) |> DF.to_columns(atom_keys: true) == %{
+               data: [0.5, 1.0, nil, 0.7, 0.9, 1.0, 0.2, 0.2, 0.3],
+               id: [1, 1, 1, 2, 2, 2, 3, 3, 3]
+             }
+    end
   end
 
   describe "sort_with/2" do


### PR DESCRIPTION
We were using the wrong implementation for the grouped branch.

Close https://github.com/elixir-explorer/explorer/issues/883