### PR TITLE
Improve "from_list/2" decoding of terms for binary series

### DIFF
--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -14,7 +14,7 @@ pub fn s_from_list_date(name: &str, val: Term) -> Result<ExSeries, ExplorerError
 
     let values: Vec<Option<i32>> = iterator
         .map(|item| match item.get_type() {
-            TermType::Integer => item.decode::<i32>().map(Some).map_err(|err| {
+            TermType::Integer => item.decode::<Option<i32>>().map_err(|err| {
                 ExplorerError::Other(format!("int number is too big for an i32: {err:?}"))
             }),
             TermType::Map => item
@@ -55,7 +55,7 @@ pub fn s_from_list_naive_datetime(
 
     let values: Vec<Option<i64>> = iterator
         .map(|item| match item.get_type() {
-            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+            TermType::Integer => item.decode::<Option<i64>>().map_err(|err| {
                 ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
             }),
             TermType::Map => item
@@ -98,7 +98,7 @@ pub fn s_from_list_datetime(
 
     let values: Vec<Option<i64>> = iterator
         .map(|item| match item.get_type() {
-            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+            TermType::Integer => item.decode::<Option<i64>>().map_err(|err| {
                 ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
             }),
             TermType::Map => item
@@ -139,7 +139,7 @@ pub fn s_from_list_duration(
 
     let values: Vec<Option<i64>> = iterator
         .map(|item| match item.get_type() {
-            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+            TermType::Integer => item.decode::<Option<i64>>().map_err(|err| {
                 ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
             }),
             TermType::Map => item
@@ -175,7 +175,7 @@ pub fn s_from_list_time(name: &str, val: Term) -> Result<ExSeries, ExplorerError
 
     let values: Vec<Option<i64>> = iterator
         .map(|item| match item.get_type() {
-            TermType::Integer => item.decode::<i64>().map(Some).map_err(|err| {
+            TermType::Integer => item.decode::<Option<i64>>().map_err(|err| {
                 ExplorerError::Other(format!("int number is too big for an i64: {err:?}"))
             }),
             TermType::Map => item

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -278,13 +278,14 @@ from_list_float!(s_from_list_f32, f32, f32);
 from_list_float!(s_from_list_f64, f64, f64);
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_from_list_binary(name: &str, val: Vec<Option<Binary>>) -> ExSeries {
-    ExSeries::new(Series::new(
-        name,
-        val.iter()
-            .map(|bin| bin.map(|bin| bin.as_slice()))
-            .collect::<Vec<Option<&[u8]>>>(),
-    ))
+pub fn s_from_list_binary(name: &str, val: Term) -> NifResult<ExSeries> {
+    val.decode::<ListIterator>()?
+        .map(|term| {
+            term.decode::<Option<Binary>>()
+                .map(|maybe_bin| maybe_bin.map(|bin| bin.as_slice()))
+        })
+        .collect::<NifResult<Vec<Option<&[u8]>>>>()
+        .map(|values| ExSeries::new(Series::new(name, values)))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -271,8 +271,7 @@ macro_rules! from_list_float {
                 })
                 .collect::<NifResult<Vec<Option<$type>>>>()
                 .map(|values| {
-                    let s = Series::new(name, values);
-                    ExSeries::new(s)
+                    ExSeries::new(Series::new(name, values))
                 })
         }
     };


### PR DESCRIPTION
This is a gain of around 30% in the "Explorer.Series.from_list/2" for then the data type is binary.

This PR also includes some error handling and a filter to error in case of an unknown atom for float series.