### PR TITLE
Add Artifact Attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,12 @@ jobs:
   build_release:
     name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }} | ${{ matrix.job.variant || 'default' }})
     runs-on: ${{ matrix.job.os }}
+
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +88,11 @@ jobs:
           project-dir: "native/explorer"
           cargo-args: ${{ matrix.job.cargo-args }}
           variant: ${{ matrix.job.variant }}
+
+      - name: Artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ steps.build-crate.outputs.file-path }}
 
       - name: Artifact upload
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is a new feature from GitHub Actions to store the attestation that the artifact generated in the build was not modified later on.