### PR TITLE
Update exploring_explorer.livemd

### DIFF
--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -964,7 +964,7 @@ series contents, but every operation will be optimized and run only once.
 Remember those helpful error messages?
 
 ```elixir
-DF.filter(df, country == "BRAZIL")
+DF.filter(df, cuontry == "BRAZIL")
 ```
 
 ### Mutate

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -354,7 +354,7 @@ s = 1..11 |> Enum.to_list() |> Series.from_list()
 ```
 
 ```elixir
-s1 = 11..1 |> Enum.to_list() |> Series.from_list()
+s1 = 11..1//-1 |> Enum.to_list() |> Series.from_list()
 ```
 
 <!-- livebook:{"output":true} -->
@@ -964,7 +964,7 @@ series contents, but every operation will be optimized and run only once.
 Remember those helpful error messages?
 
 ```elixir
-DF.filter(df, cuontry == "BRAZIL")
+DF.filter(df, country == "BRAZIL")
 ```
 
 ### Mutate


### PR DESCRIPTION
The first change fixes the warning: 

```
warning: 11..1 has a default step of -1, please write 11..1//-1 instead
```

The second change fixes a typo that results in error:

```
** (ArgumentError) could not find column name "cuontry". Did you mean:

      * "country"

If you are attempting to interpolate a value, use ^cuontry.
```