### PR TITLE
Document/test unstable decimal dtype

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -186,6 +186,14 @@ defmodule Explorer.Series do
   @type dtype_alias :: integer_dtype_alias | float_dtype_alias | decimal_dtype_alias
   @type float_dtype_alias :: :float | :f32 | :f64
   @type integer_dtype_alias :: :integer | :u8 | :u16 | :u32 | :u64 | :s8 | :s16 | :s32 | :s64
+  @typedoc """
+  Dtype for a fixed-point decimal represented internally as an integer.
+
+  > #### Warning: Unstable {: .warning}
+  >
+  > This functionality is considered unstable. It is a work-in-progress feature
+  > and may not always work as expected. It may be changed at any point.
+  """
   @type decimal_dtype_alias :: :decimal
 
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -28,6 +28,10 @@ defmodule Explorer.Series do
     * `{:u, size}` - a 8-bit or 16-bit or 32-bit or 64-bit unsigned integer number.
     * `{:decimal, precision, scale}` - a 128-bit signed integer number representing a decimal,
       with a scale and precision. This unwraps to `Decimal`, using the `:decimal` package.
+      > #### Warning: Unstable {: .warning}
+      >
+      > This functionality is considered unstable. It is a work-in-progress feature
+      > and may not always work as expected. It may be changed at any point.
     * `:null` - `nil`s exclusively
     * `:string` - UTF-8 encoded binary
     * `:time` - Time type that unwraps to `Elixir.Time`
@@ -186,14 +190,6 @@ defmodule Explorer.Series do
   @type dtype_alias :: integer_dtype_alias | float_dtype_alias | decimal_dtype_alias
   @type float_dtype_alias :: :float | :f32 | :f64
   @type integer_dtype_alias :: :integer | :u8 | :u16 | :u32 | :u64 | :s8 | :s16 | :s32 | :s64
-  @typedoc """
-  Dtype for a fixed-point decimal represented internally as an integer.
-
-  > #### Warning: Unstable {: .warning}
-  >
-  > This functionality is considered unstable. It is a work-in-progress feature
-  > and may not always work as expected. It may be changed at any point.
-  """
   @type decimal_dtype_alias :: :decimal
 
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}

--- a/test/explorer/polars_backend/decimal_unstable_test.exs
+++ b/test/explorer/polars_backend/decimal_unstable_test.exs
@@ -1,0 +1,65 @@
+defmodule Explorer.PolarsBackend.DecimalUnstableTest do
+  # This module tracks some oddities we've found with decimal dtypes. The Polars
+  # docs warn that decimals are unstable:
+  #
+  #   > This functionality is considered unstable. It is a work-in-progress
+  #   > feature and may not always work as expected. It may be changed at any
+  #   > point without it being considered a breaking change.
+  #
+  # https://docs.pola.rs/api/python/stable/reference/api/polars.datatypes.Decimal.html
+  #
+  # If the tests in the module start breaking, it probably means Polars has
+  # changed its decimal implementation. Be prepared to change the tests: they
+  # function as canaries rather than imposing expected behavior.
+
+  use ExUnit.Case, async: true
+
+  alias Explorer.PolarsBackend
+
+  require Explorer.DataFrame, as: DF
+
+  setup do
+    %{df: DF.new(a: [Decimal.new("1.0"), Decimal.new("2.0")])}
+  end
+
+  test "mean returns decimal instead of float", %{df: df} do
+    assert_raise(
+      RuntimeError,
+      """
+      DataFrame mismatch.
+
+      expected:
+
+          names: ["a"]
+          dtypes: %{"a" => {:f, 64}}
+
+      got:
+
+          names: ["a"]
+          dtypes: %{"a" => {:decimal, 38, 1}}
+      """,
+      fn -> DF.summarise(df, a: mean(a)) end
+    )
+  end
+
+  test "unchecked mean returns nil", %{df: df} do
+    # Here we recreate the internals of `DF.summarise(df, a: mean(a))` to avoid
+    # the invalid dtype expectation. What we should get is a decimal that
+    # represents the mean, but what we do get is `nil`.
+    qf = Explorer.Query.new(df)
+    ldf = PolarsBackend.DataFrame.lazy(df)
+    lazy_mean_a = Explorer.Series.mean(qf["a"])
+
+    expr =
+      lazy_mean_a.data
+      |> PolarsBackend.Expression.to_expr()
+      |> PolarsBackend.Expression.alias_expr("a")
+
+    df =
+      with {:ok, pdf1} <- PolarsBackend.Native.lf_summarise_with(ldf.data, [], [expr]),
+           {:ok, pdf2} <- PolarsBackend.Native.lf_compute(pdf1),
+           do: PolarsBackend.Shared.create_dataframe!(pdf2)
+
+    assert Explorer.Series.to_list(df["a"]) == [nil]
+  end
+end


### PR DESCRIPTION
Discussed here: https://github.com/elixir-explorer/explorer/issues/1018#issuecomment-2508583403

Adds a test module and a warning to the moduledoc:

<img width="826" alt="Screen Shot 2024-11-30 at 11 29 17 AM" src="https://github.com/user-attachments/assets/998078f3-816d-478e-ba0a-775b71abdd6b">