### PR TITLE
Implements `:streaming` option for DataFrame.to_csv/3

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -59,7 +59,13 @@ defmodule Explorer.Backend.DataFrame do
               parse_dates :: boolean(),
               eol_delimiter :: option(String.t())
             ) :: io_result(df)
-  @callback to_csv(df, entry :: fs_entry(), header? :: boolean(), delimiter :: String.t()) ::
+  @callback to_csv(
+              df,
+              entry :: fs_entry(),
+              header? :: boolean(),
+              delimiter :: String.t(),
+              streaming :: boolean()
+            ) ::
               ok_result()
   @callback dump_csv(df, header? :: boolean(), delimiter :: String.t()) :: io_result(binary())
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1329,15 +1329,15 @@ defmodule Explorer.DataFrame do
 
     * `:streaming` - Tells the backend if it should use streaming, which means
       that the dataframe is not loaded to the memory at once, and instead it is
-      written in chunks from a lazy dataframe.  This option is not supported when using an S3
-      entry.
+      written in chunks from a lazy dataframe.  Defaults to true on supported filesystems,
+      ignored on all others.
 
   """
   @doc type: :io
   @spec to_csv(df :: DataFrame.t(), filename :: fs_entry() | String.t(), opts :: Keyword.t()) ::
           :ok | {:error, Exception.t()}
   def to_csv(df, filename, opts \\ []) do
-    opts = Keyword.validate!(opts, header: true, delimiter: ",", streaming: false, config: nil)
+    opts = Keyword.validate!(opts, header: true, delimiter: ",", streaming: true, config: nil)
 
     with {:ok, entry} <- normalise_entry(filename, opts[:config]) do
       Shared.apply_impl(df, :to_csv, [entry, opts[:header], opts[:delimiter], opts[:streaming]])

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1329,7 +1329,7 @@ defmodule Explorer.DataFrame do
 
     * `:streaming` - Tells the backend if it should use streaming, which means
       that the dataframe is not loaded to the memory at once, and instead it is
-      written in chunks from a lazy dataframe.  Defaults to true on supported filesystems,
+      written in chunks from a lazy dataframe.  Defaults to true for local filesystems,
       ignored on all others.
 
   """

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -144,7 +144,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_csv(%DataFrame{data: df}, %Local.Entry{} = entry, header?, delimiter) do
+  def to_csv(%DataFrame{data: df}, %Local.Entry{} = entry, header?, delimiter, _streaming) do
     <<delimiter::utf8>> = delimiter
 
     case Native.df_to_csv(df, entry.path, header?, delimiter) do
@@ -154,7 +154,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_csv(%DataFrame{data: df}, %S3.Entry{} = entry, header?, delimiter) do
+  def to_csv(%DataFrame{data: df}, %S3.Entry{} = entry, header?, delimiter, _streaming) do
     <<delimiter::utf8>> = delimiter
 
     case Native.df_to_csv_cloud(df, entry, header?, delimiter) do

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -354,6 +354,28 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
+  def to_csv(%DF{data: df}, %Local.Entry{} = entry, header?, delimiter, streaming) do
+    <<delimiter::utf8>> = delimiter
+
+    case Native.lf_to_csv(df, entry.path, header?, delimiter, streaming) do
+      {:ok, _} -> :ok
+      {:error, error} -> {:error, RuntimeError.exception(error)}
+    end
+  end
+
+  @impl true
+  def to_csv(%DF{data: _df}, %S3.Entry{}, _header?, _delimiter, _streaming = true) do
+    {:error, ArgumentError.exception("streaming is not supported for writes to AWS S3")}
+  end
+
+  @impl true
+  def to_csv(%DF{} = ldf, %S3.Entry{} = entry, header?, delimiter, _streaming = false) do
+    eager_df = collect(ldf)
+
+    Eager.to_csv(eager_df, entry, header?, delimiter, false)
+  end
+
+  @impl true
   def to_parquet(%DF{} = ldf, %Local.Entry{} = entry, {compression, level}, streaming) do
     polars_df = apply_operations(ldf)
 
@@ -573,8 +595,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
   @impl true
   def concat_rows([%DF{} | _tail] = dfs, %DF{} = out_df) do
-    polars_dfs =
-      Enum.map(dfs, &apply_operations/1)
+    polars_dfs = Enum.map(dfs, &apply_operations/1)
 
     # Since we apply operations in all DFs, and out_df is pointing to the `head`,
     # we need to reset the operations for `out_df` (they were applied already).
@@ -608,7 +629,6 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     put: 4,
     sample: 5,
     slice: 2,
-    to_csv: 4,
     to_ipc_stream: 3,
     to_ndjson: 2,
     to_rows: 2,

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -354,10 +354,12 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def to_csv(%DF{data: df}, %Local.Entry{} = entry, header?, delimiter, streaming) do
+  def to_csv(%DF{} = ldf, %Local.Entry{} = entry, header?, delimiter, streaming) do
     <<delimiter::utf8>> = delimiter
 
-    case Native.lf_to_csv(df, entry.path, header?, delimiter, streaming) do
+    polars_df = apply_operations(ldf)
+
+    case Native.lf_to_csv(polars_df, entry.path, header?, delimiter, streaming) do
       {:ok, _} -> :ok
       {:error, error} -> {:error, RuntimeError.exception(error)}
     end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -366,12 +366,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def to_csv(%DF{data: _df}, %S3.Entry{}, _header?, _delimiter, _streaming = true) do
-    {:error, ArgumentError.exception("streaming is not supported for writes to AWS S3")}
-  end
-
-  @impl true
-  def to_csv(%DF{} = ldf, %S3.Entry{} = entry, header?, delimiter, _streaming = false) do
+  def to_csv(%DF{} = ldf, %S3.Entry{} = entry, header?, delimiter, _streaming) do
     eager_df = collect(ldf)
 
     Eager.to_csv(eager_df, entry, header?, delimiter, false)

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -273,6 +273,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_to_parquet(_df, _filename, _compression, _streaming), do: err()
   def lf_to_parquet_cloud(_df, _filename, _compression), do: err()
   def lf_to_ipc(_df, _filename, _compression, _streaming), do: err()
+  def lf_to_csv(_df, _filename, _header, _delimiter, _streaming), do: err()
 
   # Series
   def s_as_str(_s), do: err()

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -243,7 +243,7 @@ pub fn lf_to_csv(
         let options = CsvWriterOptions {
             include_header: include_headers,
             maintain_order: true,
-            serialize_options: serialize_options,
+            serialize_options,
             ..Default::default()
         };
 

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -242,6 +242,7 @@ pub fn lf_to_csv(
 
         let options = CsvWriterOptions {
             include_header: include_headers,
+            maintain_order: true,
             serialize_options: serialize_options,
             ..Default::default()
         };

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -225,6 +225,42 @@ pub fn lf_from_csv(
     Ok(ExLazyFrame::new(df))
 }
 
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn lf_to_csv(
+    data: ExLazyFrame,
+    filename: &str,
+    include_headers: bool,
+    delimiter: u8,
+    streaming: bool,
+) -> Result<(), ExplorerError> {
+    let lf = data.clone_inner();
+    if streaming {
+        let serialize_options = SerializeOptions {
+            separator: delimiter,
+            ..Default::default()
+        };
+
+        let options = CsvWriterOptions {
+            include_header: include_headers,
+            serialize_options: serialize_options,
+            ..Default::default()
+        };
+
+        lf.sink_csv(filename.into(), options)?;
+        Ok(())
+    } else {
+        let df = lf.collect()?;
+        let file = File::create(filename)?;
+        let mut buf_writer = BufWriter::new(file);
+
+        CsvWriter::new(&mut buf_writer)
+            .include_header(include_headers)
+            .with_separator(delimiter)
+            .finish(&mut df.clone())?;
+        Ok(())
+    }
+}
+
 #[cfg(feature = "ndjson")]
 #[rustler::nif]
 pub fn lf_from_ndjson(

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -319,6 +319,7 @@ rustler::init!(
         lf_to_parquet,
         lf_to_parquet_cloud,
         lf_to_ipc,
+        lf_to_csv,
         // series
         s_as_str,
         s_abs,

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -587,16 +587,6 @@ defmodule Explorer.DataFrame.CSVTest do
       saved_df = DF.from_csv!(entry)
       assert DF.to_columns(saved_df) == DF.to_columns(Explorer.Datasets.wine())
     end
-
-    test "returns an error when the streaming option is enabled", %{df: df, s3_config: config} do
-      entry = %FSS.S3.Entry{
-        key: "wine-yolo-streaming-#{System.monotonic_time()}.csv",
-        config: config
-      }
-
-      assert {:error, error} = DF.to_csv(df, entry, streaming: true)
-      assert error == ArgumentError.exception("streaming is not supported for writes to AWS S3")
-    end
   end
 
   describe "from_csv/2 - HTTP" do

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -587,6 +587,16 @@ defmodule Explorer.DataFrame.CSVTest do
       saved_df = DF.from_csv!(entry)
       assert DF.to_columns(saved_df) == DF.to_columns(Explorer.Datasets.wine())
     end
+
+    test "returns an error when the streaming option is enabled", %{df: df, s3_config: config} do
+      entry = %FSS.S3.Entry{
+        key: "wine-yolo-streaming-#{System.monotonic_time()}.csv",
+        config: config
+      }
+
+      assert {:error, error} = DF.to_csv(df, entry, streaming: true)
+      assert error == ArgumentError.exception("streaming is not supported for writes to AWS S3")
+    end
   end
 
   describe "from_csv/2 - HTTP" do

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -275,6 +275,22 @@ defmodule Explorer.DataFrame.LazyTest do
     assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
   end
 
+  test "to_csv/3 - cloud with streaming enabled", %{ldf: ldf} do
+    config = %FSS.S3.Config{
+      access_key_id: "test",
+      secret_access_key: "test",
+      endpoint: "http://localhost:4566",
+      region: "us-east-1"
+    }
+
+    path = "s3://test-bucket/test-lazy-writes/wine-#{System.monotonic_time()}.csv"
+
+    ldf = DF.head(ldf, 15)
+    assert {:error, error} = DF.to_ipc(ldf, path, streaming: true, config: config)
+
+    assert error == ArgumentError.exception("streaming is not supported for writes to AWS S3")
+  end
+
   @tag :tmp_dir
   test "to_ipc/2 - with defaults", %{ldf: ldf, tmp_dir: tmp_dir} do
     path = Path.join([tmp_dir, "fossil_fuels.ipc"])

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -250,6 +250,32 @@ defmodule Explorer.DataFrame.LazyTest do
   end
 
   @tag :tmp_dir
+  test "to_csv/2 - with defaults", %{ldf: ldf, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.csv"])
+
+    ldf = DF.head(ldf, 15)
+    DF.to_csv!(ldf, path)
+
+    df = DF.collect(ldf)
+    df1 = DF.from_csv!(path)
+
+    assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
+  end
+
+  @tag :tmp_dir
+  test "to_csv/2 - with streaming enabled", %{ldf: ldf, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.csv"])
+
+    ldf = DF.head(ldf, 15)
+    DF.to_csv!(ldf, path, streaming: true)
+
+    df = DF.collect(ldf)
+    df1 = DF.from_csv!(path)
+
+    assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
+  end
+
+  @tag :tmp_dir
   test "to_ipc/2 - with defaults", %{ldf: ldf, tmp_dir: tmp_dir} do
     path = Path.join([tmp_dir, "fossil_fuels.ipc"])
 


### PR DESCRIPTION
Closes #888 

### Description

I have added a streaming option for the `to_csv/3` that uses the [Polars `sink_csv` function](https://docs.pola.rs/docs/rust/dev/polars_lazy/frame/struct.LazyFrame.html#method.sink_csv) under the hood.  Polars does not have a `sink_csv_cloud` function similar to `sink_parquet_cloud`, so for now, I implemented it only for a LazyFrame using a local entry.

### Notes

As far as my implementation goes, I've kept the DataFrame API clean since I'm really just adding an option, but it does beg the question of how we'd want to expose some other [Polars serialization options](https://docs.pola.rs/docs/rust/dev/polars_lazy/prelude/struct.CsvWriterOptions.html) for users of the `to_csv` function.  For now I won't worry about that, though.  