### PR TITLE
Fix datetime encoding overflow

### DIFF
--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -332,7 +332,7 @@ pub fn microseconds_six_digits(microseconds: u32) -> u32 {
     }
 }
 
-pub fn ex_naive_datetime_to_timestamp_res(
+pub fn ex_naive_datetime_to_timestamp(
     ex_naive_datetime: ExNaiveDateTime,
     time_unit: TimeUnit,
 ) -> Result<i64, ExplorerError> {
@@ -417,7 +417,7 @@ pub struct ExDateTime<'a> {
     pub zone_abbr: &'a str,
 }
 
-pub fn ex_datetime_to_timestamp_res(
+pub fn ex_datetime_to_timestamp(
     ex_datetime: ExDateTime,
     time_unit: TimeUnit,
 ) -> Result<i64, ExplorerError> {

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -19,6 +19,15 @@ use polars::prelude::cloud::AmazonS3ConfigKey as S3Key;
 
 use chrono_tz::{OffsetComponents, OffsetName, Tz};
 
+pub use polars::export::arrow::datatypes::TimeUnit as ArrowTimeUnit;
+
+pub use polars::export::arrow::temporal_conversions::{
+    date32_to_date as days_to_date, timestamp_ms_to_datetime as timestamp_ms_to_naive_datetime,
+    timestamp_ns_to_datetime as timestamp_ns_to_naive_datetime,
+    timestamp_to_datetime as arrow_timestamp_to_datetime,
+    timestamp_us_to_datetime as timestamp_us_to_naive_datetime,
+};
+
 pub use ex_dtypes::*;
 
 pub struct ExDataFrameRef(pub DataFrame);
@@ -285,33 +294,37 @@ pub struct ExNaiveDateTime {
     pub year: i32,
 }
 
-pub use polars::export::arrow::temporal_conversions::date32_to_date as days_to_date;
-
-pub fn timestamp_to_datetime_utc(microseconds: i64) -> DateTime<Utc> {
-    let sign = microseconds.signum();
-    let seconds = match sign {
-        -1 => microseconds / 1_000_000 - 1,
-        _ => microseconds / 1_000_000,
-    };
-    let remainder = match sign {
-        -1 => 1_000_000 + microseconds % 1_000_000,
-        _ => microseconds % 1_000_000,
-    };
-    let nanoseconds = remainder.abs() * 1_000;
-    DateTime::<Utc>::from_timestamp(seconds, nanoseconds.try_into().unwrap())
-        .expect("construct a UTC")
+pub fn timestamp_to_datetime(
+    timestamp: i64,
+    time_unit: TimeUnit,
+    time_zone: Tz,
+) -> chrono::DateTime<Tz> {
+    let arrow_time_unit = convert_to_arrow_time_unit(time_unit);
+    arrow_timestamp_to_datetime(timestamp, arrow_time_unit, &time_zone)
 }
 
-/// Converts a microsecond i64 to a `NaiveDateTime`.
-/// This is because when getting a timestamp, it might have negative values.
-pub fn timestamp_to_datetime(microseconds: i64) -> NaiveDateTime {
-    timestamp_to_datetime_utc(microseconds).naive_utc()
+// Note: arrow has a native datetime analog to `timestamp_to_datetime` but it's
+// private, so we're adapting its internals here.
+pub fn timestamp_to_naive_datetime(timestamp: i64, time_unit: TimeUnit) -> NaiveDateTime {
+    match time_unit {
+        TimeUnit::Milliseconds => timestamp_ms_to_naive_datetime(timestamp),
+        TimeUnit::Microseconds => timestamp_us_to_naive_datetime(timestamp),
+        TimeUnit::Nanoseconds => timestamp_ns_to_naive_datetime(timestamp),
+    }
+}
+
+fn convert_to_arrow_time_unit(time_unit: TimeUnit) -> ArrowTimeUnit {
+    match time_unit {
+        TimeUnit::Milliseconds => ArrowTimeUnit::Millisecond,
+        TimeUnit::Microseconds => ArrowTimeUnit::Microsecond,
+        TimeUnit::Nanoseconds => ArrowTimeUnit::Nanosecond,
+    }
 }
 
 // Limit the number of digits in the microsecond part of a timestamp to 6.
 // This is necessary because the microsecond part of Elixir is only 6 digits.
 #[inline]
-fn microseconds_six_digits(microseconds: u32) -> u32 {
+pub fn microseconds_six_digits(microseconds: u32) -> u32 {
     if microseconds > 999_999 {
         999_999
     } else {
@@ -319,29 +332,27 @@ fn microseconds_six_digits(microseconds: u32) -> u32 {
     }
 }
 
-impl From<i64> for ExNaiveDateTime {
-    fn from(microseconds: i64) -> Self {
-        timestamp_to_datetime(microseconds).into()
+pub fn ex_naive_datetime_to_timestamp_res(
+    ex_naive_datetime: ExNaiveDateTime,
+    time_unit: TimeUnit,
+) -> Result<i64, ExplorerError> {
+    let naive_datetime = NaiveDateTime::from(ex_naive_datetime);
+
+    match time_unit {
+        TimeUnit::Milliseconds => Ok(naive_datetime.and_utc().timestamp_millis()),
+        TimeUnit::Microseconds => Ok(naive_datetime.and_utc().timestamp_micros()),
+        TimeUnit::Nanoseconds => naive_datetime.and_utc().timestamp_nanos_opt().map_or(
+            Err(ExplorerError::TimestampConversion(format!(
+                "cannot represent naive datetime(ns) with `i64`"
+            ))),
+            |timestamp| Ok(timestamp),
+        ),
     }
 }
 
-impl From<ExNaiveDateTime> for i64 {
-    fn from(dt: ExNaiveDateTime) -> i64 {
-        let duration = NaiveDate::from_ymd_opt(dt.year, dt.month, dt.day)
-            .unwrap()
-            .and_hms_micro_opt(dt.hour, dt.minute, dt.second, dt.microsecond.0)
-            .unwrap()
-            .signed_duration_since(
-                NaiveDate::from_ymd_opt(1970, 1, 1)
-                    .unwrap()
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap(),
-            );
-
-        match duration.num_microseconds() {
-            Some(us) => us,
-            None => duration.num_milliseconds() * 1_000,
-        }
+impl From<i64> for ExNaiveDateTime {
+    fn from(timestamp: i64) -> Self {
+        timestamp_to_naive_datetime(timestamp, TimeUnit::Microseconds).into()
     }
 }
 
@@ -407,29 +418,21 @@ pub struct ExDateTime<'a> {
     pub zone_abbr: &'a str,
 }
 
-// impl From<i64> for ExDateTime<'_> {
-//     fn from(microseconds: i64) -> Self {
-//         timestamp_to_datetime_utc(microseconds).into()
-//     }
-// }
+pub fn ex_datetime_to_timestamp_res(
+    ex_datetime: ExDateTime,
+    time_unit: TimeUnit,
+) -> Result<i64, ExplorerError> {
+    let datetime = DateTime::from(ex_datetime);
 
-impl From<ExDateTime<'_>> for i64 {
-    fn from(dt: ExDateTime<'_>) -> i64 {
-        let duration = NaiveDate::from_ymd_opt(dt.year, dt.month, dt.day)
-            .unwrap()
-            .and_hms_micro_opt(dt.hour, dt.minute, dt.second, dt.microsecond.0)
-            .unwrap()
-            .signed_duration_since(
-                NaiveDate::from_ymd_opt(1970, 1, 1)
-                    .unwrap()
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap(),
-            );
-
-        match duration.num_microseconds() {
-            Some(us) => us,
-            None => duration.num_milliseconds() * 1_000,
-        }
+    match time_unit {
+        TimeUnit::Milliseconds => Ok(datetime.timestamp_millis()),
+        TimeUnit::Microseconds => Ok(datetime.timestamp_micros()),
+        TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().map_or(
+            Err(ExplorerError::TimestampConversion(format!(
+                "cannot represent datetime(ns) with `i64`"
+            ))),
+            |timestamp| Ok(timestamp),
+        ),
     }
 }
 

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -341,11 +341,10 @@ pub fn ex_naive_datetime_to_timestamp_res(
     match time_unit {
         TimeUnit::Milliseconds => Ok(naive_datetime.and_utc().timestamp_millis()),
         TimeUnit::Microseconds => Ok(naive_datetime.and_utc().timestamp_micros()),
-        TimeUnit::Nanoseconds => naive_datetime.and_utc().timestamp_nanos_opt().map_or(
-            Err(ExplorerError::TimestampConversion(format!(
-                "cannot represent naive datetime(ns) with `i64`"
-            ))),
-            |timestamp| Ok(timestamp),
+        TimeUnit::Nanoseconds => naive_datetime.and_utc().timestamp_nanos_opt().ok_or(
+            ExplorerError::TimestampConversion(
+                "cannot represent naive datetime(ns) with `i64`".to_string(),
+            ),
         ),
     }
 }
@@ -427,12 +426,13 @@ pub fn ex_datetime_to_timestamp_res(
     match time_unit {
         TimeUnit::Milliseconds => Ok(datetime.timestamp_millis()),
         TimeUnit::Microseconds => Ok(datetime.timestamp_micros()),
-        TimeUnit::Nanoseconds => datetime.timestamp_nanos_opt().map_or(
-            Err(ExplorerError::TimestampConversion(format!(
-                "cannot represent datetime(ns) with `i64`"
-            ))),
-            |timestamp| Ok(timestamp),
-        ),
+        TimeUnit::Nanoseconds => {
+            datetime
+                .timestamp_nanos_opt()
+                .ok_or(ExplorerError::TimestampConversion(
+                    "cannot represent datetime(ns) with `i64`".to_string(),
+                ))
+        }
     }
 }
 

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -188,7 +188,7 @@ fn naive_datetime_series_to_list<'b>(s: &Series, env: Env<'b>) -> Result<Term<'b
     let calendar_iso_module = atoms::calendar_iso_module().encode(env).as_c_arg();
     let naive_datetime_module = atoms::naive_datetime_module().encode(env).as_c_arg();
     let time_unit = match s.dtype() {
-        DataType::Datetime(time_unit, None) => time_unit.clone(),
+        DataType::Datetime(time_unit, None) => *time_unit,
         _ => panic!("should only use this function for naive datetimes"),
     };
 
@@ -304,7 +304,7 @@ fn datetime_series_to_list<'b>(s: &Series, env: Env<'b>) -> Result<Term<'b>, Exp
     let calendar_iso_module = atoms::calendar_iso_module().encode(env).as_c_arg();
     let datetime_module = atoms::datetime_module().encode(env).as_c_arg();
     let time_unit = match s.dtype() {
-        DataType::Datetime(time_unit, Some(_)) => time_unit.clone(),
+        DataType::Datetime(time_unit, Some(_)) => *time_unit,
         _ => panic!("datetime_series_to_list called on series with wrong type"),
     };
     let time_zone = match s.dtype() {

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -13,7 +13,8 @@ use crate::atoms::{
     neg_infinity, precision, second, std_offset, time_zone, utc_offset, value, year, zone_abbr,
 };
 use crate::datatypes::{
-    days_to_date, time64ns_to_time, timestamp_to_datetime, ExSeries, ExSeriesRef,
+    days_to_date, microseconds_six_digits, time64ns_to_time, timestamp_to_datetime,
+    timestamp_to_naive_datetime, ExSeries, ExSeriesRef,
 };
 use crate::ExplorerError;
 
@@ -108,17 +109,17 @@ fn date_series_to_list<'b>(s: &Series, env: Env<'b>) -> Result<Term<'b>, Explore
 }
 
 macro_rules! unsafe_encode_naive_datetime {
-    ($v: expr, $naive_datetime_struct_keys: ident, $calendar_iso_module: ident, $naive_datetime_module: ident, $env: ident) => {{
-        let dt = timestamp_to_datetime($v);
-        let microseconds = dt.and_utc().timestamp_subsec_micros();
-
-        // Limit the number of digits in the microsecond part of a timestamp to 6.
-        // This is necessary because the microsecond part of Elixir is only 6 digits.
-        let limited_ms = if microseconds > 999_999 {
-            999_999
-        } else {
-            microseconds
-        };
+    (
+        $timestamp: expr,
+        $time_unit: expr,
+        $naive_datetime_struct_keys: ident,
+        $calendar_iso_module: ident,
+        $naive_datetime_module: ident,
+        $env: ident
+    ) => {{
+        let ndt = timestamp_to_naive_datetime($timestamp, $time_unit);
+        let microseconds = ndt.and_utc().timestamp_subsec_micros();
+        let limited_microseconds = microseconds_six_digits(microseconds);
 
         unsafe {
             Term::new(
@@ -129,13 +130,13 @@ macro_rules! unsafe_encode_naive_datetime {
                     &[
                         $naive_datetime_module,
                         $calendar_iso_module,
-                        dt.day().encode($env).as_c_arg(),
-                        dt.month().encode($env).as_c_arg(),
-                        dt.year().encode($env).as_c_arg(),
-                        dt.hour().encode($env).as_c_arg(),
-                        dt.minute().encode($env).as_c_arg(),
-                        dt.second().encode($env).as_c_arg(),
-                        (limited_ms, 6).encode($env).as_c_arg(),
+                        ndt.day().encode($env).as_c_arg(),
+                        ndt.month().encode($env).as_c_arg(),
+                        ndt.year().encode($env).as_c_arg(),
+                        ndt.hour().encode($env).as_c_arg(),
+                        ndt.minute().encode($env).as_c_arg(),
+                        ndt.second().encode($env).as_c_arg(),
+                        (limited_microseconds, 6).encode($env).as_c_arg(),
                     ],
                 )
                 .unwrap(),
@@ -162,23 +163,18 @@ fn naive_datetime_struct_keys(env: Env) -> [NIF_TERM; 9] {
 }
 
 #[inline]
-fn naive_datetime_to_microseconds(v: i64, time_unit: TimeUnit) -> i64 {
-    match time_unit {
-        TimeUnit::Milliseconds => v * 1000,
-        TimeUnit::Microseconds => v,
-        TimeUnit::Nanoseconds => (v as f64 * 0.001) as i64,
-    }
-}
-
-#[inline]
-pub fn encode_naive_datetime(v: i64, time_unit: TimeUnit, env: Env) -> Result<Term, ExplorerError> {
+pub fn encode_naive_datetime(
+    timestamp: i64,
+    time_unit: TimeUnit,
+    env: Env,
+) -> Result<Term, ExplorerError> {
     let naive_datetime_struct_keys = &naive_datetime_struct_keys(env);
     let calendar_iso_module = atoms::calendar_iso_module().encode(env).as_c_arg();
     let naive_datetime_module = atoms::naive_datetime_module().encode(env).as_c_arg();
-    let microseconds_time = naive_datetime_to_microseconds(v, time_unit);
 
     Ok(unsafe_encode_naive_datetime!(
-        microseconds_time,
+        timestamp,
+        time_unit,
         naive_datetime_struct_keys,
         calendar_iso_module,
         naive_datetime_module,
@@ -187,23 +183,22 @@ pub fn encode_naive_datetime(v: i64, time_unit: TimeUnit, env: Env) -> Result<Te
 }
 
 #[inline]
-fn naive_datetime_series_to_list<'b>(
-    s: &Series,
-    time_unit: TimeUnit,
-    env: Env<'b>,
-) -> Result<Term<'b>, ExplorerError> {
+fn naive_datetime_series_to_list<'b>(s: &Series, env: Env<'b>) -> Result<Term<'b>, ExplorerError> {
     let naive_datetime_struct_keys = &naive_datetime_struct_keys(env);
     let calendar_iso_module = atoms::calendar_iso_module().encode(env).as_c_arg();
     let naive_datetime_module = atoms::naive_datetime_module().encode(env).as_c_arg();
+    let time_unit = match s.dtype() {
+        DataType::Datetime(time_unit, None) => time_unit.clone(),
+        _ => panic!("should only use this function for naive datetimes"),
+    };
 
     Ok(unsafe_iterator_series_to_list!(
         env,
-        s.datetime()?.into_iter().map(|option| option
-            .map(|v| {
-                let microseconds_time = naive_datetime_to_microseconds(v, time_unit);
-
+        s.datetime()?.into_iter().map(|opt_timestamp| opt_timestamp
+            .map(|timestamp| {
                 unsafe_encode_naive_datetime!(
-                    microseconds_time,
+                    timestamp,
+                    time_unit,
                     naive_datetime_struct_keys,
                     calendar_iso_module,
                     naive_datetime_module,
@@ -216,26 +211,17 @@ fn naive_datetime_series_to_list<'b>(
 
 macro_rules! unsafe_encode_datetime {
     (
-        $v: expr,
+        $timestamp: expr,
+        $time_unit: expr,
         $time_zone: expr,
         $datetime_struct_keys: ident,
         $calendar_iso_module: ident,
         $datetime_module: ident,
         $env: ident
     ) => {{
-        let ndt = timestamp_to_datetime($v);
-        let microseconds = ndt.and_utc().timestamp_subsec_micros();
-        let tz = $time_zone.parse::<Tz>().unwrap();
-        let dt_tz = tz.from_local_datetime(&ndt).unwrap();
+        let dt_tz = timestamp_to_datetime($timestamp, $time_unit, $time_zone);
         let tz_offset = dt_tz.offset();
-
-        // Limit the number of digits in the microsecond part of a timestamp to 6.
-        // This is necessary because the microsecond part of Elixir is only 6 digits.
-        let limited_ms = if microseconds > 999_999 {
-            999_999
-        } else {
-            microseconds
-        };
+        let limited_microseconds = microseconds_six_digits(dt_tz.timestamp_subsec_micros());
 
         unsafe {
             Term::new(
@@ -248,7 +234,7 @@ macro_rules! unsafe_encode_datetime {
                         $calendar_iso_module,
                         dt_tz.day().encode($env).as_c_arg(),
                         dt_tz.hour().encode($env).as_c_arg(),
-                        (limited_ms, 6).encode($env).as_c_arg(),
+                        (limited_microseconds, 6).encode($env).as_c_arg(),
                         dt_tz.minute().encode($env).as_c_arg(),
                         dt_tz.month().encode($env).as_c_arg(),
                         dt_tz.second().encode($env).as_c_arg(),
@@ -292,18 +278,18 @@ fn datetime_struct_keys(env: Env) -> [NIF_TERM; 13] {
 
 #[inline]
 pub fn encode_datetime(
-    v: i64,
+    timestamp: i64,
     time_unit: TimeUnit,
-    time_zone: String,
+    time_zone: Tz,
     env: Env,
 ) -> Result<Term, ExplorerError> {
     let datetime_struct_keys = &datetime_struct_keys(env);
     let calendar_iso_module = atoms::calendar_iso_module().encode(env).as_c_arg();
     let datetime_module = atoms::datetime_module().encode(env).as_c_arg();
-    let microseconds_time = naive_datetime_to_microseconds(v, time_unit);
 
     Ok(unsafe_encode_datetime!(
-        microseconds_time,
+        timestamp,
+        time_unit,
         time_zone,
         datetime_struct_keys,
         calendar_iso_module,
@@ -313,24 +299,26 @@ pub fn encode_datetime(
 }
 
 #[inline]
-fn datetime_series_to_list<'b>(
-    s: &Series,
-    time_unit: TimeUnit,
-    time_zone: String,
-    env: Env<'b>,
-) -> Result<Term<'b>, ExplorerError> {
+fn datetime_series_to_list<'b>(s: &Series, env: Env<'b>) -> Result<Term<'b>, ExplorerError> {
     let datetime_struct_keys = &datetime_struct_keys(env);
     let calendar_iso_module = atoms::calendar_iso_module().encode(env).as_c_arg();
     let datetime_module = atoms::datetime_module().encode(env).as_c_arg();
+    let time_unit = match s.dtype() {
+        DataType::Datetime(time_unit, Some(_)) => time_unit.clone(),
+        _ => panic!("datetime_series_to_list called on series with wrong type"),
+    };
+    let time_zone = match s.dtype() {
+        DataType::Datetime(_, Some(time_zone)) => time_zone.parse::<Tz>().unwrap(),
+        _ => panic!("datetime_series_to_list called on series with wrong type"),
+    };
 
     Ok(unsafe_iterator_series_to_list!(
         env,
-        s.datetime()?.into_iter().map(|option| option
-            .map(|v| {
-                let microseconds_time = naive_datetime_to_microseconds(v, time_unit);
-
+        s.datetime()?.into_iter().map(|opt_timestamp| opt_timestamp
+            .map(|timestamp| {
                 unsafe_encode_datetime!(
-                    microseconds_time,
+                    timestamp,
+                    time_unit,
                     time_zone,
                     datetime_struct_keys,
                     calendar_iso_module,
@@ -744,7 +732,7 @@ pub fn resource_term_from_value<'b>(
         AnyValue::Time(v) => encode_time(v, env),
         AnyValue::Datetime(v, time_unit, None) => encode_naive_datetime(v, time_unit, env),
         AnyValue::Datetime(v, time_unit, Some(time_zone)) => {
-            encode_datetime(v, time_unit, time_zone.to_string(), env)
+            encode_datetime(v, time_unit, time_zone.parse::<Tz>().unwrap(), env)
         }
         AnyValue::Duration(v, time_unit) => encode_duration(v, time_unit, env),
         AnyValue::Categorical(idx, mapping, _) => Ok(mapping.get(idx).encode(env)),
@@ -805,14 +793,14 @@ pub fn list_from_series(s: ExSeries, env: Env) -> Result<Term, ExplorerError> {
 
         DataType::Date => date_series_to_list(&s, env),
         DataType::Time => time_series_to_list(&s, env),
-        DataType::Datetime(time_unit, None) => naive_datetime_series_to_list(&s, *time_unit, env),
-        DataType::Datetime(time_unit, Some(time_zone)) => {
-            datetime_series_to_list(&s, *time_unit, time_zone.clone().to_string(), env)
-        }
+        DataType::Datetime(_, None) => naive_datetime_series_to_list(&s, env),
+        DataType::Datetime(_, Some(_)) => datetime_series_to_list(&s, env),
         DataType::Duration(time_unit) => duration_series_to_list(&s, *time_unit, env),
+
         DataType::Binary => generic_binary_series_to_list(&s.resource, &s, env),
         DataType::String => generic_string_series_to_list(&s, env),
         DataType::Categorical(Some(mapping), _) => categorical_series_to_list(&s, env, mapping),
+
         DataType::List(_inner_dtype) => s
             .list()?
             .into_iter()

--- a/native/explorer/src/error.rs
+++ b/native/explorer/src/error.rs
@@ -26,6 +26,8 @@ pub enum ExplorerError {
     Internal(String),
     #[error("Generic Error: {0}")]
     Other(String),
+    #[error("Timestamp Conversion Error: {0}")]
+    TimestampConversion(String),
     #[error(transparent)]
     TryFromInt(#[from] std::num::TryFromIntError),
     #[error(transparent)]

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -562,7 +562,7 @@ pub fn s_fill_missing_with_datetime(
     ex_naive_datetime: ExNaiveDateTime,
 ) -> Result<ExSeries, ExplorerError> {
     let time_unit = match series._dtype() {
-        DataType::Datetime(time_unit, _) => time_unit.clone(),
+        DataType::Datetime(time_unit, _) => *time_unit,
         _ => TimeUnit::Microseconds,
     };
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1,7 +1,7 @@
 use crate::{
     datatypes::{
-        ex_naive_datetime_to_timestamp_res, ExCorrelationMethod, ExDate, ExDecimal,
-        ExNaiveDateTime, ExRankMethod, ExSeriesDtype, ExTime, ExTimeUnit, ExValidValue,
+        ex_naive_datetime_to_timestamp, ExCorrelationMethod, ExDate, ExDecimal, ExNaiveDateTime,
+        ExRankMethod, ExSeriesDtype, ExTime, ExTimeUnit, ExValidValue,
     },
     encoding, ExDataFrame, ExSeries, ExplorerError,
 };
@@ -566,15 +566,14 @@ pub fn s_fill_missing_with_datetime(
         _ => TimeUnit::Microseconds,
     };
 
-    ex_naive_datetime_to_timestamp_res(ex_naive_datetime, time_unit).and_then(|value| {
-        Ok(ExSeries::new(
-            series
-                .datetime()?
-                .fill_null_with_values(value)?
-                .cast(series.dtype())?
-                .into_series(),
-        ))
-    })
+    let timestamp = ex_naive_datetime_to_timestamp(ex_naive_datetime, time_unit)?;
+
+    let s = series
+        .datetime()?
+        .fill_null_with_values(timestamp)?
+        .cast(series.dtype())?
+        .into_series();
+    Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -1,7 +1,7 @@
 use crate::atoms;
 use crate::datatypes::{
-    ex_datetime_to_timestamp_res, ex_naive_datetime_to_timestamp_res, ExDate, ExDateTime,
-    ExDecimal, ExDuration, ExNaiveDateTime, ExSeriesDtype, ExTime, ExTimeUnit,
+    ex_datetime_to_timestamp, ex_naive_datetime_to_timestamp, ExDate, ExDateTime, ExDecimal,
+    ExDuration, ExNaiveDateTime, ExSeriesDtype, ExTime, ExTimeUnit,
 };
 use crate::{ExSeries, ExplorerError};
 
@@ -70,7 +70,7 @@ pub fn s_from_list_naive_datetime(
                     ))
                 })
                 .and_then(|ex_naive_datetime| {
-                    ex_naive_datetime_to_timestamp_res(ex_naive_datetime, timeunit).map(Some)
+                    ex_naive_datetime_to_timestamp(ex_naive_datetime, timeunit).map(Some)
                 }),
             TermType::Atom => Ok(None),
             term_type => Err(ExplorerError::Other(format!(
@@ -114,9 +114,7 @@ pub fn s_from_list_datetime(
                         "cannot decode a valid datetime from term. error: {error:?}"
                     ))
                 })
-                .and_then(|ex_datetime| {
-                    ex_datetime_to_timestamp_res(ex_datetime, timeunit).map(Some)
-                }),
+                .and_then(|ex_datetime| ex_datetime_to_timestamp(ex_datetime, timeunit).map(Some)),
             TermType::Atom => Ok(None),
             term_type => Err(ExplorerError::Other(format!(
                 "from_list/2 for datetimes not implemented for {term_type:?}"

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -70,8 +70,7 @@ pub fn s_from_list_naive_datetime(
                     ))
                 })
                 .and_then(|ex_naive_datetime| {
-                    ex_naive_datetime_to_timestamp_res(ex_naive_datetime, timeunit)
-                        .map(|timestamp| Some(timestamp))
+                    ex_naive_datetime_to_timestamp_res(ex_naive_datetime, timeunit).map(Some)
                 }),
             TermType::Atom => Ok(None),
             term_type => Err(ExplorerError::Other(format!(
@@ -116,8 +115,7 @@ pub fn s_from_list_datetime(
                     ))
                 })
                 .and_then(|ex_datetime| {
-                    ex_datetime_to_timestamp_res(ex_datetime, timeunit)
-                        .map(|timestamp| Some(timestamp))
+                    ex_datetime_to_timestamp_res(ex_datetime, timeunit).map(Some)
                 }),
             TermType::Atom => Ok(None),
             term_type => Err(ExplorerError::Other(format!(

--- a/native/explorer/src/series/from_list.rs
+++ b/native/explorer/src/series/from_list.rs
@@ -1,6 +1,7 @@
 use crate::atoms;
 use crate::datatypes::{
-    ExDate, ExDateTime, ExDecimal, ExDuration, ExNaiveDateTime, ExSeriesDtype, ExTime, ExTimeUnit,
+    ex_datetime_to_timestamp_res, ex_naive_datetime_to_timestamp_res, ExDate, ExDateTime,
+    ExDecimal, ExDuration, ExNaiveDateTime, ExSeriesDtype, ExTime, ExTimeUnit,
 };
 use crate::{ExSeries, ExplorerError};
 
@@ -63,11 +64,14 @@ pub fn s_from_list_naive_datetime(
             }),
             TermType::Map => item
                 .decode::<ExNaiveDateTime>()
-                .map(|ex_naive_datetime| Some(i64::from(ex_naive_datetime)))
                 .map_err(|error| {
                     ExplorerError::Other(format!(
                         "cannot decode a valid naive datetime from term. error: {error:?}"
                     ))
+                })
+                .and_then(|ex_naive_datetime| {
+                    ex_naive_datetime_to_timestamp_res(ex_naive_datetime, timeunit)
+                        .map(|timestamp| Some(timestamp))
                 }),
             TermType::Atom => Ok(None),
             term_type => Err(ExplorerError::Other(format!(
@@ -106,11 +110,14 @@ pub fn s_from_list_datetime(
             }),
             TermType::Map => item
                 .decode::<ExDateTime>()
-                .map(|ex_datetime| Some(i64::from(ex_datetime)))
                 .map_err(|error| {
                     ExplorerError::Other(format!(
                         "cannot decode a valid datetime from term. error: {error:?}"
                     ))
+                })
+                .and_then(|ex_datetime| {
+                    ex_datetime_to_timestamp_res(ex_datetime, timeunit)
+                        .map(|timestamp| Some(timestamp))
                 }),
             TermType::Atom => Ok(None),
             term_type => Err(ExplorerError::Other(format!(

--- a/test/explorer/series/datetime_test.exs
+++ b/test/explorer/series/datetime_test.exs
@@ -151,10 +151,10 @@ defmodule Explorer.Series.DateTimeTest do
       timestamp_trunc =
         case time_unit do
           :nanosecond -> timestamp
-          _ -> NaiveDateTime.truncate(timestamp, time_unit)
+          _ -> DateTime.truncate(timestamp, time_unit)
         end
 
-      assert NaiveDateTime.compare(timestamp_trunc, timestamp_after) == :eq
+      assert DateTime.compare(timestamp_trunc, timestamp_after) == :eq
     end
   end
 end


### PR DESCRIPTION
Fixes one of the #1014 issues with printing dataframes.

This one stems from how we encode datetimes. Example:

```elixir
dtypes = [{"col_j", {:naive_datetime, :millisecond}}]
rows = [[{"col_j", ~N[8332-06-03 16:03:40.489446]}]]
df = DF.new(rows, dtypes: dtypes)
DF.print(df)
```

Panics with:

```
thread '<unnamed>' panicked at src/encoding.rs:167:35:
attempt to multiply with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at /Users/billy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/polars-arrow-0.43.1/src/temporal_conversions.rs:159:37:
invalid or out-of-range datetime


  1) test specific property failures 1 (Explorer.DataFrameTest)
     test/explorer/data_frame_test.exs:4850
     ** (ErlangError) Erlang error: :nif_panicked
     code: DF.print(df)
     stacktrace:
       (explorer 0.11.0-dev) Explorer.PolarsBackend.Native.s_to_list(#Explorer.PolarsBackend.Series<
  #Reference<0.2007251331.1252655135.131382>
>)
       (explorer 0.11.0-dev) lib/explorer/polars_backend/shared.ex:24: Explorer.PolarsBackend.Shared.apply_series/3
       (explorer 0.11.0-dev) lib/explorer/data_frame.ex:5981: anonymous fn/2 in Explorer.DataFrame.non_empty_table_string/2
       (elixir 1.16.0) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
       (explorer 0.11.0-dev) lib/explorer/data_frame.ex:5979: Explorer.DataFrame.non_empty_table_string/2
       (explorer 0.11.0-dev) lib/explorer/data_frame.ex:5945: Explorer.DataFrame.print/2
       test/explorer/data_frame_test.exs:4854: (test)
```

The culprit is how we encode datetimes: we always turn them into microseconds first. This is usually fine. But with certain operations like printing, especially when the datetime is far from the unix epoch, it can result in overflow.

My proposed fix is to build the `i64` representation directly from the `(%DateTime{}, time_unit)` pair using (mostly) Polars functions. This works -- and I added some properties to be confident -- but it has the drawback of us no longer being able to support `impl From<ExNaiveDateTime> for i64` since we need to know which time unit the user wants to represent the datetime with. We didn't use that `impl` much so I think the drawback is acceptable.

We're also handling the case where nanosecond precision datetimes can't be represented more explicitly.