### PR TITLE
Add function clause for `%FSS.HTTP.Entry{}`

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -842,6 +842,7 @@ defmodule Explorer.DataFrame do
   end
 
   defp normalise_entry(%Local.Entry{} = entry, nil), do: {:ok, entry}
+  defp normalise_entry(%HTTP.Entry{} = entry, nil), do: {:ok, entry}
   defp normalise_entry(%S3.Entry{config: %S3.Config{}} = entry, nil), do: {:ok, entry}
 
   defp normalise_entry("s3://" <> _rest = entry, config) do

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -127,7 +127,7 @@ defmodule Explorer.DataFrame.ParquetTest do
 
     test "reads a parquet file from an FFS entry", %{bypass: bypass, df: df_expected} do
       # Setup a `GET` expectation for `path` that returns the expected
-      # DataFrame.
+      # DataFrame as a `parquet` binary.
       path = "/path/to/file.parquet"
       authorization = "Bearer my-token"
 
@@ -142,7 +142,7 @@ defmodule Explorer.DataFrame.ParquetTest do
       config = [headers: [{"authorization", authorization}]]
       {:ok, %FSS.HTTP.Entry{} = entry} = FSS.HTTP.parse(url, config: config)
 
-      # Assert that we can read from that entry.
+      # Assert that we can read the parquet binary from that entry.
       {:ok, df_actual} = DF.from_parquet(entry)
       assert DF.to_columns(df_expected) == DF.to_columns(df_actual)
     end

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -125,7 +125,7 @@ defmodule Explorer.DataFrame.ParquetTest do
       assert DF.to_columns(df1) == DF.to_columns(df)
     end
 
-    test "reads a parquet file from an FFS entry", %{bypass: bypass, df: df_expected} do
+    test "reads a parquet file from an FSS entry", %{bypass: bypass, df: df_expected} do
       # Setup a `GET` expectation for `path` that returns the expected
       # DataFrame as a `parquet` binary.
       path = "/path/to/file.parquet"


### PR DESCRIPTION
Closes: https://github.com/elixir-explorer/explorer/issues/991

```elixir
{:ok, entry} = FSS.HTTP.parse("https://huggingface.co/datasets/aqubed/kub_tickets_small/resolve/main/data/train-00000-of-00001-47868532d4f55873.parquet")

Explorer.DataFrame.from_parquet!(entry)
# #Explorer.DataFrame<
#   Polars[1099 x 11]
#   number s64 [120202, 120201, 120200, 120198, 120197, ...]
#   ...
# >
```