### PR TITLE
[WIP] Initial SQL support

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -241,6 +241,10 @@ defmodule Explorer.Backend.DataFrame do
   @callback summarise_with(df, out_df :: df(), aggregations :: [{column_name(), lazy_series()}]) ::
               df
 
+  # SQL
+
+  @callback execute_sql(df, sql_string :: binary()) :: df()
+
   # Functions
   alias Explorer.{DataFrame, Series}
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5946,6 +5946,22 @@ defmodule Explorer.DataFrame do
     Shared.apply_impl(df, :covariance, [out_df, opts[:ddof]])
   end
 
+  # SQL
+
+  @doc """
+  ## Examples
+
+      iex> df = Explorer.DataFrame.new(a: [1, 2, 3])
+      iex> Explorer.DataFrame.execute_sql(df, "max(a)")
+      #Explorer.DataFrame<
+        Polars[1 x 1]
+        a s64 [3]
+      >
+  """
+  def execute_sql(%__MODULE__{} = df, sql_string) when is_binary(sql_string) do
+    Shared.apply_impl(df, :execute_sql, [sql_string])
+  end
+
   # Helpers
 
   defp backend_from_options!(opts) do

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -878,6 +878,16 @@ defmodule Explorer.PolarsBackend.DataFrame do
     |> LazyFrame.collect()
   end
 
+  # SQL
+
+  @impl true
+  def execute_sql(%DataFrame{} = df, sql_string) do
+    df
+    |> lazy()
+    |> LazyFrame.execute_sql(sql_string)
+    |> LazyFrame.collect()
+  end
+
   # Inspect
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -580,6 +580,13 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     Eager.re_dtype(regex_as_string)
   end
 
+  @impl true
+  def execute_sql(ldf, sql_string) do
+    ldf.data
+    |> Native.lf_execute_sql(sql_string)
+    |> Shared.create_dataframe()
+  end
+
   not_available_funs = [
     correlation: 4,
     covariance: 3,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -271,6 +271,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_to_parquet_cloud(_df, _filename, _compression), do: err()
   def lf_to_ipc(_df, _filename, _compression, _streaming), do: err()
   def lf_to_csv(_df, _filename, _header, _delimiter, _streaming), do: err()
+  def lf_execute_sql(_df, _sql_string), do: err()
 
   # Series
   def s_as_str(_s), do: err()

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -77,6 +77,7 @@ features = [
   "round_series",
   "rows",
   "simd",
+  "sql",
   "streaming",
   "strings",
   "temporal",

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -344,3 +344,11 @@ pub fn lf_concat_columns(
 
     Ok(ExLazyFrame::new(out_df.drop([id_column])))
 }
+
+#[rustler::nif]
+pub fn lf_execute_sql(lf: ExLazyFrame, sql_string: &str) -> ExLazyFrame {
+    let lf = lf.clone_inner();
+    let expr = polars::sql::sql_expr(sql_string).unwrap();
+    let lf_sql = lf.select(vec![expr]);
+    ExLazyFrame::new(lf_sql)
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -322,6 +322,7 @@ rustler::init!(
         lf_to_parquet_cloud,
         lf_to_ipc,
         lf_to_csv,
+        lf_execute_sql,
         // series
         s_as_str,
         s_abs,


### PR DESCRIPTION
### Description

This PR experiments with initial SQL support. From the doctest:

```elixir
iex> df = Explorer.DataFrame.new(a: [1, 2, 3])
iex> Explorer.DataFrame.execute_sql(df, "max(a)")
# #Explorer.DataFrame<
#   Polars[1 x 1]
#   a s64 [3]
# >
```

### Open questions

* [ ] Overall API structure? Right now I'm just calling `lf.select(expr)`, but we could do much more.
* [ ] Implement `Ecto.Queryable`?