### PR TITLE
Fix return type in `DataFrame.dtypes/1` typespec (#1002)

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2048,7 +2048,7 @@ defmodule Explorer.DataFrame do
       %{"floats" => {:f, 64}, "ints" => {:s, 64}}
   """
   @doc type: :introspection
-  @spec dtypes(df :: DataFrame.t()) :: %{String.t() => atom()}
+  @spec dtypes(df :: DataFrame.t()) :: %{String.t() => Explorer.Series.dtype()}
   def dtypes(df), do: df.dtypes
 
   @doc """


### PR DESCRIPTION
This change uses the same type for the `dtypes` struct field and the `dtypes` function.

Resolves https://github.com/elixir-explorer/explorer/issues/1002.