### PR TITLE
Add read support for lazy http ndjson

### DIFF
--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -241,6 +241,14 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
+  def from_ndjson(%HTTP.Entry{url: url}, infer_schema_length, batch_size) do
+    case Native.lf_from_ndjson(url, infer_schema_length, batch_size) do
+      {:ok, polars_ldf} -> Shared.create_dataframe(polars_ldf)
+      {:error, error} -> {:error, RuntimeError.exception(error)}
+    end
+  end
+
+  @impl true
   def from_ipc(%S3.Entry{}, _) do
     {:error,
      ArgumentError.exception("reading IPC from AWS S3 is not supported for Lazy dataframes")}


### PR DESCRIPTION


- This is a followup for https://github.com/elixir-explorer/explorer/pull/993
- Currently reading http ndjson with lazy option is not supported 👇🏼 
```elixir
iex(2)> frame = Explorer.DataFrame.from_ndjson("http://127.0.0.1:8080/demo.ndjson", lazy: true)
** (FunctionClauseError) no function clause matching in Explorer.PolarsBackend.LazyFrame.from_ndjson/3    
    
    The following arguments were given to Explorer.PolarsBackend.LazyFrame.from_ndjson/3:
    
        # 1
        %FSS.HTTP.Entry{
          url: "http://127.0.0.1:8080/demo.ndjson",
          config: %FSS.HTTP.Config{headers: []}
        }
    
        # 2
        1000
    
        # 3
        1000
    
    Attempted function clauses (showing 2 out of 2):
    
        def from_ndjson(%FSS.S3.Entry{}, _, _)
        def from_ndjson(%FSS.Local.Entry{} = entry, infer_schema_length, batch_size)
    
    (explorer 0.10.0-dev) lib/explorer/polars_backend/lazy_frame.ex:230: Explorer.PolarsBackend.LazyFrame.from_ndjson/3
    iex:2: (file)
```
- This adds support for it.

## Manual Test

- to test locally you can download and extract the attached ndjson or simply create one like 
- `demo.ndjson`
```
{"a":1}
{"b":2}
``` 
- run `http-server .` on the path containing `demo.ndjson`
- Test after the change 👇🏼 
```elixir
iex(3)> frame = Explorer.DataFrame.from_ndjson("http://127.0.0.1:8080/demo.ndjson", lazy: true)
{:ok,
 #Explorer.DataFrame<
   LazyPolars[??? x 2]
   a s64 [1, nil]
   b s64 [nil, 2]
 >}
```


[demo.ndjson.tar.gz](https://github.com/user-attachments/files/17191491/demo.ndjson.tar.gz)


