### PR TITLE
Fix decimal empty list bug

### DIFF
--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -242,7 +242,7 @@ pub fn s_from_list_decimal(
                 .map(|ex_decimal| AnyValue::Decimal(ex_decimal.signed_coef(), ex_decimal.scale()))
                 .map_err(|error| {
                     ExplorerError::Other(format!(
-                        "cannot decode a valid decimal from term. error: {error:?}"
+                        "cannot decode a valid decimal from term; check that `coef` fits into an `i128`. error: {error:?}"
                     ))
                 }),
             TermType::Atom => Ok(AnyValue::Null),

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -264,13 +264,22 @@ pub fn s_from_list_decimal(
 
     let mut series = Series::from_any_values(name.into(), &values, true)?;
 
-    if let DataType::Decimal(result_precision, result_scale) = series.dtype() {
-        let p: Option<usize> = Some(precision.unwrap_or(result_precision.unwrap_or(38)));
-        let s: Option<usize> = Some(scale.unwrap_or(result_scale.unwrap_or(0)));
+    match series.dtype() {
+        DataType::Decimal(result_precision, result_scale) => {
+            let p: Option<usize> = Some(precision.unwrap_or(result_precision.unwrap_or(38)));
+            let s: Option<usize> = Some(scale.unwrap_or(result_scale.unwrap_or(0)));
 
-        if *result_precision != p || *result_scale != s {
+            if *result_precision != p || *result_scale != s {
+                series = series.cast(&DataType::Decimal(p, s))?;
+            }
+        }
+        // An empty list will result in the `Null` dtype.
+        DataType::Null => {
+            let p = Some(precision.unwrap_or(38));
+            let s = Some(scale.unwrap_or(0));
             series = series.cast(&DataType::Decimal(p, s))?;
         }
+        other_dtype => panic!("expected dtype to be Decimal. found: {other_dtype:?}"),
     }
 
     Ok(ExSeries::new(series))

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -4730,9 +4730,7 @@ defmodule Explorer.DataFrameTest do
   describe "properties" do
     property "should be able to create a DataFrame from valid rows" do
       check all(
-              # TODO: remove `exclude: :decimal` once we fix whatever bug(s)
-              # this is finding.
-              dtypes <- Explorer.Generator.dtypes(exclude: :decimal),
+              dtypes <- Explorer.Generator.dtypes(),
               rows <- Explorer.Generator.rows(dtypes),
               max_runs: 1_000
             ) do
@@ -4742,9 +4740,7 @@ defmodule Explorer.DataFrameTest do
 
     property "should be able to create a DataFrame from valid columns" do
       check all(
-              # TODO: remove `exclude: :decimal` once we fix whatever bug(s)
-              # this is finding.
-              dtypes <- Explorer.Generator.dtypes(exclude: :decimal),
+              dtypes <- Explorer.Generator.dtypes(),
               cols <- Explorer.Generator.columns(dtypes),
               max_runs: 1_000
             ) do
@@ -4770,9 +4766,7 @@ defmodule Explorer.DataFrameTest do
     @tag :skip
     property "can dump any DataFrame (without duration) to CSV" do
       check all(
-              # TODO: remove `:decimal` once we fix whatever bug(s) this is
-              # finding.
-              dtypes <- Explorer.Generator.dtypes(exclude: [:decimal, :duration]),
+              dtypes <- Explorer.Generator.dtypes(exclude: :duration),
               rows <- Explorer.Generator.rows(dtypes),
               max_runs: 1_000
             ) do
@@ -4785,9 +4779,7 @@ defmodule Explorer.DataFrameTest do
     @tag :skip
     property "can dump any DataFrame to IPC" do
       check all(
-              # TODO: remove `exclude: :decimal` once we fix whatever bug(s)
-              # this is finding.
-              dtypes <- Explorer.Generator.dtypes(exclude: :decimal),
+              dtypes <- Explorer.Generator.dtypes(),
               rows <- Explorer.Generator.rows(dtypes),
               max_runs: 1_000
             ) do
@@ -4800,9 +4792,7 @@ defmodule Explorer.DataFrameTest do
     @tag :skip
     property "can dump any DataFrame to NDJSON" do
       check all(
-              # TODO: remove `exclude: :decimal` once we fix whatever bug(s)
-              # this is finding.
-              dtypes <- Explorer.Generator.dtypes(exclude: :decimal),
+              dtypes <- Explorer.Generator.dtypes(),
               rows <- Explorer.Generator.rows(dtypes),
               max_runs: 1_000
             ) do
@@ -4815,9 +4805,7 @@ defmodule Explorer.DataFrameTest do
     @tag :skip
     property "can dump any DataFrame to PARQUET" do
       check all(
-              # TODO: remove `exclude: :decimal` once we fix whatever bug(s)
-              # this is finding.
-              dtypes <- Explorer.Generator.dtypes(exclude: :decimal),
+              dtypes <- Explorer.Generator.dtypes(),
               rows <- Explorer.Generator.rows(dtypes),
               max_runs: 1_000
             ) do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -503,6 +503,10 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s) == {:decimal, 38, 5}
     end
 
+    test "{:list, {:decimal, _, _}} works with empty lists" do
+      Series.from_list([[Decimal.new("3.21")], []], dtype: {:list, {:decimal, 3, 2}})
+    end
+
     test "mixing dates and integers with `:date` dtype" do
       s = Series.from_list([1, nil, ~D[2024-06-13]], dtype: :date)
 


### PR DESCRIPTION
Fixes two things:

1. The `:decimal` generator was generating Elixir-side `#Decimal<>`s that the Rust-side couldn't represent.
2. There was a bug in `s_from_list_decimal` where empty lists failed to have the `Decimal(...)` dtype.

Now we can remove the decimal-related TODOs we added in https://github.com/elixir-explorer/explorer/pull/1012.

See also: https://github.com/elixir-explorer/explorer/issues/1014.