### PR TITLE
added error message text to exploring_explorer.livemd

### DIFF
--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -484,6 +484,8 @@ s1 = Series.from_list(["a", "b", "c"])
 Series.add(s, s1)
 ```
 
+> cannot invoke Explorer.Series.add/2 with mismatched dtypes: {:s, 64} and :string
+
 You can flip them around.
 
 ```elixir
@@ -967,6 +969,8 @@ Remember those helpful error messages?
 # Notice that the following typo is intentional here.
 DF.filter(df, cuontry == "BRAZIL")
 ```
+
+> could not find column name "cuontry". Did you mean: "country"
 
 ### Mutate
 
@@ -1525,6 +1529,8 @@ Trying for those helpful error messages again.
 ```elixir
 DF.sample(df, 10000)
 ```
+
+> in order to sample more rows than are in the dataframe (1094), sampling `replace` must be true
 
 ```elixir
 DF.sample(df, 10000, replace: true)


### PR DESCRIPTION
Overall I think this "Ten Minutes to Explorer" article is great, but there was one thing I thought could be improved. 

Four times it's mentioned that the user will get helpful error messages. The first time it's mentioned, we get to see the error message, and can see that it is indeed helpful. 

The other 3 times, we're told we'll get helpful error messages, plus shown code that would trigger the error, but then it just goes on without actually showing the error message text and it left me unsure if that part was done, or the next part was still a continuation of the error message example. Because there's the setup for an error message, and we're shown code that would trigger an error message, my brain is expecting to see the error message to conclude that idea/section.

So all this PR does is add 1 line of text to the end of those last 3 error message examples, that shows the actual error message text, in the same style as it appears in the first example.