### PR TITLE
Add support for some operations with decimals

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -18,6 +18,7 @@ defmodule Explorer.Backend.Series do
           | Time.t()
           | NaiveDateTime.t()
           | Explorer.Duration.t()
+          | Decimal.t()
 
   @type non_finite :: Explorer.Series.non_finite()
   @type option(type) :: type | nil

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -319,6 +319,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_fill_missing_with_atom(_s, _value), do: err()
   def s_fill_missing_with_date(_s, _value), do: err()
   def s_fill_missing_with_datetime(_s, _value), do: err()
+  def s_fill_missing_with_decimal(_s, _value), do: err()
   def s_greater(_s, _rhs), do: err()
   def s_greater_equal(_s, _rhs), do: err()
   def s_head(_s, _length), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -657,6 +657,8 @@ defmodule Explorer.PolarsBackend.Series do
         is_boolean(value) -> :s_fill_missing_with_boolean
         is_struct(value, Date) -> :s_fill_missing_with_date
         is_struct(value, NaiveDateTime) -> :s_fill_missing_with_datetime
+        is_struct(value, Decimal) -> :s_fill_missing_with_decimal
+        true -> raise "cannot fill missing with value: #{inspect(value)}"
       end
 
     Shared.apply_series(series, operation, [value])

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -22,7 +22,19 @@ defmodule Explorer.PolarsBackend.Series do
   @impl true
   def from_list(data, type) when is_list(data) do
     series = Shared.from_list(data, type)
-    Explorer.Backend.Series.new(series, type)
+
+    result = Explorer.Backend.Series.new(series, type)
+
+    # This is a special case for decimals, where
+    # scale is found by Polars. So we need to update it here.
+    type =
+      if match?({:decimal, _, _}, type) do
+        dtype(result)
+      else
+        type
+      end
+
+    %{result | dtype: type}
   end
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -23,18 +23,7 @@ defmodule Explorer.PolarsBackend.Series do
   def from_list(data, type) when is_list(data) do
     series = Shared.from_list(data, type)
 
-    result = Explorer.Backend.Series.new(series, type)
-
-    # This is a special case for decimals, where
-    # scale is found by Polars. So we need to update it here.
-    type =
-      if match?({:decimal, _, _}, type) do
-        dtype(result)
-      else
-        type
-      end
-
-    %{result | dtype: type}
+    Explorer.Backend.Series.new(series, type)
   end
 
   @impl true

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -189,7 +189,7 @@ defmodule Explorer.PolarsBackend.Shared do
       {:duration, precision} -> apply(:s_from_list_duration, [name, list, precision])
       :binary -> Native.s_from_list_binary(name, list)
       :null -> Native.s_from_list_null(name, length(list))
-      {:decimal, precision, scale} -> Native.s_from_list_decimal(name, list, precision, scale)
+      {:decimal, precision, scale} -> apply(:s_from_list_decimal, [name, list, precision, scale])
     end
   end
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -26,6 +26,8 @@ defmodule Explorer.Series do
     * `{:f, size}` - a 64-bit or 32-bit floating point number
     * `{:s, size}` - a 8-bit or 16-bit or 32-bit or 64-bit signed integer number.
     * `{:u, size}` - a 8-bit or 16-bit or 32-bit or 64-bit unsigned integer number.
+    * `{:decimal, precision, scale}` - a 128-bit signed integer number representing a decimal,
+      with a scale and precision. This unwraps to `Decimal`, using the `:decimal` package.
     * `:null` - `nil`s exclusively
     * `:string` - UTF-8 encoded binary
     * `:time` - Time type that unwraps to `Elixir.Time`
@@ -38,10 +40,11 @@ defmodule Explorer.Series do
   When passing a dtype as argument, aliases are supported for convenience
   and compatibility with the Elixir ecosystem:
 
-    * All numeric dtypes (signed integer, unsigned integer, and floats) can
-      be specified as an atom in the form of `:s32`, `:u8`, `:f32` and so on
+    * All numeric dtypes (signed integer, unsigned integer, floats and decimals) can
+      be specified as an atom in the form of `:s32`, `:u8`, `:f32` and so on.
     * The atom `:float` as an alias for `{:f, 64}` to mirror Elixir's floats
     * The atom `:integer` as an alias for `{:s, 64}` to mirror Elixir's integers
+    * The atom `:decimal` as an alias for the `{:decimal, nil, nil}`.
 
   A series must consist of a single data type only. Series may have `nil` values in them.
   The series `dtype` can be retrieved via the `dtype/1` function or directly accessed as
@@ -140,7 +143,8 @@ defmodule Explorer.Series do
   @numeric_dtypes Explorer.Shared.numeric_types()
   @numeric_or_temporal_dtypes @numeric_dtypes ++ @temporal_dtypes
 
-  @io_dtypes Shared.dtypes() -- [:binary, :string, {:list, :any}, {:struct, :any}]
+  @io_dtypes Shared.dtypes() --
+               [:binary, :string, {:list, :any}, {:struct, :any}, {:decimal, :any, :any}]
 
   @type dtype ::
           :null
@@ -150,11 +154,12 @@ defmodule Explorer.Series do
           | :date
           | :time
           | :string
-          | naive_datetime_dtype
           | datetime_dtype
+          | decimal_dtype
           | duration_dtype
           | float_dtype
           | list_dtype
+          | naive_datetime_dtype
           | signed_integer_dtype
           | struct_dtype
           | unsigned_integer_dtype
@@ -170,10 +175,12 @@ defmodule Explorer.Series do
   @type signed_integer_dtype :: {:s, 8} | {:s, 16} | {:s, 32} | {:s, 64}
   @type unsigned_integer_dtype :: {:u, 8} | {:u, 16} | {:u, 32} | {:u, 64}
   @type float_dtype :: {:f, 32} | {:f, 64}
+  @type decimal_dtype :: {:decimal, nil | pos_integer(), nil | pos_integer()}
 
-  @type dtype_alias :: integer_dtype_alias | float_dtype_alias
+  @type dtype_alias :: integer_dtype_alias | float_dtype_alias | decimal_dtype_alias
   @type float_dtype_alias :: :float | :f32 | :f64
   @type integer_dtype_alias :: :integer | :u8 | :u16 | :u32 | :u64 | :s8 | :s16 | :s32 | :s64
+  @type decimal_dtype_alias :: :decimal
 
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -149,7 +149,7 @@ defmodule Explorer.Series do
                  :string,
                  {:list, :any},
                  {:struct, :any},
-                 {:decimal, :nil_or_pos_integer, :pos_integer}
+                 {:decimal, :pos_integer, :pos_integer}
                ]
 
   @type dtype ::
@@ -181,12 +181,12 @@ defmodule Explorer.Series do
   @type signed_integer_dtype :: {:s, 8} | {:s, 16} | {:s, 32} | {:s, 64}
   @type unsigned_integer_dtype :: {:u, 8} | {:u, 16} | {:u, 32} | {:u, 64}
   @type float_dtype :: {:f, 32} | {:f, 64}
-  @type decimal_dtype :: {:decimal, nil | pos_integer(), pos_integer()}
+  @type decimal_dtype :: {:decimal, pos_integer(), pos_integer()}
 
   @type dtype_alias :: integer_dtype_alias | float_dtype_alias | decimal_dtype_alias
   @type float_dtype_alias :: :float | :f32 | :f64
   @type integer_dtype_alias :: :integer | :u8 | :u16 | :u32 | :u64 | :s8 | :s16 | :s32 | :s64
-  @type decimal_dtype_alias :: :decimal | :d0 | :d1 | :d2 | :d3 | :d4 | :d5
+  @type decimal_dtype_alias :: :decimal
 
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2601,7 +2601,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal`. The result will be a float.
+    * decimals: the result will be a float
 
   ## Examples
 
@@ -3454,7 +3454,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal`
+    * decimals
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -44,7 +44,7 @@ defmodule Explorer.Series do
       be specified as an atom in the form of `:s32`, `:u8`, `:f32` and so on.
     * The atom `:float` as an alias for `{:f, 64}` to mirror Elixir's floats
     * The atom `:integer` as an alias for `{:s, 64}` to mirror Elixir's integers
-    * The atom `:decimal` as an alias for the `{:decimal, nil, nil}`.
+    * The atom `:decimal` as an alias for the `{:decimal, 38, 0}`.
 
   A series must consist of a single data type only. Series may have `nil` values in them.
   The series `dtype` can be retrieved via the `dtype/1` function or directly accessed as
@@ -2675,7 +2675,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal`. The result will be a float.
+    * decimals: the result will be a float
 
   ## Examples
 
@@ -2745,7 +2745,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal`. The result will be a float.
+    * decimals: the result will be a float
 
   ## Examples
 
@@ -2917,7 +2917,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal`. The result will be a float.
+    * decimals: the result will be a float
 
   ## Examples
 
@@ -2949,7 +2949,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal`. The result will be a float.
+    * decimals: the result will be a float
 
   ## Examples
 
@@ -3525,7 +3525,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal` - returning decimal series.
+    * decimals: the result will be a decimal series
 
   ## Examples
 
@@ -3582,7 +3582,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal` - returning f64 series.
+    * decimals: the result will be a float series
 
   ## Examples
 
@@ -3662,7 +3662,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * `:decimal` - returning f64 series.
+    * decimals: the result will be a float series
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2601,7 +2601,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals. The result will be a float.
+    * `:decimal`. The result will be a float.
 
   ## Examples
 
@@ -2675,7 +2675,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals. The result will be a float.
+    * `:decimal`. The result will be a float.
 
   ## Examples
 
@@ -2745,7 +2745,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals. The result will be a float.
+    * `:decimal`. The result will be a float.
 
   ## Examples
 
@@ -2917,7 +2917,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals. The result will be a float.
+    * `:decimal`. The result will be a float.
 
   ## Examples
 
@@ -2949,7 +2949,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals. The result will be a float.
+    * `:decimal`. The result will be a float.
 
   ## Examples
 
@@ -4243,6 +4243,7 @@ defmodule Explorer.Series do
     * `:time`
     * `:datetime`
     * `:duration`
+    * `:decimal`
 
   ## Examples
 
@@ -4282,6 +4283,7 @@ defmodule Explorer.Series do
     * `:time`
     * `:datetime`
     * `:duration`
+    * `:decimal`
 
   ## Examples
 
@@ -4321,6 +4323,7 @@ defmodule Explorer.Series do
     * `:time`
     * `:datetime`
     * `:duration`
+    * `:decimal`
 
   ## Examples
 
@@ -4360,6 +4363,7 @@ defmodule Explorer.Series do
     * `:time`
     * `:datetime`
     * `:duration`
+    * `:decimal`
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1267,6 +1267,7 @@ defmodule Explorer.Series do
   def iotype(%Series{dtype: dtype}) do
     case dtype do
       :category -> {:u, 32}
+      {:decimal, _, _} -> {:s, 128}
       other -> Shared.dtype_to_iotype(other)
     end
   end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3262,6 +3262,7 @@ defmodule Explorer.Series do
     * `:time`
     * `:datetime`
     * `:duration`
+    * `:decimal`
 
   ## Examples
 
@@ -3344,6 +3345,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
+    * `:decimal`
 
   ## Examples
 
@@ -3422,6 +3424,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
+    * `:decimal`
 
   ## Examples
 
@@ -3492,7 +3495,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals - returning decimal series.
+    * `:decimal` - returning decimal series.
 
   ## Examples
 
@@ -3549,7 +3552,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals - returning f64 series.
+    * `:decimal` - returning f64 series.
 
   ## Examples
 
@@ -3629,7 +3632,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals - returning f64 series.
+    * `:decimal` - returning f64 series.
 
   ## Examples
 
@@ -3701,7 +3704,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals.
+    * `:decimal` - returns f64 series.
 
   ## Examples
 
@@ -3726,7 +3729,7 @@ defmodule Explorer.Series do
 
     * floats: #{Shared.inspect_dtypes(@float_dtypes, backsticks: true)}
     * integers: #{Shared.inspect_dtypes(@integer_types, backsticks: true)}
-    * decimals.
+    * `:decimal`.
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -4506,6 +4506,8 @@ defmodule Explorer.Series do
   defp cast_to_ordered_series({:duration, _}, %Explorer.Duration{}),
     do: :duration
 
+  defp cast_to_ordered_series({:decimal, _precision, _scale} = decimal, %Decimal{}), do: decimal
+
   defp cast_to_ordered_series(_dtype, _value),
     do: nil
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -518,7 +518,7 @@ defmodule Explorer.Shared do
   def dtype_to_string({:f, size}), do: "f" <> Integer.to_string(size)
   def dtype_to_string({:s, size}), do: "s" <> Integer.to_string(size)
   def dtype_to_string({:u, size}), do: "u" <> Integer.to_string(size)
-  def dtype_to_string({:decimal, precision, scale}), do: "decimal[#{precision || "*"}, #{scale}]"
+  def dtype_to_string({:decimal, precision, scale}), do: "decimal[#{precision}, #{scale}]"
   def dtype_to_string(other) when is_atom(other), do: Atom.to_string(other)
 
   defp precision_string(:millisecond), do: "ms"

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -378,8 +378,8 @@ defmodule Explorer.Shared do
   def merge_numeric_dtype({:decimal, _, _} = decimal, :null), do: decimal
   def merge_numeric_dtype(:null, {:decimal, _, _} = decimal), do: decimal
 
-  def merge_numeric_dtype({:decimal, _, _} = decimal, {:f, _}), do: decimal
-  def merge_numeric_dtype({:f, _}, {:decimal, _, _} = decimal), do: decimal
+  def merge_numeric_dtype({:decimal, _, _}, {:f, _} = float), do: float
+  def merge_numeric_dtype({:f, _} = float, {:decimal, _, _}), do: float
 
   def merge_numeric_dtype(_, _), do: nil
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -378,6 +378,7 @@ defmodule Explorer.Shared do
   def merge_numeric_dtype({:decimal, _, _} = decimal, :null), do: decimal
   def merge_numeric_dtype(:null, {:decimal, _, _} = decimal), do: decimal
 
+  # For now, float has priority over decimals due to Polars.
   def merge_numeric_dtype({:decimal, _, _}, {:f, _} = float), do: float
   def merge_numeric_dtype({:f, _} = float, {:decimal, _, _}), do: float
 
@@ -512,7 +513,7 @@ defmodule Explorer.Shared do
   def dtype_to_string({:f, size}), do: "f" <> Integer.to_string(size)
   def dtype_to_string({:s, size}), do: "s" <> Integer.to_string(size)
   def dtype_to_string({:u, size}), do: "u" <> Integer.to_string(size)
-  def dtype_to_string({:decimal, precision, scale}), do: "decimal[#{precision}, #{scale}]"
+  def dtype_to_string({:decimal, precision, scale}), do: "decimal[#{precision || "*"}, #{scale}]"
   def dtype_to_string(other) when is_atom(other), do: Atom.to_string(other)
 
   defp precision_string(:millisecond), do: "ms"

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -43,7 +43,7 @@ defmodule Explorer.Shared do
   """
   def dtypes do
     @scalar_types ++
-      [{:list, :any}, {:struct, :any}, {:decimal, :nil_or_pos_integer, :pos_integer}]
+      [{:list, :any}, {:struct, :any}, {:decimal, :pos_integer, :pos_integer}]
   end
 
   @doc """
@@ -103,14 +103,6 @@ defmodule Explorer.Shared do
   def normalise_dtype({:decimal, precision, scale} = dtype)
       when is_integer(scale) and (is_nil(precision) or is_integer(precision)),
       do: dtype
-
-  def normalise_dtype(:decimal), do: {:decimal, nil, 0}
-  def normalise_dtype(:d0), do: {:decimal, nil, 0}
-  def normalise_dtype(:d1), do: {:decimal, nil, 1}
-  def normalise_dtype(:d2), do: {:decimal, nil, 2}
-  def normalise_dtype(:d3), do: {:decimal, nil, 3}
-  def normalise_dtype(:d4), do: {:decimal, nil, 4}
-  def normalise_dtype(:d5), do: {:decimal, nil, 5}
 
   def normalise_dtype(_dtype), do: nil
 
@@ -324,7 +316,7 @@ defmodule Explorer.Shared do
   defp infer_type(%DateTime{time_zone: tz} = _item), do: {:datetime, :microsecond, tz}
   defp infer_type(%NaiveDateTime{} = _item), do: {:naive_datetime, :microsecond}
   defp infer_type(%Explorer.Duration{precision: precision} = _item), do: {:duration, precision}
-  defp infer_type(%Decimal{} = item), do: {:decimal, nil, Decimal.scale(item)}
+  defp infer_type(%Decimal{} = item), do: {:decimal, 38, Decimal.scale(item)}
   defp infer_type(%_{} = item), do: raise(ArgumentError, "unsupported datatype: #{inspect(item)}")
   defp infer_type(item) when is_integer(item), do: {:s, 64}
   defp infer_type(item) when is_float(item) or item in @non_finite, do: {:f, 64}

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -42,7 +42,8 @@ defmodule Explorer.Shared do
   within lists inside.
   """
   def dtypes do
-    @scalar_types ++ [{:list, :any}, {:struct, :any}, {:decimal, :any, :any}]
+    @scalar_types ++
+      [{:list, :any}, {:struct, :any}, {:decimal, :nil_or_pos_integer, :pos_integer}]
   end
 
   @doc """
@@ -99,7 +100,10 @@ defmodule Explorer.Shared do
     {:naive_datetime, precision}
   end
 
-  def normalise_dtype({:decimal, _precision, _scale} = dtype), do: dtype
+  def normalise_dtype({:decimal, precision, scale} = dtype)
+      when is_integer(scale) and (is_nil(precision) or is_integer(precision)),
+      do: dtype
+
   def normalise_dtype(:decimal), do: {:decimal, nil, 0}
   def normalise_dtype(:d0), do: {:decimal, nil, 0}
   def normalise_dtype(:d1), do: {:decimal, nil, 1}

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -574,6 +574,16 @@ pub struct ExDecimal {
 }
 
 impl ExDecimal {
+    pub fn new(signed_coef: i128, scale: usize) -> Self {
+        Self {
+            coef: signed_coef
+                .abs()
+                .try_into()
+                .expect("signed coef is too large for u64"),
+            sign: if signed_coef >= 0 { 1 } else { -1 },
+            exp: -(scale as i64),
+        }
+    }
     pub fn signed_coef(self) -> i128 {
         self.sign as i128 * self.coef as i128
     }

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -577,6 +577,13 @@ impl ExDecimal {
     pub fn signed_coef(self) -> i128 {
         self.sign as i128 * self.coef as i128
     }
+
+    pub fn scale(self) -> usize {
+        self.exp
+            .abs()
+            .try_into()
+            .expect("cannot convert exponent (Elixir) to scale (Rust)")
+    }
 }
 
 impl Literal for ExDecimal {

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -425,6 +425,8 @@ macro_rules! unsafe_encode_decimal {
         let coef = $v.abs();
         let scale = -($scale as isize);
         let sign = $v.signum();
+        // Elixir's Decimal has only 1 or -1. We need to treat positive zero as positive - 1.
+        let sign = if sign == 0 { 1 } else { sign };
 
         unsafe {
             Term::new(

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1,7 +1,7 @@
 use crate::{
     datatypes::{
-        ExCorrelationMethod, ExDate, ExNaiveDateTime, ExRankMethod, ExSeriesDtype, ExTime,
-        ExTimeUnit, ExValidValue,
+        ExCorrelationMethod, ExDate, ExDecimal, ExNaiveDateTime, ExRankMethod, ExSeriesDtype,
+        ExTime, ExTimeUnit, ExValidValue,
     },
     encoding, ExDataFrame, ExSeries, ExplorerError,
 };
@@ -557,6 +557,22 @@ pub fn s_fill_missing_with_boolean(
 ) -> Result<ExSeries, ExplorerError> {
     let s = series.bool()?.fill_null_with_values(boolean)?.into_series();
     Ok(ExSeries::new(s))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_fill_missing_with_decimal(
+    _series: ExSeries,
+    _decimal: ExDecimal,
+) -> Result<ExSeries, ExplorerError> {
+    // We need to make sure that the series dtype is aligned with the decimal's scale.
+    // let s = series
+    //     .decimal()?
+    //     .fill_null_with_values(decimal.signed_coef())?
+    //     .into_series();
+    // Ok(ExSeries::new(s))
+    Err(ExplorerError::Other(
+        "fill_missing/2 with decimals is not supported yet by Polars".to_string(),
+    ))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -394,6 +394,7 @@ pub fn s_in(s: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
         | DataType::Binary
         | DataType::Date
         | DataType::Time
+        | DataType::Decimal(_, _)
         | DataType::Datetime(_, _) => is_in(&s, &rhs)?,
         DataType::Categorical(Some(mapping), _) => {
             let l_logical = s.categorical()?.physical();

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -1,6 +1,6 @@
 use crate::atoms;
 use crate::datatypes::{
-    ExDate, ExDateTime, ExDuration, ExNaiveDateTime, ExSeriesDtype, ExTime, ExTimeUnit,
+    ExDate, ExDateTime, ExDecimal, ExDuration, ExNaiveDateTime, ExSeriesDtype, ExTime, ExTimeUnit,
 };
 use crate::{ExSeries, ExplorerError};
 
@@ -217,49 +217,76 @@ pub fn s_from_list_null(name: &str, length: usize) -> ExSeries {
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_from_list_decimal(
-    _name: &str,
-    _val: Term,
+    name: &str,
+    val: Term,
     _precision: Option<usize>,
-    _scale: Option<usize>,
+    scale: Option<usize>,
 ) -> Result<ExSeries, ExplorerError> {
-    Err(ExplorerError::Other(
-        "from_list/2 not yet implemented for decimal lists".into(),
-    ))
-    // let iterator = val
-    //     .decode::<ListIterator>()
-    //     .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
-    // // let mut precision = precision;
-    // // let mut scale = scale;
+    let iterator = val
+        .decode::<ListIterator>()
+        .map_err(|err| ExplorerError::Other(format!("expecting list as term: {err:?}")))?;
 
-    // let values: Vec<Option<i128>> = iterator
-    //     .map(|item| match item.get_type() {
-    //         TermType::Integer => item.decode::<Option<i128>>().map_err(|err| {
-    //             ExplorerError::Other(format!("int number is too big for an i128: {err:?}"))
-    //         }),
-    //         TermType::Map => item
-    //             .decode::<ExDecimal>()
-    //             .map(|ex_decimal| Some(ex_decimal.signed_coef()))
-    //             .map_err(|error| {
-    //                 ExplorerError::Other(format!(
-    //                     "cannot decode a valid decimal from term. error: {error:?}"
-    //                 ))
-    //             }),
-    //         // TODO: handle float special cases
-    //         TermType::Atom => Ok(None),
-    //         term_type => Err(ExplorerError::Other(format!(
-    //             "from_list/2 for decimals not implemented for {term_type:?}"
-    //         ))),
-    //     })
-    //     .collect::<Result<Vec<Option<i128>>, ExplorerError>>()?;
+    let values: Vec<AnyValue> = iterator
+        .map(|item| match item.get_type() {
+            TermType::Integer => {
+                let s = scale.unwrap_or(0);
+                item.decode::<i128>()
+                    .map(|num| AnyValue::Decimal(num, s))
+                    .map_err(|err| {
+                        ExplorerError::Other(format!("int number is too big for an i128: {err:?}"))
+                    })
+            }
 
-    // Series::new(name.into(), values)
-    //     .cast(&DataType::Decimal(precision, scale))
-    //     .map(ExSeries::new)
-    //     .map_err(|error| {
-    //         ExplorerError::Other(format!(
-    //             "from_list/2 cannot cast integer series to a valid decimal series: {error:?}"
-    //         ))
-    //     })
+            TermType::Map => item
+                .decode::<ExDecimal>()
+                .map(|ex_decimal| AnyValue::Decimal(ex_decimal.signed_coef(), ex_decimal.scale()))
+                .map_err(|error| {
+                    ExplorerError::Other(format!(
+                        "cannot decode a valid decimal from term. error: {error:?}"
+                    ))
+                }),
+            TermType::Atom => Ok(AnyValue::Null),
+
+            TermType::Float => item
+                .decode::<f64>()
+                .map(|num| match native_float_to_decimal_parts(num) {
+                    Some((integer, scale)) => AnyValue::Decimal(integer, scale),
+                    None => AnyValue::Null,
+                })
+                .map_err(|err| {
+                    ExplorerError::Other(format!("float number is too big f64: {err:?}"))
+                }),
+            term_type => Err(ExplorerError::Other(format!(
+                "from_list/2 for decimals not implemented for {term_type:?}"
+            ))),
+        })
+        .collect::<Result<Vec<AnyValue>, ExplorerError>>()?;
+
+    Ok(ExSeries::new(Series::from_any_values(
+        name.into(),
+        &values,
+        true,
+    )?))
+}
+
+fn native_float_to_decimal_parts(float: f64) -> Option<(i128, usize)> {
+    let float_str = float.to_string();
+
+    match float_str.split_once(".") {
+        Some((integer_part, fraction_part)) => {
+            let new_str = integer_part.to_string() + fraction_part;
+            let coef: i128 = new_str.parse().expect("expecting a valid i128 number");
+            Some((coef, fraction_part.len()))
+        }
+
+        None => {
+            let res_coef = float_str.parse::<i128>();
+            match res_coef {
+                Ok(coef) => Some((coef, 0)),
+                Err(_) => None,
+            }
+        }
+    }
 }
 
 macro_rules! from_list {

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -219,7 +219,7 @@ pub fn s_from_list_null(name: &str, length: usize) -> ExSeries {
 pub fn s_from_list_decimal(
     name: &str,
     val: Term,
-    _precision: Option<usize>,
+    precision: Option<usize>,
     scale: Option<usize>,
 ) -> Result<ExSeries, ExplorerError> {
     let iterator = val
@@ -264,11 +264,12 @@ pub fn s_from_list_decimal(
 
     let mut series = Series::from_any_values(name.into(), &values, true)?;
 
-    if let Some(given_scale) = scale {
-        if let DataType::Decimal(precision, Some(result_scale)) = series.dtype() {
-            if given_scale != *result_scale {
-                series = series.cast(&DataType::Decimal(*precision, Some(given_scale)))?;
-            }
+    if let DataType::Decimal(result_precision, result_scale) = series.dtype() {
+        let p: Option<usize> = Some(precision.unwrap_or(result_precision.unwrap_or(38)));
+        let s: Option<usize> = Some(scale.unwrap_or(result_scale.unwrap_or(0)));
+
+        if *result_precision != p || *result_scale != s {
+            series = series.cast(&DataType::Decimal(p, s))?;
         }
     }
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1692,7 +1692,7 @@ defmodule Explorer.DataFrameTest do
 
       df1 =
         DF.mutate(df,
-          b: from_list([Decimal.new(1), Decimal.new(2), nil]),
+          b: from_list([Decimal.new("3.14159265359"), Decimal.new(2), nil]),
           # Casting works, but the df will be different if we don't pass the precision,
           # because it will take the default precision for decimals, which is "38".
           # The second problem of not passing precision is that scale will be handled differently.
@@ -1702,13 +1702,13 @@ defmodule Explorer.DataFrameTest do
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 2, 4],
-               b: [Decimal.new(1), Decimal.new(2), nil],
+               b: [Decimal.new("3.14159265359"), Decimal.new("2.00000000000"), nil],
                c: [Decimal.new("1.00"), Decimal.new("2.00"), Decimal.new("4.00")]
              }
 
       assert DF.dtypes(df1) == %{
                "a" => {:s, 64},
-               "b" => {:decimal, nil, 0},
+               "b" => {:decimal, nil, 11},
                "c" => {:decimal, 10, 2}
              }
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -395,7 +395,7 @@ defmodule Explorer.SeriesTest do
                Decimal.new("5.12467")
              ]
 
-      assert Series.dtype(s) == {:decimal, nil, 5}
+      assert Series.dtype(s) == {:decimal, 38, 5}
     end
 
     test "with decimals without dtype option mixing with floats" do
@@ -419,13 +419,13 @@ defmodule Explorer.SeriesTest do
                Decimal.new("42.59000")
              ]
 
-      assert Series.dtype(s) == {:decimal, nil, 5}
+      assert Series.dtype(s) == {:decimal, 38, 5}
     end
 
     test "with floats as decimals" do
       s =
         Series.from_list([0.0, 0.42, nil, 5.12467],
-          dtype: :d5
+          dtype: {:decimal, 38, 5}
         )
 
       assert s[1] === Decimal.new("0.42000")
@@ -438,13 +438,13 @@ defmodule Explorer.SeriesTest do
                Decimal.new("5.12467")
              ]
 
-      assert Series.dtype(s) == {:decimal, nil, 5}
+      assert Series.dtype(s) == {:decimal, 38, 5}
     end
 
     test "with floats as decimals and lower scale" do
       s =
         Series.from_list([0.0, 0.42, nil, 5.12467],
-          dtype: :d2
+          dtype: {:decimal, 38, 2}
         )
 
       assert s[1] === Decimal.new("0.42")
@@ -457,13 +457,13 @@ defmodule Explorer.SeriesTest do
                Decimal.new("5.12")
              ]
 
-      assert Series.dtype(s) == {:decimal, nil, 2}
+      assert Series.dtype(s) == {:decimal, 38, 2}
     end
 
     test "with integers as decimals passing scale" do
       s =
         Series.from_list([0, 4237, nil, 550],
-          dtype: {:decimal, nil, 2}
+          dtype: {:decimal, 38, 2}
         )
 
       assert s[1] === Decimal.new("42.37")
@@ -476,7 +476,7 @@ defmodule Explorer.SeriesTest do
                Decimal.new("5.50")
              ]
 
-      assert Series.dtype(s) == {:decimal, nil, 2}
+      assert Series.dtype(s) == {:decimal, 38, 2}
     end
 
     test "mixing dates and integers with `:date` dtype" do
@@ -915,8 +915,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "compare decimal series" do
-      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
-      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, 38, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, 38, 2})
 
       assert s1 |> Series.equal(s2) |> Series.to_list() == [true, true, false]
     end
@@ -994,8 +994,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "compare decimal series" do
-      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
-      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, 38, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, 38, 2})
 
       assert s1 |> Series.not_equal(s2) |> Series.to_list() == [false, false, true]
     end
@@ -1109,8 +1109,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "compare decimal series" do
-      s1 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
-      s2 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
+      s1 = Series.from_list([1, 0, 3], dtype: {:decimal, 38, 2})
+      s2 = Series.from_list([1, 0, 2], dtype: {:decimal, 38, 2})
 
       assert s1 |> Series.greater(s2) |> Series.to_list() == [false, false, true]
     end
@@ -1149,8 +1149,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "compare decimal series" do
-      s1 = Series.from_list([1, 0, 3, -1], dtype: {:decimal, nil, 2})
-      s2 = Series.from_list([1, 0, 2, 1], dtype: {:decimal, nil, 2})
+      s1 = Series.from_list([1, 0, 3, -1], dtype: {:decimal, 38, 2})
+      s2 = Series.from_list([1, 0, 2, 1], dtype: {:decimal, 38, 2})
 
       assert s1 |> Series.greater_equal(s2) |> Series.to_list() == [true, true, true, false]
     end
@@ -1316,8 +1316,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "compare decimal series" do
-      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
-      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, 38, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, 38, 2})
 
       assert s1 |> Series.less(s2) |> Series.to_list() == [false, false, true]
     end
@@ -2071,8 +2071,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "subtracting two decimal series together" do
-      s1 = Series.from_list([1, 2, 3], dtype: :decimal)
-      s2 = Series.from_list([4, 5, 6], dtype: :decimal)
+      s1 = Series.from_list([1, 2, 3], dtype: {:decimal, 38, 0})
+      s2 = Series.from_list([4, 5, 6], dtype: {:decimal, 38, 0})
 
       s3 = Series.subtract(s1, s2)
 
@@ -2081,7 +2081,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "subtracting decimal series and float series" do
-      s1 = Series.from_list([1, 2, 3], dtype: :decimal)
+      s1 = Series.from_list([1, 2, 3], dtype: {:decimal, 38, 0})
       s2 = Series.from_list([4, 5, 6], dtype: :f64)
 
       s3 = Series.subtract(s1, s2)
@@ -2223,8 +2223,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "multiplying two decimal series together" do
-      s1 = Series.from_list([1, 2, 3], dtype: :decimal)
-      s2 = Series.from_list([4, 5, 6], dtype: :decimal)
+      s1 = Series.from_list([1, 2, 3], dtype: {:decimal, 38, 0})
+      s2 = Series.from_list([4, 5, 6], dtype: {:decimal, 38, 0})
 
       s3 = Series.multiply(s1, s2)
 
@@ -2233,7 +2233,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "multiplying decimal by float series" do
-      s1 = Series.from_list([1, 2, 3], dtype: :decimal)
+      s1 = Series.from_list([1, 2, 3], dtype: {:decimal, 38, 0})
       s2 = Series.from_list([4, 5, 6], dtype: :f64)
 
       s3 = Series.multiply(s1, s2)
@@ -2387,8 +2387,8 @@ defmodule Explorer.SeriesTest do
     end
 
     test "dividing two decimal series together" do
-      s1 = Series.from_list([1, 2, 3], dtype: :decimal)
-      s2 = Series.from_list([4, 5, 6], dtype: :decimal)
+      s1 = Series.from_list([1, 2, 3], dtype: {:decimal, 38, 0})
+      s2 = Series.from_list([4, 5, 6], dtype: {:decimal, 38, 0})
 
       s3 = Series.divide(s2, s1)
 
@@ -3022,7 +3022,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "pow(decimal, s64) = float" do
-      base = Series.from_list([1, 2, 3], dtype: :decimal)
+      base = Series.from_list([1, 2, 3], dtype: {:decimal, 38, 0})
       power = Series.from_list([3, 2, 1])
 
       result = Series.pow(base, power)

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -381,11 +381,9 @@ defmodule Explorer.SeriesTest do
       end
     end
 
-    test "with decimals" do
+    test "with decimals without dtype given" do
       s =
-        Series.from_list([Decimal.new("0"), Decimal.new("0.42"), nil, Decimal.new("5.12467")],
-          dtype: :decimal
-        )
+        Series.from_list([Decimal.new("0"), Decimal.new("0.42"), nil, Decimal.new("5.12467")])
 
       assert s[1] === Decimal.new("0.42000")
       assert s[3] === Decimal.new("5.12467")
@@ -427,7 +425,7 @@ defmodule Explorer.SeriesTest do
     test "with floats as decimals" do
       s =
         Series.from_list([0.0, 0.42, nil, 5.12467],
-          dtype: :decimal
+          dtype: :d5
         )
 
       assert s[1] === Decimal.new("0.42000")
@@ -443,10 +441,29 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s) == {:decimal, nil, 5}
     end
 
+    test "with floats as decimals and lower scale" do
+      s =
+        Series.from_list([0.0, 0.42, nil, 5.12467],
+          dtype: :d2
+        )
+
+      assert s[1] === Decimal.new("0.42")
+      assert s[3] === Decimal.new("5.12")
+
+      assert Series.to_list(s) === [
+               Decimal.new("0.00"),
+               Decimal.new("0.42"),
+               nil,
+               Decimal.new("5.12")
+             ]
+
+      assert Series.dtype(s) == {:decimal, nil, 2}
+    end
+
     test "with integers as decimals passing scale" do
       s =
         Series.from_list([0, 4237, nil, 550],
-          dtype: {:decimal, 0, 2}
+          dtype: {:decimal, nil, 2}
         )
 
       assert s[1] === Decimal.new("42.37")

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -897,6 +897,13 @@ defmodule Explorer.SeriesTest do
       assert Series.equal(s, "a") |> Series.to_list() == [true, false, false, nil, true]
     end
 
+    test "compare decimal series" do
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+
+      assert s1 |> Series.equal(s2) |> Series.to_list() == [true, true, false]
+    end
+
     test "performs broadcasting" do
       s1 = Series.from_list([-1, 0, 1])
       s2 = Series.from_list([0])
@@ -967,6 +974,13 @@ defmodule Explorer.SeriesTest do
       s1 = Series.from_list([1, 0, 2])
 
       assert 2 |> Series.not_equal(s1) |> Series.to_list() == [true, true, false]
+    end
+
+    test "compare decimal series" do
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+
+      assert s1 |> Series.not_equal(s2) |> Series.to_list() == [false, false, true]
     end
 
     test "compare float series with a float value on the left-hand side" do
@@ -1077,6 +1091,13 @@ defmodule Explorer.SeriesTest do
                [false, false, false, false, false]
     end
 
+    test "compare decimal series" do
+      s1 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
+
+      assert s1 |> Series.greater(s2) |> Series.to_list() == [false, false, true]
+    end
+
     test "compares series of different sizes" do
       s1 = Series.from_list([1, 2, 3])
       s2 = Series.from_list([3, 2, 1, 4])
@@ -1108,6 +1129,13 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:50:59.999999]])
 
       assert s1 |> Series.greater_equal(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "compare decimal series" do
+      s1 = Series.from_list([1, 0, 3, -1], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 2, 1], dtype: {:decimal, nil, 2})
+
+      assert s1 |> Series.greater_equal(s2) |> Series.to_list() == [true, true, true, false]
     end
 
     test "compare integer series with a scalar value on the right-hand side" do
@@ -1270,6 +1298,13 @@ defmodule Explorer.SeriesTest do
                [true, true, true, true, false]
     end
 
+    test "compare decimal series" do
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+
+      assert s1 |> Series.less(s2) |> Series.to_list() == [false, false, true]
+    end
+
     test "raises on value mismatch" do
       assert_raise ArgumentError,
                    "cannot invoke Explorer.Series.less/2 with mismatched dtypes: {:f, 64} and nil",
@@ -1295,6 +1330,13 @@ defmodule Explorer.SeriesTest do
 
       assert s1 |> Series.less_equal(s2) |> Series.to_list() ==
                [true, true, true, true, true, true]
+    end
+
+    test "compare decimal series" do
+      s1 = Series.from_list([1, 0, 2], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
+
+      assert s1 |> Series.less_equal(s2) |> Series.to_list() == [true, true, true]
     end
 
     test "compare time series" do
@@ -1384,6 +1426,13 @@ defmodule Explorer.SeriesTest do
     test "with signed integer series" do
       s1 = Series.from_list([1, 2, 3])
       s2 = Series.from_list([1, 0, 3])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with decimal series" do
+      s1 = Series.from_list([1, 2, 3], dtype: {:decimal, nil, 2})
+      s2 = Series.from_list([1, 0, 3], dtype: {:decimal, nil, 2})
 
       assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -381,6 +381,87 @@ defmodule Explorer.SeriesTest do
       end
     end
 
+    test "with decimals" do
+      s =
+        Series.from_list([Decimal.new("0"), Decimal.new("0.42"), nil, Decimal.new("5.12467")],
+          dtype: :decimal
+        )
+
+      assert s[1] === Decimal.new("0.42000")
+      assert s[3] === Decimal.new("5.12467")
+
+      assert Series.to_list(s) === [
+               Decimal.new("0.00000"),
+               Decimal.new("0.42000"),
+               nil,
+               Decimal.new("5.12467")
+             ]
+
+      assert Series.dtype(s) == {:decimal, nil, 5}
+    end
+
+    test "with decimals without dtype option mixing with floats" do
+      s =
+        Series.from_list([
+          Decimal.new("0"),
+          Decimal.new("0.42"),
+          nil,
+          Decimal.new("5.12467"),
+          42.59
+        ])
+
+      assert s[1] === Decimal.new("0.42000")
+      assert s[4] === Decimal.new("42.59000")
+
+      assert Series.to_list(s) === [
+               Decimal.new("0.00000"),
+               Decimal.new("0.42000"),
+               nil,
+               Decimal.new("5.12467"),
+               Decimal.new("42.59000")
+             ]
+
+      assert Series.dtype(s) == {:decimal, nil, 5}
+    end
+
+    test "with floats as decimals" do
+      s =
+        Series.from_list([0.0, 0.42, nil, 5.12467],
+          dtype: :decimal
+        )
+
+      assert s[1] === Decimal.new("0.42000")
+      assert s[3] === Decimal.new("5.12467")
+
+      assert Series.to_list(s) === [
+               Decimal.new("0.00000"),
+               Decimal.new("0.42000"),
+               nil,
+               Decimal.new("5.12467")
+             ]
+
+      assert Series.dtype(s) == {:decimal, nil, 5}
+    end
+
+    test "with integers as decimals passing scale" do
+      s =
+        Series.from_list([0, 4237, nil, 550],
+          dtype: {:decimal, 0, 2}
+        )
+
+      assert s[1] === Decimal.new("42.37")
+      assert s[3] === Decimal.new("5.50")
+
+      assert Series.to_list(s) === [
+               Decimal.new("0.00"),
+               Decimal.new("42.37"),
+               nil,
+               Decimal.new("5.50")
+             ]
+
+      assert Series.dtype(s) == {:decimal, nil, 2}
+    end
+
     test "mixing dates and integers with `:date` dtype" do
       s = Series.from_list([1, nil, ~D[2024-06-13]], dtype: :date)
 


### PR DESCRIPTION
Adding support for decimals in some of functions that work with integers and floats. This is adding support for creating decimal series using the `Explorer.Series.from_list/2` function as well.

The decimals support is still in the experimental phase in Polars, so we won't be able to support all the operations now. Some of the operations are returning `f64` series or float results, and some of the functions are raising exceptions from Polars because they are not implemented at the backend.