### PR TITLE
Fix "dump_ndjson" by activating "timezones" feature

### DIFF
--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "mimalloc",
  "object_store",
  "polars",
+ "polars-json",
  "polars-ops",
  "rand",
  "rand_pcg",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -84,6 +84,12 @@ features = [
 version = "0.42"
 features = ["abs", "ewma", "cum_agg", "cov"]
 
+# This dep is only needed to activate "timezones" feature
+# for the polars-json crate. We should remove when Polars fixes it.
+[dependencies.polars-json]
+version = "*"
+features = ["timezones", "chrono-tz"]
+
 [features]
 default = ["ndjson", "cloud", "nif_version_2_15"]
 


### PR DESCRIPTION
This is an internal feature from the "polars-json" crate that is not activated with the "timezones" feature - a problem in Polars. We should rollback when it gets fixed upstream.

Fix https://github.com/elixir-explorer/explorer/issues/977