### PR TITLE
Add method to estimate DataFrame memory use

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -168,6 +168,7 @@ defmodule Explorer.Backend.DataFrame do
   # Introspection
 
   @callback n_rows(df) :: integer()
+  @callback estimated_size(df) :: integer()
   @callback inspect(df, opts :: Inspect.Opts.t()) :: Inspect.Algebra.t()
   @callback re_dtype(String.t()) :: dtype()
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2104,6 +2104,15 @@ defmodule Explorer.DataFrame do
   @spec n_columns(df :: DataFrame.t()) :: integer()
   def n_columns(df), do: map_size(df.dtypes)
 
+  @doc """
+  Returns an estimation of the total (heap) allocated byte size of the DataFrame.
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.new(%{integers: 0..255}, dtypes: [{:integers, {:s, 8}}])
+      iex> Explorer.DataFrame.estimated_size(df)
+      256
+  """
   @doc type: :introspection
   @spec estimated_size(df :: DataFrame.t()) :: integer()
   def estimated_size(df), do: Shared.apply_dataframe(df, :estimated_size)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2104,6 +2104,10 @@ defmodule Explorer.DataFrame do
   @spec n_columns(df :: DataFrame.t()) :: integer()
   def n_columns(df), do: map_size(df.dtypes)
 
+  @doc type: :introspection
+  @spec estimated_size(df :: DataFrame.t()) :: integer()
+  def estimated_size(df), do: Shared.apply_dataframe(df, :estimated_size)
+
   @doc """
   Returns the groups of a dataframe.
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -614,6 +614,9 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @impl true
   def n_rows(df), do: Shared.apply_dataframe(df, :df_n_rows)
 
+  @impl true
+  def estimated_size(df), do: Shared.apply_dataframe(df, :df_estimated_size)
+
   # Single table verbs
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -646,6 +646,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     dump_parquet: 2,
     mask: 2,
     n_rows: 1,
+    estimated_size: 1,
     pivot_wider: 5,
     pull: 2,
     put: 4,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -169,6 +169,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_parquet(_df, _filename, _compression), do: err()
   def df_to_parquet_cloud(_df, _ex_entry, _compression), do: err()
   def df_width(_df), do: err()
+  def df_estimated_size(_df), do: err()
   def df_nil_count(_df), do: err()
   def df_re_dtype(_pattern), do: err()
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -63,6 +63,11 @@ pub fn df_width(df: ExDataFrame) -> Result<usize, ExplorerError> {
     Ok(df.width())
 }
 
+#[rustler::nif]
+pub fn df_estimated_size(df: ExDataFrame) -> Result<usize, ExplorerError> {
+    Ok(df.estimated_size())
+}
+
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_concat_columns(dfs: Vec<ExDataFrame>) -> Result<ExDataFrame, ExplorerError> {
     let mut previous_names = PlHashSet::new();

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -29,6 +29,12 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
+  test "estimated_size/1" do
+    df = DF.new(%{integers: 0..255}, dtypes: [{:integers, {:s, 8}}])
+    assert DF.dtypes(df) == %{"integers" => {:s, 8}}
+    assert DF.estimated_size(df) == 256
+  end
+
   describe "from_query/3" do
     alias Adbc.{Database, Connection}
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -29,12 +29,6 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
-  test "estimated_size/1" do
-    df = DF.new(%{integers: 0..255}, dtypes: [{:integers, {:s, 8}}])
-    assert DF.dtypes(df) == %{"integers" => {:s, 8}}
-    assert DF.estimated_size(df) == 256
-  end
-
   describe "from_query/3" do
     alias Adbc.{Database, Connection}
 


### PR DESCRIPTION
See:
- #1032 

This adds `Explorer.DataFrame.estimated_sized/1`, which leverages https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.estimated_size.html (thanks @billylanchantin for the pointer) to "return an estimation of the total (heap) allocated size of the DataFrame".