### PR TITLE
Stop inference of type if dtype is given and manually decode terms where needed

### DIFF
--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -8,11 +8,12 @@ defmodule Explorer.PolarsBackend.Shared do
   alias Explorer.PolarsBackend.Native
   alias Explorer.PolarsBackend.Series, as: PolarsSeries
   alias Explorer.Series, as: Series
+  import Kernel, except: [apply: 2]
 
   @polars_df [PolarsDataFrame, PolarsLazyFrame]
 
   def apply(fun, args \\ []) do
-    case apply(Native, fun, args) do
+    case Kernel.apply(Native, fun, args) do
       {:ok, value} -> value
       {:error, error} -> raise runtime_error(error)
     end
@@ -185,11 +186,11 @@ defmodule Explorer.PolarsBackend.Shared do
       :boolean -> Native.s_from_list_bool(name, list)
       :string -> Native.s_from_list_str(name, list)
       :category -> Native.s_from_list_categories(name, list)
-      :date -> Native.s_from_list_date(name, list)
-      :time -> Native.s_from_list_time(name, list)
-      {:naive_datetime, precision} -> Native.s_from_list_naive_datetime(name, list, precision)
-      {:datetime, precision, tz} -> Native.s_from_list_datetime(name, list, precision, tz)
-      {:duration, precision} -> Native.s_from_list_duration(name, list, precision)
+      :date -> apply(:s_from_list_date, [name, list])
+      :time -> apply(:s_from_list_time, [name, list])
+      {:naive_datetime, precision} -> apply(:s_from_list_naive_datetime, [name, list, precision])
+      {:datetime, precision, tz} -> apply(:s_from_list_datetime, [name, list, precision, tz])
+      {:duration, precision} -> apply(:s_from_list_duration, [name, list, precision])
       :binary -> Native.s_from_list_binary(name, list)
       :null -> Native.s_from_list_null(name, length(list))
     end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -296,7 +296,7 @@ defmodule Explorer.Series do
   ## Options
 
     * `:backend` - The backend to allocate the series on.
-    * `:dtype` - Cast the series to a given `:dtype`. By default this is `nil`, which means
+    * `:dtype` - Create a series of a given `:dtype`. By default this is `nil`, which means
       that Explorer will infer the type from the values in the list.
       See the module docs for the list of valid dtypes and aliases.
 
@@ -387,12 +387,6 @@ defmodule Explorer.Series do
         s64 [nil, nil]
       >
 
-      iex> Explorer.Series.from_list([1, nil], dtype: :string)
-      #Explorer.Series<
-        Polars[2]
-        string ["1", nil]
-      >
-
       iex> Explorer.Series.from_list([1, 2], dtype: :f32)
       #Explorer.Series<
         Polars[2]
@@ -431,6 +425,14 @@ defmodule Explorer.Series do
         category ["EUA", "Brazil", "Poland"]
       >
 
+  It is possible to create a series of `:date` from a list of days since Unix Epoch.
+
+      iex> Explorer.Series.from_list([1, nil], dtype: :date)
+      #Explorer.Series<
+        Polars[2]
+        date [1970-01-02, nil]
+      >
+
   It is possible to create a series of `:datetime` from a list of microseconds since Unix Epoch.
 
       iex> Explorer.Series.from_list([1649883642 * 1_000 * 1_000], dtype: {:naive_datetime, :microsecond})
@@ -451,6 +453,15 @@ defmodule Explorer.Series do
 
       iex> Explorer.Series.from_list([1, "a"])
       ** (ArgumentError) the value "a" does not match the inferred dtype {:s, 64}
+
+  But mixing integers and some of the types for `:date`, `:datetime`, `:time`, or `:duration`
+  will work if the desired dtype is given:
+
+      iex> Explorer.Series.from_list([1, nil, ~D[2024-06-13]], dtype: :date)
+      #Explorer.Series<
+        Polars[3]
+        date [1970-01-02, nil, 2024-06-13]
+      >
   """
   @doc type: :conversion
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()
@@ -462,13 +473,7 @@ defmodule Explorer.Series do
 
     type = Shared.dtype_from_list!(list, normalised_dtype)
 
-    series = backend.from_list(list, type)
-
-    case normalised_dtype do
-      nil -> series
-      ^type -> series
-      other -> cast(series, other)
-    end
+    backend.from_list(list, type)
   end
 
   defp from_same_value(%{data: %backend{}}, value) do

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -35,6 +35,7 @@ pub use error::ExplorerError;
 use expressions::*;
 use lazyframe::io::*;
 use lazyframe::*;
+use series::from_list::*;
 use series::log::*;
 use series::*;
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1,8 +1,8 @@
 use crate::{
     atoms,
     datatypes::{
-        ExCorrelationMethod, ExDate, ExDateTime, ExDuration, ExNaiveDateTime, ExRankMethod,
-        ExSeriesDtype, ExTime, ExTimeUnit, ExValidValue,
+        ExCorrelationMethod, ExDate, ExNaiveDateTime, ExRankMethod, ExSeriesDtype, ExTime,
+        ExTimeUnit, ExValidValue,
     },
     encoding, ExDataFrame, ExSeries, ExplorerError,
 };
@@ -16,6 +16,7 @@ use polars_ops::prelude::peaks::*;
 use rustler::{Binary, Encoder, Env, Error, ListIterator, NifResult, Term, TermType};
 use std::slice;
 
+pub mod from_list;
 pub mod log;
 
 #[rustler::nif]
@@ -96,96 +97,6 @@ macro_rules! from_list_float {
 
 from_list_float!(s_from_list_f32, f32, f32);
 from_list_float!(s_from_list_f64, f64, f64);
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_date(name: &str, val: Vec<Option<ExDate>>) -> ExSeries {
-    ExSeries::new(
-        Series::new(
-            name,
-            val.iter()
-                .map(|d| d.map(|d| d.into()))
-                .collect::<Vec<Option<i32>>>(),
-        )
-        .cast(&DataType::Date)
-        .unwrap(),
-    )
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_naive_datetime(
-    name: &str,
-    val: Vec<Option<ExNaiveDateTime>>,
-    precision: ExTimeUnit,
-) -> ExSeries {
-    let timeunit = TimeUnit::try_from(&precision).unwrap();
-
-    ExSeries::new(
-        Series::new(
-            name,
-            val.iter()
-                .map(|dt| dt.map(|dt| dt.into()))
-                .collect::<Vec<Option<i64>>>(),
-        )
-        .cast(&DataType::Datetime(timeunit, None))
-        .unwrap(),
-    )
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_datetime(
-    name: &str,
-    val: Vec<Option<ExDateTime>>,
-    precision: ExTimeUnit,
-    time_zone_str: Option<&str>,
-) -> ExSeries {
-    let timeunit = TimeUnit::try_from(&precision).unwrap();
-    let time_zone = time_zone_str.map(|s| s.to_string());
-
-    ExSeries::new(
-        Series::new(
-            name,
-            val.iter()
-                .map(|dt| dt.map(|dt| dt.into()))
-                .collect::<Vec<Option<i64>>>(),
-        )
-        .cast(&DataType::Datetime(timeunit, time_zone))
-        .unwrap(),
-    )
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_duration(
-    name: &str,
-    val: Vec<Option<ExDuration>>,
-    precision: ExTimeUnit,
-) -> ExSeries {
-    let timeunit = TimeUnit::try_from(&precision).unwrap();
-
-    ExSeries::new(
-        Series::new(
-            name,
-            val.iter()
-                .map(|d| d.map(|d| d.into()))
-                .collect::<Vec<Option<i64>>>(),
-        )
-        .cast(&DataType::Duration(timeunit))
-        .unwrap(),
-    )
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_time(name: &str, val: Vec<Option<ExTime>>) -> ExSeries {
-    ExSeries::new(
-        Series::new(
-            name,
-            val.iter()
-                .map(|dt| dt.map(|dt| dt.into()))
-                .collect::<Vec<Option<i64>>>(),
-        )
-        .cast(&DataType::Time)
-        .unwrap(),
-    )
-}
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_from_list_binary(name: &str, val: Vec<Option<Binary>>) -> ExSeries {

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1,5 +1,4 @@
 use crate::{
-    atoms,
     datatypes::{
         ExCorrelationMethod, ExDate, ExNaiveDateTime, ExRankMethod, ExSeriesDtype, ExTime,
         ExTimeUnit, ExValidValue,
@@ -13,8 +12,7 @@ use encoding::encode_naive_datetime;
 use polars::prelude::*;
 use polars_ops::chunked_array::cov::{cov, pearson_corr};
 use polars_ops::prelude::peaks::*;
-use rustler::{Binary, Encoder, Env, Error, ListIterator, NifResult, Term, TermType};
-use std::slice;
+use rustler::{Binary, Encoder, Env, Term};
 
 pub mod from_list;
 pub mod log;
@@ -23,154 +21,6 @@ pub mod log;
 pub fn s_as_str(data: ExSeries) -> Result<String, ExplorerError> {
     Ok(format!("{:?}", data.resource.0))
 }
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_null(name: &str, length: usize) -> ExSeries {
-    let s = Series::new_null(name, length);
-    ExSeries::new(Series::new(name, s))
-}
-
-macro_rules! from_list {
-    ($name:ident, $type:ty) => {
-        #[rustler::nif(schedule = "DirtyCpu")]
-        pub fn $name(name: &str, val: Vec<Option<$type>>) -> ExSeries {
-            ExSeries::new(Series::new(name, val.as_slice()))
-        }
-    };
-}
-
-from_list!(s_from_list_s8, i8);
-from_list!(s_from_list_s16, i16);
-from_list!(s_from_list_s32, i32);
-from_list!(s_from_list_s64, i64);
-
-from_list!(s_from_list_u8, u8);
-from_list!(s_from_list_u16, u16);
-from_list!(s_from_list_u32, u32);
-from_list!(s_from_list_u64, u64);
-
-from_list!(s_from_list_bool, bool);
-from_list!(s_from_list_str, String);
-
-macro_rules! from_list_float {
-    ($name:ident, $type:ty, $module:ident) => {
-        #[rustler::nif(schedule = "DirtyCpu")]
-        pub fn $name(name: &str, val: Term) -> NifResult<ExSeries> {
-            let nan = atoms::nan();
-            let infinity = atoms::infinity();
-            let neg_infinity = atoms::neg_infinity();
-
-            let values: NifResult<Vec<Option<$type>>> = val
-                .decode::<ListIterator>()?
-                .map(|item| match item.get_type() {
-                    TermType::Float => item.decode::<Option<$type>>(),
-                    TermType::Integer => {
-                        let int_value = item.decode::<i64>().unwrap();
-                        Ok(Some(int_value as $type))
-                    }
-                    TermType::Atom => Ok(if nan.eq(&item) {
-                        Some($module::NAN)
-                    } else if infinity.eq(&item) {
-                        Some($module::INFINITY)
-                    } else if neg_infinity.eq(&item) {
-                        Some($module::NEG_INFINITY)
-                    } else {
-                        None
-                    }),
-                    term_type => {
-                        let message = format!("from_list/2 not implemented for {term_type:?}");
-                        Err(Error::RaiseTerm(Box::new(message)))
-                    }
-                })
-                .collect::<NifResult<Vec<Option<$type>>>>();
-
-            match (values) {
-                Ok(x) => {
-                    let s = Series::new(name, x);
-                    Ok(ExSeries::new(s))
-                }
-                Err(x) => Err(x),
-            }
-        }
-    };
-}
-
-from_list_float!(s_from_list_f32, f32, f32);
-from_list_float!(s_from_list_f64, f64, f64);
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_binary(name: &str, val: Vec<Option<Binary>>) -> ExSeries {
-    ExSeries::new(Series::new(
-        name,
-        val.iter()
-            .map(|bin| bin.map(|bin| bin.as_slice()))
-            .collect::<Vec<Option<&[u8]>>>(),
-    ))
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_categories(name: &str, val: Vec<Option<String>>) -> ExSeries {
-    ExSeries::new(
-        Series::new(name, val.as_slice())
-            .cast(&DataType::Categorical(None, CategoricalOrdering::default()))
-            .unwrap(),
-    )
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_of_series(name: &str, series_vec: Vec<Option<ExSeries>>) -> ExSeries {
-    let lists: Vec<Option<Series>> = series_vec
-        .iter()
-        .map(|maybe_series| {
-            maybe_series
-                .as_ref()
-                .map(|ex_series| ex_series.clone_inner())
-        })
-        .collect();
-
-    ExSeries::new(Series::new(name, lists))
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_of_series_as_structs(name: &str, series_vec: Vec<ExSeries>) -> ExSeries {
-    let struct_chunked = StructChunked::new(
-        name,
-        series_vec
-            .into_iter()
-            .map(|s| s.clone_inner())
-            .collect::<Vec<_>>()
-            .as_slice(),
-    )
-    .unwrap();
-
-    ExSeries::new(struct_chunked.into_series())
-}
-
-macro_rules! from_binary {
-    ($name:ident, $type:ty, $bytes:expr) => {
-        #[rustler::nif(schedule = "DirtyCpu")]
-        pub fn $name(name: &str, val: Binary) -> ExSeries {
-            let slice = val.as_slice();
-            let transmuted = unsafe {
-                slice::from_raw_parts(slice.as_ptr() as *const $type, slice.len() / $bytes)
-            };
-            ExSeries::new(Series::new(name, transmuted))
-        }
-    };
-}
-
-from_binary!(s_from_binary_f32, f32, 4);
-from_binary!(s_from_binary_f64, f64, 8);
-
-from_binary!(s_from_binary_s8, i8, 1);
-from_binary!(s_from_binary_s16, i16, 2);
-from_binary!(s_from_binary_s32, i32, 4);
-from_binary!(s_from_binary_s64, i64, 8);
-
-from_binary!(s_from_binary_u8, u8, 1);
-from_binary!(s_from_binary_u16, u16, 2);
-from_binary!(s_from_binary_u32, u32, 4);
-from_binary!(s_from_binary_u64, u64, 8);
 
 #[rustler::nif]
 pub fn s_name(data: ExSeries) -> Result<String, ExplorerError> {

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -21,14 +21,14 @@ pub fn s_from_list_date(name: &str, val: Term) -> Result<ExSeries, ExplorerError
                 .decode::<ExDate>()
                 .map(|ex_date| Some(i32::from(ex_date)))
                 .map_err(|error| {
-                    let message = format!("cannot decode a valid date from term. error: {error:?}");
-                    ExplorerError::Other(message)
+                    ExplorerError::Other(format!(
+                        "cannot decode a valid date from term. error: {error:?}"
+                    ))
                 }),
             TermType::Atom => Ok(None),
-            term_type => {
-                let message = format!("from_list/2 for dates not implemented for {term_type:?}");
-                Err(ExplorerError::Other(message))
-            }
+            term_type => Err(ExplorerError::Other(format!(
+                "from_list/2 for dates not implemented for {term_type:?}"
+            ))),
         })
         .collect::<Result<Vec<Option<i32>>, ExplorerError>>()?;
 
@@ -62,16 +62,14 @@ pub fn s_from_list_naive_datetime(
                 .decode::<ExNaiveDateTime>()
                 .map(|ex_naive_datetime| Some(i64::from(ex_naive_datetime)))
                 .map_err(|error| {
-                    let message =
-                        format!("cannot decode a valid naive datetime from term. error: {error:?}");
-                    ExplorerError::Other(message)
+                    ExplorerError::Other(format!(
+                        "cannot decode a valid naive datetime from term. error: {error:?}"
+                    ))
                 }),
             TermType::Atom => Ok(None),
-            term_type => {
-                let message =
-                    format!("from_list/2 for naive datetimess not implemented for {term_type:?}");
-                Err(ExplorerError::Other(message))
-            }
+            term_type => Err(ExplorerError::Other(format!(
+                "from_list/2 for naive datetimes not implemented for {term_type:?}"
+            ))),
         })
         .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
 
@@ -105,18 +103,16 @@ pub fn s_from_list_datetime(
             }),
             TermType::Map => item
                 .decode::<ExDateTime>()
-                .map(|ex_naive_datetime| Some(i64::from(ex_naive_datetime)))
+                .map(|ex_datetime| Some(i64::from(ex_datetime)))
                 .map_err(|error| {
-                    let message =
-                        format!("cannot decode a valid datetime from term. error: {error:?}");
-                    ExplorerError::Other(message)
+                    ExplorerError::Other(format!(
+                        "cannot decode a valid datetime from term. error: {error:?}"
+                    ))
                 }),
             TermType::Atom => Ok(None),
-            term_type => {
-                let message =
-                    format!("from_list/2 for datetimes not implemented for {term_type:?}");
-                Err(ExplorerError::Other(message))
-            }
+            term_type => Err(ExplorerError::Other(format!(
+                "from_list/2 for datetimes not implemented for {term_type:?}"
+            ))),
         })
         .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
 
@@ -150,16 +146,14 @@ pub fn s_from_list_duration(
                 .decode::<ExDuration>()
                 .map(|ex_duration| Some(i64::from(ex_duration)))
                 .map_err(|error| {
-                    let message =
-                        format!("cannot decode a valid duration from term. error: {error:?}");
-                    ExplorerError::Other(message)
+                    ExplorerError::Other(format!(
+                        "cannot decode a valid duration from term. error: {error:?}"
+                    ))
                 }),
             TermType::Atom => Ok(None),
-            term_type => {
-                let message =
-                    format!("from_list/2 for datetimes not implemented for {term_type:?}");
-                Err(ExplorerError::Other(message))
-            }
+            term_type => Err(ExplorerError::Other(format!(
+                "from_list/2 for durations not implemented for {term_type:?}"
+            ))),
         })
         .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
 
@@ -186,17 +180,16 @@ pub fn s_from_list_time(name: &str, val: Term) -> Result<ExSeries, ExplorerError
             }),
             TermType::Map => item
                 .decode::<ExTime>()
-                .map(|ex_duration| Some(i64::from(ex_duration)))
+                .map(|ex_time| Some(i64::from(ex_time)))
                 .map_err(|error| {
-                    let message =
-                        format!("cannot decode a valid duration from term. error: {error:?}");
-                    ExplorerError::Other(message)
+                    ExplorerError::Other(format!(
+                        "cannot decode a valid time from term. error: {error:?}"
+                    ))
                 }),
             TermType::Atom => Ok(None),
-            term_type => {
-                let message = format!("from_list/2 for time not implemented for {term_type:?}");
-                Err(ExplorerError::Other(message))
-            }
+            term_type => Err(ExplorerError::Other(format!(
+                "from_list/2 for time not implemented for {term_type:?}"
+            ))),
         })
         .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
 

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -1,0 +1,209 @@
+use crate::datatypes::{ExDate, ExDateTime, ExDuration, ExNaiveDateTime, ExTime, ExTimeUnit};
+use crate::{ExSeries, ExplorerError};
+
+use polars::prelude::*;
+use rustler::{ListIterator, Term, TermType};
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_date(name: &str, val: Term) -> Result<ExSeries, ExplorerError> {
+    let iterator = val
+        .decode::<ListIterator>()
+        .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
+
+    let values: Vec<Option<i32>> = iterator
+        .map(|item| match item.get_type() {
+            TermType::Integer => item.decode::<i32>().map(Some).map_err(|err| {
+                ExplorerError::Other(format!("int number is too big for an i32: {err:?}"))
+            }),
+            TermType::Map => item
+                .decode::<ExDate>()
+                .map(|ex_date| Some(i32::from(ex_date)))
+                .map_err(|error| {
+                    let message = format!("cannot decode a valid date from term. error: {error:?}");
+                    ExplorerError::Other(message)
+                }),
+            TermType::Atom => Ok(None),
+            term_type => {
+                let message = format!("from_list/2 for dates not implemented for {term_type:?}");
+                Err(ExplorerError::Other(message))
+            }
+        })
+        .collect::<Result<Vec<Option<i32>>, ExplorerError>>()?;
+
+    Series::new(name, values)
+        .cast(&DataType::Date)
+        .map(ExSeries::new)
+        .map_err(|error| {
+            ExplorerError::Other(format!(
+                "from_list/2 cannot cast integer series to a valid date series: {error:?}"
+            ))
+        })
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_naive_datetime(
+    name: &str,
+    val: Term,
+    precision: ExTimeUnit,
+) -> Result<ExSeries, ExplorerError> {
+    let timeunit = TimeUnit::try_from(&precision)?;
+    let iterator = val
+        .decode::<ListIterator>()
+        .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
+
+    let values: Vec<Option<i64>> = iterator
+        .map(|item| match item.get_type() {
+            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+                ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
+            }),
+            TermType::Map => item
+                .decode::<ExNaiveDateTime>()
+                .map(|ex_naive_datetime| Some(i64::from(ex_naive_datetime)))
+                .map_err(|error| {
+                    let message =
+                        format!("cannot decode a valid naive datetime from term. error: {error:?}");
+                    ExplorerError::Other(message)
+                }),
+            TermType::Atom => Ok(None),
+            term_type => {
+                let message =
+                    format!("from_list/2 for naive datetimess not implemented for {term_type:?}");
+                Err(ExplorerError::Other(message))
+            }
+        })
+        .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
+
+    Series::new(name, values)
+        .cast(&DataType::Datetime(timeunit, None))
+        .map(ExSeries::new)
+        .map_err(|error| {
+            ExplorerError::Other(format!(
+                "from_list/2 cannot cast integer series to a valid naive datetime series: {error:?}"
+            ))
+        })
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_datetime(
+    name: &str,
+    val: Term,
+    precision: ExTimeUnit,
+    time_zone_str: Option<&str>,
+) -> Result<ExSeries, ExplorerError> {
+    let timeunit = TimeUnit::try_from(&precision)?;
+    let time_zone = time_zone_str.map(|s| s.to_string());
+    let iterator = val
+        .decode::<ListIterator>()
+        .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
+
+    let values: Vec<Option<i64>> = iterator
+        .map(|item| match item.get_type() {
+            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+                ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
+            }),
+            TermType::Map => item
+                .decode::<ExDateTime>()
+                .map(|ex_naive_datetime| Some(i64::from(ex_naive_datetime)))
+                .map_err(|error| {
+                    let message =
+                        format!("cannot decode a valid datetime from term. error: {error:?}");
+                    ExplorerError::Other(message)
+                }),
+            TermType::Atom => Ok(None),
+            term_type => {
+                let message =
+                    format!("from_list/2 for datetimes not implemented for {term_type:?}");
+                Err(ExplorerError::Other(message))
+            }
+        })
+        .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
+
+    Series::new(name, values)
+        .cast(&DataType::Datetime(timeunit, time_zone))
+        .map(ExSeries::new)
+        .map_err(|error| {
+            ExplorerError::Other(format!(
+                "from_list/2 cannot cast integer series to a valid datetime series: {error:?}"
+            ))
+        })
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_duration(
+    name: &str,
+    val: Term,
+    precision: ExTimeUnit,
+) -> Result<ExSeries, ExplorerError> {
+    let timeunit = TimeUnit::try_from(&precision)?;
+    let iterator = val
+        .decode::<ListIterator>()
+        .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
+
+    let values: Vec<Option<i64>> = iterator
+        .map(|item| match item.get_type() {
+            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+                ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
+            }),
+            TermType::Map => item
+                .decode::<ExDuration>()
+                .map(|ex_duration| Some(i64::from(ex_duration)))
+                .map_err(|error| {
+                    let message =
+                        format!("cannot decode a valid duration from term. error: {error:?}");
+                    ExplorerError::Other(message)
+                }),
+            TermType::Atom => Ok(None),
+            term_type => {
+                let message =
+                    format!("from_list/2 for datetimes not implemented for {term_type:?}");
+                Err(ExplorerError::Other(message))
+            }
+        })
+        .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
+
+    Series::new(name, values)
+        .cast(&DataType::Duration(timeunit))
+        .map(ExSeries::new)
+        .map_err(|error| {
+            ExplorerError::Other(format!(
+                "from_list/2 cannot cast integer series to a valid duration series: {error:?}"
+            ))
+        })
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_time(name: &str, val: Term) -> Result<ExSeries, ExplorerError> {
+    let iterator = val
+        .decode::<ListIterator>()
+        .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
+
+    let values: Vec<Option<i64>> = iterator
+        .map(|item| match item.get_type() {
+            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+                ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
+            }),
+            TermType::Map => item
+                .decode::<ExTime>()
+                .map(|ex_duration| Some(i64::from(ex_duration)))
+                .map_err(|error| {
+                    let message =
+                        format!("cannot decode a valid duration from term. error: {error:?}");
+                    ExplorerError::Other(message)
+                }),
+            TermType::Atom => Ok(None),
+            term_type => {
+                let message = format!("from_list/2 for time not implemented for {term_type:?}");
+                Err(ExplorerError::Other(message))
+            }
+        })
+        .collect::<Result<Vec<Option<i64>>, ExplorerError>>()?;
+
+    Series::new(name, values)
+        .cast(&DataType::Time)
+        .map(ExSeries::new)
+        .map_err(|error| {
+            ExplorerError::Other(format!(
+                "from_list/2 cannot cast integer series to a valid time series: {error:?}"
+            ))
+        })
+}

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -249,17 +249,17 @@ defmodule Explorer.DataFrameTest do
       assert DF.dtypes(df) == %{"integers" => {:s, 64}}
     end
 
-    test "with series of integers and dtype string" do
+    test "with series of integers and dtype date" do
       df =
-        DF.new(%{strings: [1, 2, 3]},
-          dtypes: [{:strings, :string}]
+        DF.new(%{dates: [0, 1, 2, 3]},
+          dtypes: [{:dates, :date}]
         )
 
       assert DF.to_columns(df, atom_keys: true) == %{
-               strings: ["1", "2", "3"]
+               dates: [~D[1970-01-01], ~D[1970-01-02], ~D[1970-01-03], ~D[1970-01-04]]
              }
 
-      assert DF.dtypes(df) == %{"strings" => :string}
+      assert DF.dtypes(df) == %{"dates" => :date}
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -380,6 +380,22 @@ defmodule Explorer.SeriesTest do
         assert Series.dtype(s) == {:u, 8}
       end
     end
+
+    test "mixing dates and integers with `:date` dtype" do
+      s = Series.from_list([1, nil, ~D[2024-06-13]], dtype: :date)
+
+      assert s[0] == ~D[1970-01-02]
+      assert Series.to_list(s) === [~D[1970-01-02], nil, ~D[2024-06-13]]
+      assert Series.dtype(s) == :date
+    end
+
+    test "mixing dates and integers without a dtype" do
+      assert_raise ArgumentError,
+                   "the value ~D[2024-06-13] does not match the inferred dtype {:s, 64}",
+                   fn ->
+                     Series.from_list([1, nil, ~D[2024-06-13]])
+                   end
+    end
   end
 
   describe "fetch/2" do


### PR DESCRIPTION
This is a continuation of https://github.com/elixir-explorer/explorer/pull/923

We are now delegating to the backend the job of decoding the terms instead of casting if the dtype is different from the inferred dtype. In fact we stopped to infer the type if the dtype is given.

In a nutshell, this PR:

1. removes the inference of type if `:dtype` is given.
2. stop casting if given dtype and inferred dtype are different, because point 1.
3. adds a manual decoding of terms for the functions that may accept special values (structs or integers).

The main goal is to improve performance, as discussed in #922.