### PR TITLE
Allow `[]` in `DF.filter_with/2`

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2641,6 +2641,9 @@ defmodule Explorer.DataFrame do
                 "but instead it returned a LazySeries of type " <>
                 inspect(dtype)
 
+      [] ->
+        df
+
       [%Series{dtype: :boolean, data: %LazySeries{}} | _rest] = lazy_series ->
         first_non_boolean =
           Enum.find(lazy_series, &(!match?(%Series{dtype: :boolean, data: %LazySeries{}}, &1)))

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -309,6 +309,11 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df5, atom_keys: true) == %{a: [2], b: [2.0]}
     end
 
+    test "filtering with an empty list is a no-op", %{df: df1} do
+      df2 = DF.filter_with(df1, [])
+      assert df1 == df2
+    end
+
     test "raise an error if the last operation is an arithmetic operation" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 


### PR DESCRIPTION
Fixes: https://github.com/elixir-explorer/explorer/issues/1021