### PR TITLE
Fix DateTime -> ExDateTime lifetime issue

### DIFF
--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -420,10 +420,10 @@ impl<'a> From<&'a DateTime<Tz>> for ExDateTime<'a> {
             month: dt_tz.month(),
             second: dt_tz.second(),
             std_offset: dt_tz.offset().dst_offset().num_seconds(),
-            time_zone: time_zone,
+            time_zone,
             utc_offset: dt_tz.offset().base_utc_offset().num_seconds(),
             year: dt_tz.year(),
-            zone_abbr: zone_abbr,
+            zone_abbr,
         }
     }
 }

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -17,11 +17,7 @@ use std::str::FromStr;
 #[cfg(feature = "aws")]
 use polars::prelude::cloud::AmazonS3ConfigKey as S3Key;
 
-// TODO: we'll need these again when we resolve the lifetime issues with
-// `ExDateTime` below.
-// use chrono_tz::OffsetComponents;
-// use chrono_tz::OffsetName;
-use chrono_tz::Tz;
+use chrono_tz::{OffsetComponents, OffsetName, Tz};
 
 pub use ex_dtypes::*;
 
@@ -410,29 +406,27 @@ impl From<ExDateTime<'_>> for i64 {
     }
 }
 
-// TODO: resolve the lifetime issues for `time_zone` and `zone_abbr`.
-//
-// impl<'a> From<DateTime<Tz>> for ExDateTime<'a> {
-//     fn from(dt_tz: DateTime<Tz>) -> ExDateTime<'a> {
-//         let & time_zone = dt_tz.offset().tz_id();
-//         let & zone_abbr = dt_tz.offset().abbreviation();
-//
-//         ExDateTime {
-//             calendar: atoms::calendar_iso_module(),
-//             day: dt_tz.day(),
-//             hour: dt_tz.hour(),
-//             microsecond: (microseconds_six_digits(dt_tz.timestamp_subsec_micros()), 6),
-//             minute: dt_tz.minute(),
-//             month: dt_tz.month(),
-//             second: dt_tz.second(),
-//             std_offset: dt_tz.offset().dst_offset().num_seconds(),
-//             time_zone: time_zone,
-//             utc_offset: dt_tz.offset().base_utc_offset().num_seconds(),
-//             year: dt_tz.year(),
-//             zone_abbr: zone_abbr,
-//         }
-//     }
-// }
+impl<'a> From<&'a DateTime<Tz>> for ExDateTime<'a> {
+    fn from(dt_tz: &'a DateTime<Tz>) -> ExDateTime<'a> {
+        let time_zone = dt_tz.offset().tz_id();
+        let zone_abbr = dt_tz.offset().abbreviation();
+
+        ExDateTime {
+            calendar: atoms::calendar_iso_module(),
+            day: dt_tz.day(),
+            hour: dt_tz.hour(),
+            microsecond: (microseconds_six_digits(dt_tz.timestamp_subsec_micros()), 6),
+            minute: dt_tz.minute(),
+            month: dt_tz.month(),
+            second: dt_tz.second(),
+            std_offset: dt_tz.offset().dst_offset().num_seconds(),
+            time_zone: time_zone,
+            utc_offset: dt_tz.offset().base_utc_offset().num_seconds(),
+            year: dt_tz.year(),
+            zone_abbr: zone_abbr,
+        }
+    }
+}
 
 impl From<ExDateTime<'_>> for DateTime<Tz> {
     fn from(ex_dt: ExDateTime<'_>) -> DateTime<Tz> {


### PR DESCRIPTION
This PR continues the work started in #903.

@billylanchantin  and I fixed the lifetime issues for `From<DateTime<Tz>> for ExDateTime`. It was **super** close already. 

It seems to work:

```elixir
iex(1)> Explorer.PolarsBackend.Native.s_from_list_datetime("blep", [DateTime.utc_now()], :microsecond, "America/New_York") |> Explorer.PolarsBackend.Native.s_to_list()
{:ok, [#DateTime<2024-05-15 16:00:45.797338-04:00 EDT America/New_York>]}
```

I think we should consider this PR a WIP until we get some tests in place.
