### PR TITLE
Add datetime literals to expressions

### DIFF
--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -334,7 +334,7 @@ defmodule Explorer.PolarsBackend.Expression do
   def to_expr(number) when is_float(number), do: Native.expr_float(number)
   def to_expr(%Date{} = date), do: Native.expr_date(date)
   def to_expr(%NaiveDateTime{} = naive_datetime), do: Native.expr_naive_datetime(naive_datetime)
-  # def to_expr(%DateTime{} = datetime), do: Native.expr_datetime(datetime)
+  def to_expr(%DateTime{} = datetime), do: Native.expr_datetime(datetime)
   def to_expr(%Explorer.Duration{} = duration), do: Native.expr_duration(duration)
   def to_expr(%PolarsSeries{} = polars_series), do: Native.expr_series(polars_series)
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -194,7 +194,7 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_boolean(_bool), do: err()
   def expr_date(_date), do: err()
   def expr_naive_datetime(_datetime), do: err()
-  # def expr_datetime(_datetime), do: err()
+  def expr_datetime(_datetime), do: err()
   def expr_duration(_duration), do: err()
   def expr_describe_filter_plan(_df, _expr), do: err()
   def expr_float(_number), do: err()

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -10,8 +10,8 @@ use polars::prelude::{GetOutput, IntoSeries, Utf8JsonPathImpl};
 use polars::series::Series;
 
 use crate::datatypes::{
-    ExCorrelationMethod, ExDate, ExDuration, ExNaiveDateTime, ExRankMethod, ExSeriesDtype,
-    ExValidValue,
+    ExCorrelationMethod, ExDate, ExDateTime, ExDuration, ExNaiveDateTime, ExRankMethod,
+    ExSeriesDtype, ExValidValue,
 };
 use crate::series::{cast_str_to_f64, ewm_opts, rolling_opts};
 use crate::{ExDataFrame, ExExpr, ExSeries};
@@ -69,6 +69,11 @@ pub fn expr_atom(atom: &str) -> ExExpr {
 #[rustler::nif]
 pub fn expr_date(date: ExDate) -> ExExpr {
     ExExpr::new(date.lit())
+}
+
+#[rustler::nif]
+pub fn expr_datetime(datetime: ExDateTime) -> ExExpr {
+    ExExpr::new(datetime.lit())
 }
 
 #[rustler::nif]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -141,7 +141,7 @@ rustler::init!(
         expr_column,
         expr_date,
         expr_naive_datetime,
-        // expr_datetime,
+        expr_datetime,
         expr_duration,
         expr_day_of_week,
         expr_day_of_year,

--- a/test/explorer/polars_backend/expression_test.exs
+++ b/test/explorer/polars_backend/expression_test.exs
@@ -50,10 +50,19 @@ defmodule Explorer.PolarsBackend.ExpressionTest do
       assert %Expression{} = Expression.to_expr(lazy)
     end
 
-    test "with datetime value" do
+    test "with naive datetime value" do
       lazy = %LazySeries{
         op: :equal,
         args: [%LazySeries{op: :column, args: ["col_b"]}, ~N[2022-07-07 18:09:17.824019]]
+      }
+
+      assert %Expression{} = Expression.to_expr(lazy)
+    end
+
+    test "with datetime value" do
+      lazy = %LazySeries{
+        op: :equal,
+        args: [%LazySeries{op: :column, args: ["col_b"]}, ~U[2022-07-07 18:09:17.824019Z]]
       }
 
       assert %Expression{} = Expression.to_expr(lazy)


### PR DESCRIPTION
Example:

```elixir
lazy = %LazySeries{
  op: :equal,
  args: [%LazySeries{op: :column, args: ["col_b"]}, ~U[2022-07-07 18:09:17.824019Z]]
  }

%Expression{} = Expression.to_expr(lazy)
```