### PR TITLE
Update Rust toolchain to nightly-2024-06-23

### DIFF
--- a/native/explorer/rust-toolchain.toml
+++ b/native/explorer/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-02-23"
+channel = "nightly-2024-06-23"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This is an attempt to fix the precomp build.