### PR TITLE
Add Regex as a valid column type in typespec

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -239,6 +239,7 @@ defmodule Explorer.DataFrame do
   @type columns ::
           [column]
           | Range.t()
+          | Regex.t()
           | (String.t() -> boolean())
           | (String.t(), Explorer.Series.dtype() -> boolean())
 


### PR DESCRIPTION
Dialyzer is complaining when we pass a regular expression to functions like `Explorer.DataFrame.select/2`, even though the [documentation](https://hexdocs.pm/explorer/Explorer.DataFrame.html#select/2) says it's a valid argument.

It closes https://github.com/elixir-explorer/explorer/issues/1036.