### PR TITLE
Make region truly optional

### DIFF
--- a/lib/explorer/fss/s3.ex
+++ b/lib/explorer/fss/s3.ex
@@ -62,7 +62,7 @@ defimpl Explorer.FSS, for: FSS.S3.Entry do
     :aws_signature.sign_v4(
       entry.config.access_key_id,
       entry.config.secret_access_key,
-      entry.config.region,
+      entry.config.region || "",
       "s3",
       now,
       Atom.to_string(method),


### PR DESCRIPTION
Omitting `region` option causes an exception down the line because it is expected to be a binary in https://github.com/aws-beam/aws_signature/blob/0429920baf6477a76378a8569238a3186d95a9db/src/aws_signature.erl#L77

With this change, unset region is converted to an empty string in the same way as body.