### PR TITLE
Add initial support to Decimal

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -363,6 +363,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_from_list_str(_name, _val), do: err()
   def s_from_list_binary(_name, _val), do: err()
   def s_from_list_categories(_name, _val), do: err()
+  def s_from_list_decimal(_name, _val, _precision, _scale), do: err()
   def s_from_list_of_series(_name, _val, _dtype), do: err()
   def s_from_list_of_series_as_structs(_name, _val, _dtype), do: err()
   def s_from_binary_f32(_name, _val), do: err()

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -189,6 +189,7 @@ defmodule Explorer.PolarsBackend.Shared do
       {:duration, precision} -> apply(:s_from_list_duration, [name, list, precision])
       :binary -> Native.s_from_list_binary(name, list)
       :null -> Native.s_from_list_null(name, length(list))
+      {:decimal, precision, scale} -> Native.s_from_list_decimal(name, list, precision, scale)
     end
   end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -42,7 +42,7 @@ defmodule Explorer.Shared do
   within lists inside.
   """
   def dtypes do
-    @scalar_types ++ [{:list, :any}, {:struct, :any}]
+    @scalar_types ++ [{:list, :any}, {:struct, :any}, {:decimal, :any, :any}]
   end
 
   @doc """
@@ -98,6 +98,9 @@ defmodule Explorer.Shared do
 
     {:naive_datetime, precision}
   end
+
+  def normalise_dtype({:decimal, _precision, _scale} = dtype), do: dtype
+  def normalise_dtype(:decimal), do: {:decimal, nil, 2}
 
   def normalise_dtype(_dtype), do: nil
 
@@ -494,6 +497,7 @@ defmodule Explorer.Shared do
   def dtype_to_string({:f, size}), do: "f" <> Integer.to_string(size)
   def dtype_to_string({:s, size}), do: "s" <> Integer.to_string(size)
   def dtype_to_string({:u, size}), do: "u" <> Integer.to_string(size)
+  def dtype_to_string({:decimal, precision, scale}), do: "decimal[#{precision}, #{scale}]"
   def dtype_to_string(other) when is_atom(other), do: Atom.to_string(other)
 
   defp precision_string(:millisecond), do: "ms"

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule Explorer.MixProject do
       {:rustler_precompiled, "~> 0.7"},
       {:table, "~> 0.1.2"},
       {:table_rex, "~> 3.1.1 or ~> 4.0.0"},
+      {:decimal, "~> 2.1"},
 
       ## Optional
       {:flame, "~> 0.3", optional: true},

--- a/native/explorer/src/datatypes/ex_dtypes.rs
+++ b/native/explorer/src/datatypes/ex_dtypes.rs
@@ -67,6 +67,8 @@ pub enum ExSeriesDtype {
     Duration(ExTimeUnit),
     List(Box<ExSeriesDtype>),
     Struct(Vec<(String, ExSeriesDtype)>),
+    // Precision and scale.
+    Decimal(Option<usize>, Option<usize>),
 }
 
 impl TryFrom<&DataType> for ExSeriesDtype {
@@ -112,6 +114,8 @@ impl TryFrom<&DataType> for ExSeriesDtype {
 
                 Ok(ExSeriesDtype::Struct(struct_fields))
             }
+
+            DataType::Decimal(precision, scale) => Ok(ExSeriesDtype::Decimal(*precision, *scale)),
 
             _ => Err(ExplorerError::Other(format!(
                 "cannot cast to dtype: {value}"
@@ -171,6 +175,7 @@ impl TryFrom<&ExSeriesDtype> for DataType {
                     .map(|(k, v)| Ok(Field::new(k.into(), v.try_into()?)))
                     .collect::<Result<Vec<Field>, Self::Error>>()?,
             )),
+            ExSeriesDtype::Decimal(precision, scale) => Ok(DataType::Decimal(*precision, *scale)),
         }
     }
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -42,6 +42,7 @@ mod atoms {
         duration_module = "Elixir.Explorer.Duration",
         naive_datetime_module = "Elixir.NaiveDateTime",
         time_module = "Elixir.Time",
+        decimal_module = "Elixir.Decimal",
         hour,
         minute,
         second,
@@ -61,6 +62,9 @@ mod atoms {
         time_zone,
         utc_offset,
         zone_abbr,
+        coef,
+        exp,
+        sign,
     }
 }
 

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -215,6 +215,53 @@ pub fn s_from_list_null(name: &str, length: usize) -> ExSeries {
     ExSeries::new(Series::new(name.into(), s))
 }
 
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_decimal(
+    _name: &str,
+    _val: Term,
+    _precision: Option<usize>,
+    _scale: Option<usize>,
+) -> Result<ExSeries, ExplorerError> {
+    Err(ExplorerError::Other(
+        "from_list/2 not yet implemented for decimal lists".into(),
+    ))
+    // let iterator = val
+    //     .decode::<ListIterator>()
+    //     .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
+    // // let mut precision = precision;
+    // // let mut scale = scale;
+
+    // let values: Vec<Option<i128>> = iterator
+    //     .map(|item| match item.get_type() {
+    //         TermType::Integer => item.decode::<Option<i128>>().map_err(|err| {
+    //             ExplorerError::Other(format!("int number is too big for an i128: {err:?}"))
+    //         }),
+    //         TermType::Map => item
+    //             .decode::<ExDecimal>()
+    //             .map(|ex_decimal| Some(ex_decimal.signed_coef()))
+    //             .map_err(|error| {
+    //                 ExplorerError::Other(format!(
+    //                     "cannot decode a valid decimal from term. error: {error:?}"
+    //                 ))
+    //             }),
+    //         // TODO: handle float special cases
+    //         TermType::Atom => Ok(None),
+    //         term_type => Err(ExplorerError::Other(format!(
+    //             "from_list/2 for decimals not implemented for {term_type:?}"
+    //         ))),
+    //     })
+    //     .collect::<Result<Vec<Option<i128>>, ExplorerError>>()?;
+
+    // Series::new(name.into(), values)
+    //     .cast(&DataType::Decimal(precision, scale))
+    //     .map(ExSeries::new)
+    //     .map_err(|error| {
+    //         ExplorerError::Other(format!(
+    //             "from_list/2 cannot cast integer series to a valid decimal series: {error:?}"
+    //         ))
+    //     })
+}
+
 macro_rules! from_list {
     ($name:ident, $type:ty) => {
         #[rustler::nif(schedule = "DirtyCpu")]

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3899,6 +3899,42 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s3) == {:naive_datetime, :microsecond}
     end
 
+    test "integer series to decimal" do
+      s = Series.from_list([1, 2, 3])
+      s1 = Series.cast(s, {:decimal, nil, 0})
+      assert Series.to_list(s1) == [Decimal.new("1"), Decimal.new("2"), Decimal.new("3")]
+      # 38 is Polars' default for precision.
+      assert Series.dtype(s1) == {:decimal, 38, 0}
+
+      # increased scale
+      s2 = Series.cast(s, {:decimal, nil, 2})
+      assert Series.to_list(s2) == [Decimal.new("1.00"), Decimal.new("2.00"), Decimal.new("3.00")]
+      assert Series.dtype(s2) == {:decimal, 38, 2}
+    end
+
+    test "float series to decimal" do
+      s = Series.from_list([1.345, 2.561, 3.97212])
+      s1 = Series.cast(s, {:decimal, nil, 3})
+
+      assert Series.to_list(s1) == [
+               Decimal.new("1.345"),
+               Decimal.new("2.561"),
+               Decimal.new("3.972")
+             ]
+
+      assert Series.dtype(s1) == {:decimal, 38, 3}
+
+      s2 = Series.cast(s, {:decimal, nil, 4})
+
+      assert Series.to_list(s2) == [
+               Decimal.new("1.3450"),
+               Decimal.new("2.5610"),
+               Decimal.new("3.9721")
+             ]
+
+      assert Series.dtype(s2) == {:decimal, 38, 4}
+    end
+
     test "string series to category" do
       s = Series.from_list(["apple", "banana", "apple", "lemon"])
       s1 = Series.cast(s, :category)


### PR DESCRIPTION
It can read decimals and load from the Rust backend to Elixir using the "Decimal" package.

This implementation was based on https://github.com/alexpearce/explorer/commit/709aa6768f4944a07126eb7ae595f449b5153346

This is the first part to close the https://github.com/elixir-explorer/explorer/issues/867 issue.