### PR TITLE
Use `coef: i128` in decimal

### DIFF
--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -572,9 +572,7 @@ pub struct ExDecimal {
     // `coef` is a positive, arbitrary precision integer on the Elixir side.
     // It's convenient to represent it here as a signed `i128` because that's
     // what the Decimal dtype expects. While you could technically create an
-    // `ExDecimal` struct with a negative `coef`, it's not a practical concern
-    // because these structs are exclusively built from Elixir `Decimal`s which
-    // are presumed valid; i.e. with positive `coef`s.
+    // `ExDecimal` struct with a negative `coef`, it's not a practical concern.
     pub coef: i128,
     pub exp: i64,
 }

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -602,7 +602,7 @@ impl Literal for ExDecimal {
     fn lit(self) -> Expr {
         Expr::Literal(LiteralValue::Decimal(
             if self.sign.is_positive() {
-                self.coef.into()
+                self.coef
             } else {
                 -self.coef
             },

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -507,6 +507,23 @@ defmodule Explorer.SeriesTest do
       Series.from_list([[Decimal.new("3.21")], []], dtype: {:list, {:decimal, 3, 2}})
     end
 
+    test "decimal precision boundary" do
+      # Biggest number representable by an i128.
+      max_i128 = 2 ** 127 - 1
+      biggest = Decimal.new(max_i128)
+      too_big = Decimal.new(max_i128 + 1)
+
+      # Can make a series using the biggest allowed decimal.
+      s1 = Series.from_list([biggest])
+      assert [^biggest] = Series.to_list(s1)
+
+      # Can't make a series using a number bigger than the biggest allowed decimal.
+      assert_raise RuntimeError,
+                   "Generic Error: cannot decode a valid decimal from term;" <>
+                     " check that `coef` fits into an `i128`. error: throw(<term>)",
+                   fn -> Series.from_list([too_big]) end
+    end
+
     test "mixing dates and integers with `:date` dtype" do
       s = Series.from_list([1, nil, ~D[2024-06-13]], dtype: :date)
 

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -295,8 +295,8 @@ defmodule Explorer.Generator do
         date: constant(:date),
         datetime: tuple({constant(:datetime), time_unit(), constant("Etc/UTC")}),
         decimal:
-          bind(integer(0..19), fn scale ->
-            bind(integer((scale + 1)..20), fn precision ->
+          bind(integer(0..37), fn scale ->
+            bind(integer((scale + 1)..38), fn precision ->
               tuple({constant(:decimal), constant(precision), constant(scale)})
             end)
           end),
@@ -397,7 +397,7 @@ defmodule Explorer.Generator do
     |> map(&elem(&1, 1))
   end
 
-  @max_u64 2 ** 64 - 1
+  @max_i128 2 ** 127 - 1
   @spec datetime(pos_integer(), pos_integer()) :: gen(Decimal.t())
   defp decimal(precision, scale) do
     # Smallest integer with `(scale + 1)` digits.
@@ -407,7 +407,7 @@ defmodule Explorer.Generator do
 
     tuple({
       one_of([constant("-"), constant("+")]),
-      integer(min_scale..min(max_precision, @max_u64))
+      integer(min_scale..min(max_precision, @max_i128))
     })
     |> map(fn {sign, coef} ->
       # By construction, we are guaranteed that precision > scale.


### PR DESCRIPTION
Changes our `ExDecimal` representation to:

```rust
pub struct ExDecimal {
    pub sign: i8,
    pub coef: i128, // was u64
    pub exp: i64,
}
```

This gives us the ability to represent larger decimals. The trade-off is we could technically create an invalid `ExDecimal` in our Rust code. But I don't think it's a practical concern: we just need to be careful to always call `.abs()` when we instantiate it.