### PR TITLE
Add access example to DataFrame docs (#1001)

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -188,6 +188,17 @@ defmodule Explorer.DataFrame do
       iex> df["class"][3]
       1
 
+
+  When trying to access a column in the dataframe that does not exist, an `ArgumentError` is raised.
+
+      iex> df = Explorer.Datasets.wine()
+      iex> try do
+      ...>   {:ok, df["abcd"]}
+      ...> rescue
+      ...>   _ in ArgumentError -> :error
+      ...> end
+      :error
+
   """
 
   alias __MODULE__, as: DataFrame


### PR DESCRIPTION
To start, I added one example that shows what happens when trying to access a data frame column that does not exist.

I'm not sure how much to go into some of the comments in #1001, e.g., the fact that an error is raised instead of returning `nil` and other aspects of the `Access` behaviour that might be surprising.

What do you think, should it be kept simple like this or should I add something specifically about Access behaviour?