### PR TITLE
Print empty DataFrame

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5924,6 +5924,10 @@ defmodule Explorer.DataFrame do
   @doc """
   Prints the DataFrame in a tabular fashion.
 
+  ## Options
+
+    * `:limit` (non_neg_integer() | :infinity) - number of rows to print.
+
   ## Examples
 
       df = Explorer.Datasets.iris()
@@ -5934,6 +5938,23 @@ defmodule Explorer.DataFrame do
   @doc type: :introspection
   @spec print(df :: DataFrame.t(), opts :: Keyword.t()) :: :ok
   def print(df, opts \\ []) do
+    string =
+      if n_columns(df) == 0 do
+        empty_table_string()
+      else
+        non_empty_table_string(df, opts)
+      end
+
+    IO.puts(string)
+  end
+
+  defp empty_table_string() do
+    TableRex.Table.new()
+    |> TableRex.Table.add_rows([["Explorer DataFrame: [rows: 0, columns: 0]"]])
+    |> TableRex.Table.render!()
+  end
+
+  defp non_empty_table_string(df, opts) do
     {rows, columns} =
       if lazy?(df) do
         {"???", n_columns(df)}
@@ -5977,7 +5998,6 @@ defmodule Explorer.DataFrame do
       header_separator_symbol: "=",
       horizontal_style: :all
     )
-    |> IO.puts()
   end
 
   @doc """

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2638,6 +2638,17 @@ defmodule Explorer.DataFrameTest do
              """
     end
 
+    test "works with empty DataFrame" do
+      empty_df = DF.new([])
+
+      assert capture_io(fn -> DF.print(empty_df) end) == """
+             +-------------------------------------------+
+             | Explorer DataFrame: [rows: 0, columns: 0] |
+             +-------------------------------------------+
+
+             """
+    end
+
     test "works with structs" do
       df = DF.new([%{n: %{a: 1}, m: 2}, %{n: %{a: 2}, m: 3}])
 


### PR DESCRIPTION
We currently raise if you try to print a DataFrame with no rows or columns:

```elixir
iex(1)> df = Explorer.DataFrame.new([])
#Explorer.DataFrame<
  Polars[0 x 0]
>

iex(2)> Explorer.DataFrame.print(df)
** (ArithmeticError) bad argument in arithmetic expression
    (table_rex 4.0.0) lib/table_rex/renderer/text.ex:378: TableRex.Renderer.Text.max_dimensions/1
    (table_rex 4.0.0) lib/table_rex/renderer/text.ex:56: TableRex.Renderer.Text.render/2
    (table_rex 4.0.0) lib/table_rex/table.ex:280: TableRex.Table.render!/2
    (explorer 0.11.0-dev) lib/explorer/data_frame.ex:5976: Explorer.DataFrame.print/2
    iex:2: (file)
```

This PR fixes that a default print string:

```elixir
...

iex(2)> Explorer.DataFrame.print(df)
+-------------------------------------------+
| Explorer DataFrame: [rows: 0, columns: 0] |
+-------------------------------------------+

:ok
```

I also documented the option to the print function.