### PR TITLE
Encode millisecond precision

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2852,7 +2852,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~T[01:55:00], ~T[15:35:00], ~T[23:00:00]])
       iex> Explorer.Series.quantile(s, 0.5)
-      ~T[15:35:00]
+      ~T[15:35:00.000000]
 
       iex> s = Explorer.Series.from_list([true, false, true])
       iex> Explorer.Series.quantile(s, 0.5)

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -353,14 +353,6 @@ impl ExMicrosecondTuple for NaiveTime {
     fn subsec_micros(&self) -> u32 {
         self.nanosecond() / 1_000
     }
-    // fn microsecond_tuple(&self) -> (u32, u32) {
-    //     let us = self.subsec_micros_limited();
-    //     if us == 0 {
-    //         (0, 0)
-    //     } else {
-    //         (self.subsec_micros_limited(), 6)
-    //     }
-    // }
 }
 
 impl ExMicrosecondTuple for NaiveDateTime {

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -353,6 +353,14 @@ impl ExMicrosecondTuple for NaiveTime {
     fn subsec_micros(&self) -> u32 {
         self.nanosecond() / 1_000
     }
+    // fn microsecond_tuple(&self) -> (u32, u32) {
+    //     let us = self.subsec_micros_limited();
+    //     if us == 0 {
+    //         (0, 0)
+    //     } else {
+    //         (self.subsec_micros_limited(), 6)
+    //     }
+    // }
 }
 
 impl ExMicrosecondTuple for NaiveDateTime {

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -4246,7 +4246,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "string series to naive datetime" do
-      s = Series.from_list(["2023-08-29T17:39:43", "2023-08-29T17:20:09"])
+      s = Series.from_list(["2023-08-29T17:39:43"])
       ms = Series.cast(s, {:naive_datetime, :millisecond})
       us = Series.cast(s, {:naive_datetime, :microsecond})
       ns = Series.cast(s, {:naive_datetime, :nanosecond})
@@ -4255,10 +4255,10 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(us) == {:naive_datetime, :microsecond}
       assert Series.dtype(ns) == {:naive_datetime, :nanosecond}
 
-      expected = [~N[2023-08-29T17:39:43.000000], ~N[2023-08-29T17:20:09.000000]]
-      assert Series.to_list(ms) == expected
-      assert Series.to_list(us) == expected
-      assert Series.to_list(ns) == expected
+      # Note the change in precision from ms -> us.
+      assert Series.to_list(ms) == [~N[2023-08-29T17:39:43.000]]
+      assert Series.to_list(us) == [~N[2023-08-29T17:39:43.000000]]
+      assert Series.to_list(ns) == [~N[2023-08-29T17:39:43.000000]]
     end
 
     test "no-op with the same dtype" do


### PR DESCRIPTION
Follow-up to: https://github.com/elixir-explorer/explorer/pull/1020.

Before we were always encoding microseconds like:

* `microsecond: {us, 6}`

This PR changes that for when we have millisecond precision to:

* `microsecond: {us / 1_000 * 1_000, 3}`

It's still 6 digits, but rounded down to the nearest 1,000.