### PR TITLE
fix - cannot encode value Binary to term

### DIFF
--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -754,6 +754,7 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
         AnyValue::Null => Ok(None::<bool>.encode(env)),
         AnyValue::Boolean(v) => Ok(Some(v).encode(env)),
         AnyValue::String(v) => Ok(Some(v).encode(env)),
+        AnyValue::Binary(v) => Ok(Some(v).encode(env)),
         AnyValue::Int8(v) => Ok(Some(v).encode(env)),
         AnyValue::Int16(v) => Ok(Some(v).encode(env)),
         AnyValue::Int32(v) => Ok(Some(v).encode(env)),


### PR DESCRIPTION
fixes https://github.com/elixir-explorer/explorer/issues/994

```py
import polars as pl
df = pl.DataFrame({"image": [b'\x01\x02\x03']})
df.write_parquet("ok.parquet")
df = pl.DataFrame({"image": [{"bytes": b'\x01\x02\x03'}]})
df.write_parquet("bad.parquet")
```
```elixir
iex(1)> Explorer.DataFrame.from_parquet!("bad.parquet")
#Explorer.DataFrame<
  Polars[1 x 1]
  image struct[1] [%{"bytes" => [1, 2, 3]}]
>
```