### PR TITLE
Revert LazyFrame implementation with stack

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -501,7 +501,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def lazy(df) do
     case Native.df_lazy(df.data) do
       {:ok, polars_df} ->
-        %{df | data: struct!(lazy(), frame: polars_df)}
+        %{df | data: polars_df}
 
       {:error, error} ->
         raise "error when assigning lazy frame: #{inspect(error)}"

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -9,6 +9,8 @@ defmodule Explorer.PolarsBackend.Shared do
   alias Explorer.PolarsBackend.Series, as: PolarsSeries
   alias Explorer.Series, as: Series
 
+  @polars_df [PolarsDataFrame, PolarsLazyFrame]
+
   def apply(fun, args \\ []) do
     case apply(Native, fun, args) do
       {:ok, value} -> value
@@ -39,9 +41,17 @@ defmodule Explorer.PolarsBackend.Shared do
   # Applies to a dataframe. Expects a dataframe back.
   def apply_dataframe(%DataFrame{} = df, %DataFrame{} = out_df, fun, args) do
     case apply(Native, fun, [df.data | args]) do
-      {:ok, %PolarsDataFrame{} = new_df} ->
+      {:ok, %module{} = new_df} when module in @polars_df ->
         if @check_frames do
-          check_df = create_dataframe(new_df)
+          # We need to collect here, because the lazy frame may not have
+          # the full picture of the result yet.
+          check_df =
+            if match?(%PolarsLazyFrame{}, new_df) do
+              {:ok, new_df} = Native.lf_collect(new_df)
+              create_dataframe(new_df)
+            else
+              create_dataframe(new_df)
+            end
 
           if Enum.sort(out_df.names) != Enum.sort(check_df.names) or
                out_df.dtypes != check_df.dtypes do
@@ -90,8 +100,8 @@ defmodule Explorer.PolarsBackend.Shared do
     names
   end
 
-  defp df_names(%PolarsLazyFrame{frame: frame}) do
-    {:ok, names} = Native.lf_names(frame)
+  defp df_names(%PolarsLazyFrame{} = polars_df) do
+    {:ok, names} = Native.lf_names(polars_df)
     names
   end
 
@@ -100,8 +110,8 @@ defmodule Explorer.PolarsBackend.Shared do
     dtypes
   end
 
-  defp df_dtypes(%PolarsLazyFrame{frame: frame}) do
-    {:ok, dtypes} = Native.lf_dtypes(frame)
+  defp df_dtypes(%PolarsLazyFrame{} = polars_df) do
+    {:ok, dtypes} = Native.lf_dtypes(polars_df)
     dtypes
   end
 

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -46,7 +46,7 @@ pub struct ExExpr {
 }
 
 #[derive(NifStruct)]
-#[module = "Explorer.PolarsBackend.LazyFrame.Frame"]
+#[module = "Explorer.PolarsBackend.LazyFrame"]
 pub struct ExLazyFrame {
     pub resource: ResourceArc<ExLazyFrameRef>,
 }

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -106,35 +106,41 @@ defmodule Explorer.DataFrame.LazyTest do
   end
 
   test "inspect/1 without operations", %{ldf: ldf} do
-    assert inspect(ldf) == ~s(#Explorer.DataFrame<
-  LazyPolars[??? x 10]
-  year s64 [2010, 2010, 2010, 2010, 2010, ...]
-  country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
-  total s64 [2308, 1254, 32500, 141, 7924, ...]
-  solid_fuel s64 [627, 117, 332, 0, 0, ...]
-  liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
-  gas_fuel s64 [74, 7, 14565, 0, 374, ...]
-  cement s64 [5, 177, 2598, 0, 204, ...]
-  gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
-  per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
-  bunker_fuels s64 [9, 7, 663, 0, 321, ...]
->)
+    assert inspect(ldf) ==
+             """
+             #Explorer.DataFrame<
+               LazyPolars[??? x 10]
+               year s64 [2010, 2010, 2010, 2010, 2010, ...]
+               country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
+               total s64 [2308, 1254, 32500, 141, 7924, ...]
+               solid_fuel s64 [627, 117, 332, 0, 0, ...]
+               liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+               gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+               cement s64 [5, 177, 2598, 0, 204, ...]
+               gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
+               per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
+               bunker_fuels s64 [9, 7, 663, 0, 321, ...]
+             >\
+             """
   end
 
   test "inspect/1 after one operation", %{ldf: ldf} do
-    assert inspect(DF.head(ldf, 12)) == ~s{#Explorer.DataFrame<
-  LazyPolars (stale)[??? x 10]
-  year s64 ???
-  country string ???
-  total s64 ???
-  solid_fuel s64 ???
-  liquid_fuel s64 ???
-  gas_fuel s64 ???
-  cement s64 ???
-  gas_flaring s64 ???
-  per_capita f64 ???
-  bunker_fuels s64 ???
->}
+    assert inspect(DF.head(ldf, 12)) ==
+             """
+             #Explorer.DataFrame<
+               LazyPolars[??? x 10]
+               year s64 [2010, 2010, 2010, 2010, 2010, ...]
+               country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
+               total s64 [2308, 1254, 32500, 141, 7924, ...]
+               solid_fuel s64 [627, 117, 332, 0, 0, ...]
+               liquid_fuel s64 [1601, 953, 12381, 141, 3649, ...]
+               gas_fuel s64 [74, 7, 14565, 0, 374, ...]
+               cement s64 [5, 177, 2598, 0, 204, ...]
+               gas_flaring s64 [0, 0, 2623, 0, 3697, ...]
+               per_capita f64 [0.08, 0.43, 0.9, 1.68, 0.37, ...]
+               bunker_fuels s64 [9, 7, 663, 0, 321, ...]
+             >\
+             """
   end
 
   @tag :tmp_dir


### PR DESCRIPTION
This is because we could make the remaining group operations work without having to deal with the stack in any special way.

It's a revert of https://github.com/elixir-explorer/explorer/pull/882