### PR TITLE
Better `concat_rows` error messages

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5437,107 +5437,99 @@ defmodule Explorer.DataFrame do
   @doc type: :multi
   @spec concat_rows([DataFrame.t()]) :: DataFrame.t()
   def concat_rows([%DataFrame{} = head | _tail] = dfs) do
-    with :ok <- ensure_column_names_match(dfs),
-         {:ok, changed_types} <- compute_changed_types_concat_rows(dfs) do
-      out_df = out_df(head, head.names, Map.merge(head.dtypes, changed_types))
+    changed_types = compute_changed_types_concat_rows(dfs)
+    out_df = out_df(head, head.names, Map.merge(head.dtypes, changed_types))
 
-      dfs =
-        if changed_types == %{} do
-          dfs
-        else
-          for df <- dfs do
-            mutate_with(ungroup(df), fn ldf ->
-              for {column, target_type} <- changed_types,
-                  do: {column, Series.cast(ldf[column], target_type)}
-            end)
-          end
-        end
-
-      Shared.apply_dataframe(dfs, :concat_rows, [out_df])
-    else
-      {:error, message} -> raise ArgumentError, message
-    end
-  end
-
-  defp ensure_column_names_match([head | tail]) do
-    df_0_cols = head |> names() |> MapSet.new()
-
-    tail
-    |> Enum.with_index(1)
-    |> Enum.reduce_while(:ok, fn {df, index}, :ok ->
-      df_i_cols = df |> names() |> MapSet.new()
-
-      if MapSet.equal?(df_0_cols, df_i_cols) do
-        {:cont, :ok}
+    dfs =
+      if changed_types == %{} do
+        dfs
       else
-        mismatched_cols = MapSet.symmetric_difference(df_0_cols, df_i_cols)
-        in_0_only = df_0_cols |> MapSet.intersection(mismatched_cols) |> Enum.sort()
-        in_i_only = df_i_cols |> MapSet.intersection(mismatched_cols) |> Enum.sort()
-
-        message_0 =
-          if in_0_only == [] do
-            ""
-          else
-            """
-
-            * dataframe 0 has these columns not present in dataframe #{index}:
-
-                #{inspect(in_0_only)}
-            """
-          end
-
-        message_i =
-          if in_i_only == [] do
-            ""
-          else
-            """
-
-            * dataframe #{index} has these columns not present in dataframe 0:
-
-                #{inspect(in_i_only)}
-            """
-          end
-
-        message = "dataframes must have the same columns\n#{message_0}#{message_i}"
-        {:halt, {:error, message}}
+        for df <- dfs do
+          mutate_with(ungroup(df), fn ldf ->
+            for {column, target_type} <- changed_types,
+                do: {column, Series.cast(ldf[column], target_type)}
+          end)
+        end
       end
-    end)
+
+    Shared.apply_dataframe(dfs, :concat_rows, [out_df])
   end
 
   defp compute_changed_types_concat_rows([head | tail]) do
+    types = head.dtypes
+
     tail
     |> Enum.with_index(1)
-    |> Enum.reduce_while({:ok, %{}}, fn {df, index}, {:ok, changed_types} ->
-      Enum.reduce_while(df.dtypes, changed_types, fn {name, type}, changed_types ->
-        # This runs after `ensure_column_names_match`, so we can `fetch!` here.
-        current_type = Map.fetch!(head.dtypes, name)
+    |> Enum.reduce(%{}, fn {df, index}, changed_types ->
+      if n_columns(df) != map_size(types) do
+        raise ArgumentError, concat_rows_mismatched_columns_message(head, df, index)
+      end
 
-        if dtype = Shared.merge_dtype(Map.get(changed_types, name, current_type), type) do
-          {:cont, Map.put(changed_types, name, dtype)}
-        else
-          message =
-            """
-            column dtypes must be compatible for all dataframes
+      Enum.reduce(df.dtypes, changed_types, fn {name, type}, changed_types ->
+        case types do
+          %{^name => current_type} ->
+            if dtype = Shared.merge_dtype(Map.get(changed_types, name, current_type), type) do
+              Map.put(changed_types, name, dtype)
+            else
+              raise ArgumentError,
+                    concat_rows_incompatible_dtypes_message(name, current_type, type, index)
+            end
 
-            * dataframe 0, column #{name} has dtype:
-
-                #{inspect(current_type)}
-
-            * dataframe #{index}, column #{name} has dtype:
-
-                #{inspect(dtype)}
-
-            these types are incompatible
-            """
-
-          {:halt, {:error, message}}
+          %{} ->
+            raise ArgumentError, concat_rows_mismatched_columns_message(head, df, index)
         end
       end)
-      |> case do
-        {:error, message} -> {:halt, {:error, message}}
-        %{} = changed_types -> {:cont, {:ok, changed_types}}
-      end
     end)
+  end
+
+  defp concat_rows_mismatched_columns_message(df_0, df_i, i) do
+    df_0_cols = df_0 |> names() |> MapSet.new()
+    df_i_cols = df_i |> names() |> MapSet.new()
+    mismatched_cols = MapSet.symmetric_difference(df_0_cols, df_i_cols)
+    in_0_only = df_0_cols |> MapSet.intersection(mismatched_cols) |> Enum.sort()
+    in_i_only = df_i_cols |> MapSet.intersection(mismatched_cols) |> Enum.sort()
+
+    message_0 =
+      if in_0_only == [] do
+        ""
+      else
+        """
+
+        * dataframe 0 has these columns not present in dataframe #{i}:
+
+            #{inspect(in_0_only)}
+        """
+      end
+
+    message_i =
+      if in_i_only == [] do
+        ""
+      else
+        """
+
+        * dataframe #{i} has these columns not present in dataframe 0:
+
+            #{inspect(in_i_only)}
+        """
+      end
+
+    "dataframes must have the same columns\n#{message_0}#{message_i}"
+  end
+
+  defp concat_rows_incompatible_dtypes_message(column_name, df_0_dtype, df_i_dtype, i) do
+    """
+    column dtypes must be compatible for all dataframes
+
+    * dataframe 0, column #{column_name} has dtype:
+
+        #{inspect(df_0_dtype)}
+
+    * dataframe #{i}, column #{column_name} has dtype:
+
+        #{inspect(df_i_dtype)}
+
+    these types are incompatible
+    """
   end
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5460,10 +5460,11 @@ defmodule Explorer.DataFrame do
   end
 
   defp ensure_column_names_match([head | tail]) do
+    df_0_cols = head |> names() |> MapSet.new()
+
     tail
     |> Enum.with_index(1)
     |> Enum.reduce_while(:ok, fn {df, index}, :ok ->
-      df_0_cols = head |> names() |> MapSet.new()
       df_i_cols = df |> names() |> MapSet.new()
 
       if MapSet.equal?(df_0_cols, df_i_cols) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5520,11 +5520,11 @@ defmodule Explorer.DataFrame do
     """
     column dtypes must be compatible for all dataframes
 
-    * dataframe 0, column #{column_name} has dtype:
+    * dataframe 0, column #{inspect(column_name)} has dtype:
 
         #{inspect(df_0_dtype)}
 
-    * dataframe #{i}, column #{column_name} has dtype:
+    * dataframe #{i}, column #{inspect(column_name)} has dtype:
 
         #{inspect(df_i_dtype)}
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5517,7 +5517,7 @@ defmodule Explorer.DataFrame do
         else
           message =
             """
-            columns dtypes must be compatible for all dataframes
+            column dtypes must be compatible for all dataframes
 
             * dataframe 0, column #{name} has dtype:
 

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -1525,7 +1525,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
                    * dataframe 1, column y has dtype:
 
-                       nil
+                       {:s, 64}
 
                    these types are incompatible
                    """,

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -1519,11 +1519,11 @@ defmodule Explorer.DataFrame.LazyTest do
                    """
                    column dtypes must be compatible for all dataframes
 
-                   * dataframe 0, column y has dtype:
+                   * dataframe 0, column \"y\" has dtype:
 
                        :string
 
-                   * dataframe 1, column y has dtype:
+                   * dataframe 1, column \"y\" has dtype:
 
                        {:s, 64}
 

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -1517,7 +1517,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
       assert_raise ArgumentError,
                    """
-                   columns dtypes must be compatible for all dataframes
+                   column dtypes must be compatible for all dataframes
 
                    * dataframe 0, column y has dtype:
 

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -1476,15 +1476,59 @@ defmodule Explorer.DataFrame.LazyTest do
       df1 = DF.new([x: [7, 8, 9], y: ["g", "h", nil]], lazy: true)
 
       assert_raise ArgumentError,
-                   "dataframes must have the same columns",
+                   """
+                   dataframes must have the same columns
+
+                   * dataframe 0 has these columns not present in dataframe 1:
+
+                       [\"x\", \"y\"]
+
+                   * dataframe 1 has these columns not present in dataframe 0:
+
+                       [\"z\"]
+                   """,
                    fn -> DF.concat_rows(df1, DF.new([z: [7, 8, 9]], lazy: true)) end
 
       assert_raise ArgumentError,
-                   "dataframes must have the same columns",
+                   """
+                   dataframes must have the same columns
+
+                   * dataframe 0 has these columns not present in dataframe 1:
+
+                       [\"y\"]
+
+                   * dataframe 1 has these columns not present in dataframe 0:
+
+                       [\"z\"]
+                   """,
                    fn -> DF.concat_rows(df1, DF.new([x: [7, 8, 9], z: [7, 8, 9]], lazy: true)) end
 
       assert_raise ArgumentError,
-                   "columns and dtypes must be identical for all dataframes",
+                   """
+                   dataframes must have the same columns
+
+                   * dataframe 1 has these columns not present in dataframe 0:
+
+                       [\"z\"]
+                   """,
+                   fn ->
+                     DF.concat_rows(df1, DF.new([x: [7], y: [8], z: [9]], lazy: true))
+                   end
+
+      assert_raise ArgumentError,
+                   """
+                   columns dtypes must be compatible for all dataframes
+
+                   * dataframe 0, column y has dtype:
+
+                       :string
+
+                   * dataframe 1, column y has dtype:
+
+                       nil
+
+                   these types are incompatible
+                   """,
                    fn ->
                      DF.concat_rows(df1, DF.new([x: [7, 8, 9], y: [10, 11, 12]], lazy: true))
                    end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2883,7 +2883,17 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.new(x: [1, 2, 3], y: ["a", "b", "c"])
 
       assert_raise ArgumentError,
-                   "dataframes must have the same columns",
+                   """
+                   dataframes must have the same columns
+
+                   * dataframe 0 has these columns not present in dataframe 1:
+
+                       [\"x\", \"y\"]
+
+                   * dataframe 1 has these columns not present in dataframe 0:
+
+                       [\"z\"]
+                   """,
                    fn -> DF.concat_rows(df1, DF.new(z: [7, 8, 9])) end
     end
 
@@ -2891,7 +2901,19 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.new(x: [1, 2, 3], y: ["a", "b", "c"])
 
       assert_raise ArgumentError,
-                   "columns and dtypes must be identical for all dataframes",
+                   """
+                   columns dtypes must be compatible for all dataframes
+
+                   * dataframe 0, column y has dtype:
+
+                       :string
+
+                   * dataframe 1, column y has dtype:
+
+                       nil
+
+                   these types are incompatible
+                   """,
                    fn -> DF.concat_rows(df1, DF.new(x: [7, 8, 9], y: [10, 11, 12])) end
     end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2904,11 +2904,11 @@ defmodule Explorer.DataFrameTest do
                    """
                    column dtypes must be compatible for all dataframes
 
-                   * dataframe 0, column y has dtype:
+                   * dataframe 0, column \"y\" has dtype:
 
                        :string
 
-                   * dataframe 1, column y has dtype:
+                   * dataframe 1, column \"y\" has dtype:
 
                        {:s, 64}
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2910,7 +2910,7 @@ defmodule Explorer.DataFrameTest do
 
                    * dataframe 1, column y has dtype:
 
-                       nil
+                       {:s, 64}
 
                    these types are incompatible
                    """,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2902,7 +2902,7 @@ defmodule Explorer.DataFrameTest do
 
       assert_raise ArgumentError,
                    """
-                   columns dtypes must be compatible for all dataframes
+                   column dtypes must be compatible for all dataframes
 
                    * dataframe 0, column y has dtype:
 


### PR DESCRIPTION
Fixes: https://github.com/elixir-explorer/explorer/issues/1023

Example:

```elixir
df0 = DF.new([x: [1, 2, 3], y: ["g", "h", nil]])
df1 = DF.new([z: [4, 5, 6]])
DF.concat_rows(df0, df1)
```

```
dataframes must have the same columns

* dataframe 0 has these columns not present in dataframe 1:

    ["x", "y"]

* dataframe 1 has these columns not present in dataframe 0:

    ["z"]
```