### PR TITLE
Fix issue 976

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -363,7 +363,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_from_list_str(_name, _val), do: err()
   def s_from_list_binary(_name, _val), do: err()
   def s_from_list_categories(_name, _val), do: err()
-  def s_from_list_of_series(_name, _val, _dtype_or_nil), do: err()
+  def s_from_list_of_series(_name, _val, _dtype), do: err()
   def s_from_list_of_series_as_structs(_name, _val), do: err()
   def s_from_binary_f32(_name, _val), do: err()
   def s_from_binary_f64(_name, _val), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -363,7 +363,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_from_list_str(_name, _val), do: err()
   def s_from_list_binary(_name, _val), do: err()
   def s_from_list_categories(_name, _val), do: err()
-  def s_from_list_of_series(_name, _val), do: err()
+  def s_from_list_of_series(_name, _val, _dtype_or_nil), do: err()
   def s_from_list_of_series_as_structs(_name, _val), do: err()
   def s_from_binary_f32(_name, _val), do: err()
   def s_from_binary_f64(_name, _val), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -364,7 +364,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_from_list_binary(_name, _val), do: err()
   def s_from_list_categories(_name, _val), do: err()
   def s_from_list_of_series(_name, _val, _dtype), do: err()
-  def s_from_list_of_series_as_structs(_name, _val), do: err()
+  def s_from_list_of_series_as_structs(_name, _val, _dtype), do: err()
   def s_from_binary_f32(_name, _val), do: err()
   def s_from_binary_f64(_name, _val), do: err()
   def s_from_binary_s8(_name, _val), do: err()

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -127,13 +127,7 @@ defmodule Explorer.PolarsBackend.Shared do
 
   def from_list(list, dtype), do: from_list(list, dtype, "")
 
-  def from_list([], {:list, _} = dtype, name) do
-    polars_series = Native.s_from_list_of_series(name, [], nil)
-    {:ok, casted} = Native.s_cast(polars_series, dtype)
-    casted
-  end
-
-  def from_list(list, {:list, inner_dtype} = dtype, name) when is_list(list) do
+  def from_list(list, {:list, inner_dtype} = dtype, name) do
     series =
       Enum.map(list, fn
         inner_list when is_list(inner_list) -> from_list(inner_list, inner_dtype, name)

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -137,13 +137,7 @@ defmodule Explorer.PolarsBackend.Shared do
     Native.s_from_list_of_series(name, series, dtype)
   end
 
-  def from_list([], {:struct, _} = dtype, name) do
-    polars_series = Native.s_from_list_of_series_as_structs(name, [])
-    {:ok, casted} = Native.s_cast(polars_series, dtype)
-    casted
-  end
-
-  def from_list(list, {:struct, fields}, name) when is_list(list) do
+  def from_list(list, {:struct, fields} = dtype, name) when is_list(list) do
     columns = Map.new(fields, fn {k, _v} -> {k, []} end)
 
     columns =
@@ -167,7 +161,7 @@ defmodule Explorer.PolarsBackend.Shared do
         |> from_list(inner_dtype, field)
       end
 
-    Native.s_from_list_of_series_as_structs(name, series)
+    Native.s_from_list_of_series_as_structs(name, series, dtype)
   end
 
   def from_list(list, dtype, name) when is_list(list) do

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -128,18 +128,19 @@ defmodule Explorer.PolarsBackend.Shared do
   def from_list(list, dtype), do: from_list(list, dtype, "")
 
   def from_list([], {:list, _} = dtype, name) do
-    polars_series = Native.s_from_list_of_series(name, [])
+    polars_series = Native.s_from_list_of_series(name, [], nil)
     {:ok, casted} = Native.s_cast(polars_series, dtype)
     casted
   end
 
-  def from_list(list, {:list, inner_dtype} = _dtype, name) when is_list(list) do
+  def from_list(list, {:list, inner_dtype} = dtype, name) when is_list(list) do
     series =
-      Enum.map(list, fn maybe_inner_list ->
-        if is_list(maybe_inner_list), do: from_list(maybe_inner_list, inner_dtype, name)
+      Enum.map(list, fn
+        inner_list when is_list(inner_list) -> from_list(inner_list, inner_dtype, name)
+        _ -> nil
       end)
 
-    Native.s_from_list_of_series(name, series)
+    Native.s_from_list_of_series(name, series, dtype)
   end
 
   def from_list([], {:struct, _} = dtype, name) do

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -334,7 +334,7 @@ pub fn s_from_list_of_series(
                 Error::RaiseTerm(Box::new(message))
             })
         })
-        .and_then(|series| Ok(ExSeries::new(series)))
+        .map(ExSeries::new)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -354,13 +354,13 @@ pub fn s_from_list_of_series_as_structs(
             .collect::<Vec<_>>()
             .as_slice(),
     )
-    .and_then(|struct_chunked| Ok(struct_chunked.into_series()))
+    .map(|struct_chunked| struct_chunked.into_series())
     .and_then(|series| series.cast(&dtype))
-    .and_then(|series| Ok(ExSeries::new(series)))
     .map_err(|err| {
         let message = format!("from_list/2 cannot create series of structs: {err:?}");
         Error::RaiseTerm(Box::new(message))
     })
+    .map(ExSeries::new)
 }
 
 macro_rules! from_binary {

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -313,9 +313,9 @@ pub fn s_from_list_categories(name: &str, val: Term) -> NifResult<ExSeries> {
 pub fn s_from_list_of_series(
     name: &str,
     series_term: Term,
-    maybe_ex_dtype: Option<ExSeriesDtype>,
+    ex_dtype: ExSeriesDtype,
 ) -> NifResult<ExSeries> {
-    let maybe_dtype = maybe_ex_dtype.map(|ex_dtype| DataType::try_from(&ex_dtype).unwrap());
+    let dtype = DataType::try_from(&ex_dtype).unwrap();
 
     series_term
         .decode::<Vec<Option<ExSeries>>>()
@@ -329,12 +329,11 @@ pub fn s_from_list_of_series(
                 })
                 .collect();
 
-            let series = Series::new(name, lists);
-            let cast_series = match maybe_dtype {
-                None => series,
-                Some(dtype) => series.cast(&dtype).unwrap(),
+            let series = match Series::new(name, lists).cast(&dtype) {
+                Ok(series) => series,
+                Err(err) => panic!("from_list/2 cannot create series of lists: {err:?}"),
             };
-            ExSeries::new(cast_series)
+            ExSeries::new(series)
         })
 }
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -261,6 +261,19 @@ defmodule Explorer.DataFrameTest do
 
       assert DF.dtypes(df) == %{"dates" => :date}
     end
+
+    test "lists of structs of lists with nils (issue #976)" do
+      df =
+        Explorer.DataFrame.new(
+          [
+            %{a: [%{b: [""]}]},
+            %{a: [%{b: nil}]}
+          ],
+          dtypes: [{"a", {:list, {:struct, [{"b", {:list, :string}}]}}}]
+        )
+
+      assert DF.to_columns(df) == %{"a" => [[%{"b" => [""]}], [%{"b" => nil}]]}
+    end
   end
 
   describe "mask/2" do


### PR DESCRIPTION
### Description

Fixes an issue with `DF.new` where a well placed `nil` could result in a panic.

Basically, the work was being done by `Native.s_from_list_of_series/2` which attempted to do following:

* create a list of individual `polars_core::series`s each with the same `dtype`
* create a final `polars_core::series` of type `{:list, dtype}` from that list

But because `s_from_list_of_series/2` didn't have the final dtype information up front, it was possible for two elements of the intermediate list to have incompatible dtypes. When this happened, the final creation would panic.

### Changes

This PR makes the dtype a required argument for:

* `s_from_list_of_series/3`
* `s_from_list_of_series_as_structs/3`

(Those two seemed like a pair so I made them the same.)

### Links

* Closes: https://github.com/elixir-explorer/explorer/issues/976

### Discussion

I think there's an opportunity for optimization since we're now passing the expected dtype, but I didn't explore it.