### PR TITLE
[Proof of concept] Expr serialize

### DIFF
--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -356,6 +356,18 @@ defmodule Explorer.PolarsBackend.Expression do
     Native.expr_describe_filter_plan(polars_df, expression)
   end
 
+  def to_json(%__MODULE__{} = expression) do
+    expression
+    |> Native.expr_to_json()
+    |> Jason.decode!()
+  end
+
+  def from_json(%{} = json_map) do
+    json_map
+    |> Jason.encode!()
+    |> Native.expr_from_json()
+  end
+
   defp dtype(%LazySeries{dtype: dtype}), do: dtype
 
   defp dtype(%PolarsSeries{} = polars_series) do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -196,6 +196,8 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_datetime(_datetime), do: err()
   def expr_duration(_duration), do: err()
   def expr_describe_filter_plan(_df, _expr), do: err()
+  def expr_to_json(_expr), do: err()
+  def expr_from_json(_expr), do: err()
   def expr_float(_number), do: err()
   def expr_integer(_number), do: err()
   def expr_int_range(_start, _end, _step, _dtype), do: err()

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,8 @@ defmodule Explorer.MixProject do
       {:table_rex, "~> 3.1.1 or ~> 4.0.0"},
       {:castore, "~> 1.0", optional: true},
       {:adbc, "~> 0.1", optional: true},
+      # DELETEME!
+      {:jason, "~> 1.4"},
 
       ## Optional
       {:rustler, "~> 0.32.0", optional: not (@dev? or @force_build?)},

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -182,6 +182,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -483,6 +486,7 @@ dependencies = [
  "rand",
  "rand_pcg",
  "rustler",
+ "serde_json",
  "smartstring",
  "thiserror",
  "tokio",
@@ -858,6 +862,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1387,6 +1392,7 @@ dependencies = [
  "polars-error",
  "polars-utils",
  "ryu",
+ "serde",
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
@@ -1445,6 +1451,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "regex",
+ "serde",
  "smartstring",
  "thiserror",
  "version_check",
@@ -1498,6 +1505,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ryu",
+ "serde",
  "serde_json",
  "simd-json",
  "simdutf8",
@@ -1584,6 +1592,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "regex",
+ "serde",
  "serde_json",
  "smartstring",
  "unicode-reverse",
@@ -1665,6 +1674,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "serde",
  "smartstring",
  "strum_macros",
  "version_check",
@@ -1717,6 +1727,7 @@ dependencies = [
  "polars-ops",
  "polars-utils",
  "regex",
+ "serde",
  "smartstring",
 ]
 
@@ -2221,6 +2232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,6 +19,7 @@ rand = { version = "0.8", features = ["alloc"] }
 rand_pcg = "0.3"
 rustler = { version = "0.32", default-features = false, features = ["derive"] }
 thiserror = "1"
+serde_json = "1"
 smartstring = "1"
 either = "1"
 
@@ -76,6 +77,8 @@ features = [
   "rolling_window",
   "round_series",
   "rows",
+  "serde",
+  "serde-lazy",
   "simd",
   "streaming",
   "strings",

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -831,6 +831,17 @@ pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
 }
 
 #[rustler::nif]
+pub fn expr_to_json(expr: ExExpr) -> String {
+    serde_json::to_string(&expr.clone_inner()).unwrap()
+}
+
+#[rustler::nif]
+pub fn expr_from_json(expr_json: String) -> ExExpr {
+    let expr: Expr = serde_json::from_str(&expr_json).unwrap();
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
 pub fn expr_contains(expr: ExExpr, pattern: &str) -> ExExpr {
     let expr = expr.clone_inner();
     ExExpr::new(expr.str().contains_literal(pattern.lit()))

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -258,6 +258,8 @@ rustler::init!(
         expr_ewm_variance,
         // inspect expressions
         expr_describe_filter_plan,
+        expr_to_json,
+        expr_from_json,
         // string expressions
         expr_contains,
         expr_re_contains,

--- a/test/explorer/polars_backend/expression_test.exs
+++ b/test/explorer/polars_backend/expression_test.exs
@@ -135,8 +135,8 @@ defmodule Explorer.PolarsBackend.ExpressionTest do
       mutate_with_json = fn df, name, json ->
         expr =
           json
-          |> Expression.from_json()
-          |> Expression.alias_expr(name)
+          |> Explorer.PolarsBackend.Expression.from_json()
+          |> Explorer.PolarsBackend.Expression.alias_expr(name)
 
         ldf = Explorer.DataFrame.lazy(df)
         {:ok, lpdf_new} = Explorer.PolarsBackend.Native.lf_mutate_with(ldf.data, [expr])


### PR DESCRIPTION
### 🚧 Do not merge

This PR is only a proof of concept.

### Description

Adds `expr_to_json` and `expr_from_json`.

The idea is to provide an escape hatch for Polars functionality we don't yet support. Included is a test case demonstrating that it's possible.

### Discussion

Explorer can lag behind what's available in Polars. This functionality would allow users to opt into behavior not otherwise available. My hope is that we can turn this idea into something like [`Ecto.Query.API.fragment/1`](https://hexdocs.pm/ecto/Ecto.Query.API.html#fragment/1).

This approach is messy for a few reasons:

* You have to somehow get your hands on the JSON
* The escape hatch is Polars-specific
* We'd have to weave it into many functions (though I have thoughts here)

But for that price, we instantly open up all expression-based operations. Please let me know if you think!