### PR TITLE
Fix `ungroup` spec

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5625,7 +5625,10 @@ defmodule Explorer.DataFrame do
 
   """
   @doc type: :single
-  @spec ungroup(df :: DataFrame.t(), groups_or_group :: column_names() | column_name()) ::
+  @spec ungroup(
+          df :: DataFrame.t(),
+          groups_or_group :: column_names() | column_name() | Range.t() | fun()
+        ) ::
           DataFrame.t()
   def ungroup(df, groups \\ ..)
 

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -66,6 +66,17 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.groups(df2) == []
     end
 
+    test "ungroup by range", %{df: df} do
+      df1 = DF.group_by(df, ["country", "year"])
+      df2 = DF.ungroup(df1, 1..1)
+
+      # Note: the range selected the column at index 1 of `df.names` to ungroup,
+      # not `df.groups`.
+      assert Enum.take(df.names, 2) == ["year", "country"]
+      assert df2.groups == ["year"]
+      assert DF.groups(df2) == ["year"]
+    end
+
     test "raise error for unknown groups", %{df: df} do
       df1 = DF.group_by(df, ["country", "year"])
 


### PR DESCRIPTION
Fixes: https://github.com/elixir-explorer/explorer/issues/1055

@josevalim Sorry for the unnecessary discussion on that issue. Turns out the semantics of non-empty ranges were already present (note: it's different than what we discussed). I just didn't notice.

I've added a test to clarify.