### PR TITLE
Raise on out of bounds range access

### DIFF
--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -210,9 +210,14 @@ defmodule Explorer.Shared do
   def to_existing_columns(%{names: names} = df, %Range{} = columns, raise?) do
     if raise? do
       n_cols = Explorer.DataFrame.n_columns(df)
-      existing_columns = 0..(n_cols - 1)
 
-      if Enum.any?(columns, &(&1 not in existing_columns)) do
+      # With `Enum.slice/2`, negative indexes are counted from the end.
+      [slice_min, slice_max] =
+        [columns.first, columns.last]
+        |> Enum.map(&if(&1 < 0, do: n_cols + &1, else: &1))
+        |> Enum.sort()
+
+      if slice_min < 0 or slice_max >= n_cols do
         raise ArgumentError,
               "range #{inspect(columns)} is out of bounds for a dataframe with #{n_cols} columns"
       end

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -207,15 +207,17 @@ defmodule Explorer.Shared do
     names
   end
 
-  def to_existing_columns(%{names: names} = df, %Range{} = columns, raise?) do
+  def to_existing_columns(%{names: names} = df, first..last//step = columns, raise?) do
     if raise? do
       n_cols = Explorer.DataFrame.n_columns(df)
 
       # With `Enum.slice/2`, negative indices are counted from the end.
-      [slice_min, slice_max] =
-        [columns.first, columns.last]
+      [slice_min, slice_pseudo_max] =
+        [first, last]
         |> Enum.map(&if(&1 < 0, do: n_cols + &1, else: &1))
         |> Enum.sort()
+
+      slice_max = slice_min + step * (Range.size(slice_min..slice_pseudo_max//step) - 1)
 
       if slice_min < 0 or slice_max >= n_cols do
         raise ArgumentError,

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -207,7 +207,17 @@ defmodule Explorer.Shared do
     names
   end
 
-  def to_existing_columns(%{names: names}, %Range{} = columns, _raise?) do
+  def to_existing_columns(%{names: names} = df, %Range{} = columns, raise?) do
+    if raise? do
+      n_cols = Explorer.DataFrame.n_columns(df)
+      existing_columns = 0..(n_cols - 1)
+
+      if Enum.any?(columns, &(&1 not in existing_columns)) do
+        raise ArgumentError,
+              "range #{inspect(columns)} is out of bounds for a dataframe with #{n_cols} columns"
+      end
+    end
+
     Enum.slice(names, columns)
   end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -211,7 +211,7 @@ defmodule Explorer.Shared do
     if raise? do
       n_cols = Explorer.DataFrame.n_columns(df)
 
-      # With `Enum.slice/2`, negative indexes are counted from the end.
+      # With `Enum.slice/2`, negative indices are counted from the end.
       [slice_min, slice_max] =
         [columns.first, columns.last]
         |> Enum.map(&if(&1 < 0, do: n_cols + &1, else: &1))
@@ -219,7 +219,7 @@ defmodule Explorer.Shared do
 
       if slice_min < 0 or slice_max >= n_cols do
         raise ArgumentError,
-              "range #{inspect(columns)} is out of bounds for a dataframe with #{n_cols} columns"
+              "range #{inspect(columns)} is out of bounds for a dataframe with #{n_cols} column(s)"
       end
     end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -217,7 +217,7 @@ defmodule Explorer.Shared do
         |> Enum.map(&if(&1 < 0, do: n_cols + &1, else: &1))
         |> Enum.sort()
 
-      slice_max = slice_min + step * (Range.size(slice_min..slice_pseudo_max//step) - 1)
+      slice_max = slice_min + abs(step) * (Range.size(slice_min..slice_pseudo_max//abs(step)) - 1)
 
       if slice_min < 0 or slice_max >= n_cols do
         raise ArgumentError,

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -902,7 +902,7 @@ defmodule Explorer.DataFrame.LazyTest do
       assert DF.names(df3) == DF.names(df)
 
       assert_raise ArgumentError,
-                   ~r"range 100..200 is out of bounds for a dataframe with 10 columns",
+                   "range 100..200 is out of bounds for a dataframe with 10 column(s)",
                    fn -> DF.distinct(df, 100..200) end
     end
   end

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -901,7 +901,9 @@ defmodule Explorer.DataFrame.LazyTest do
       df3 = DF.distinct(df, ..)
       assert DF.names(df3) == DF.names(df)
 
-      assert df == DF.distinct(df, 100..200)
+      assert_raise ArgumentError,
+                   ~r"range 100..200 is out of bounds for a dataframe with 10 columns",
+                   fn -> DF.distinct(df, 100..200) end
     end
   end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2716,11 +2716,11 @@ defmodule Explorer.DataFrameTest do
                  fn -> df[:class] end
 
     assert_raise ArgumentError,
-                 ~r"range 0..3 is out of bounds for a dataframe with 3 columns",
+                 "range 0..3 is out of bounds for a dataframe with 3 column(s)",
                  fn -> DF.to_columns(df[0..3]) end
 
     assert_raise ArgumentError,
-                 ~r"range 0..-4//1 is out of bounds for a dataframe with 3 columns",
+                 "range 0..-4//1 is out of bounds for a dataframe with 3 column(s)",
                  fn -> DF.to_columns(df[0..-4//1]) end
   end
 
@@ -2968,7 +2968,7 @@ defmodule Explorer.DataFrameTest do
       assert DF.names(df3) == DF.names(df)
 
       assert_raise ArgumentError,
-                   ~r"range 100..200 is out of bounds for a dataframe with 10 columns",
+                   "range 100..200 is out of bounds for a dataframe with 10 column(s)",
                    fn -> DF.drop_nil(df, 100..200) end
     end
   end
@@ -2992,7 +2992,7 @@ defmodule Explorer.DataFrameTest do
 
     # It takes the slice of columns in the range
     assert_raise ArgumentError,
-                 ~r"range 0..200 is out of bounds for a dataframe with 2 columns",
+                 "range 0..200 is out of bounds for a dataframe with 2 column(s)",
                  fn -> DF.drop_nil(df, 0..200) end
   end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2690,6 +2690,7 @@ defmodule Explorer.DataFrameTest do
     assert DF.to_columns(df[[:a, :c]]) == %{"a" => [1, 2, 3], "c" => [4.0, 5.1, 6.2]}
     assert DF.to_columns(df[0..-2//1]) == %{"a" => [1, 2, 3], "b" => ["a", "b", "c"]}
     assert DF.to_columns(df[-3..-1]) == DF.to_columns(df)
+    assert DF.to_columns(df[1..3//3]) == %{"b" => ["a", "b", "c"]}
     assert DF.to_columns(df[..]) == DF.to_columns(df)
 
     assert %Series{} = s1 = df[0]

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2716,8 +2716,12 @@ defmodule Explorer.DataFrameTest do
                  fn -> df[:class] end
 
     assert_raise ArgumentError,
-                 ~r"range 0..100 is out of bounds for a dataframe with 3 columns",
-                 fn -> DF.to_columns(df[0..100]) end
+                 ~r"range 0..3 is out of bounds for a dataframe with 3 columns",
+                 fn -> DF.to_columns(df[0..3]) end
+
+    assert_raise ArgumentError,
+                 ~r"range 0..-4//1 is out of bounds for a dataframe with 3 columns",
+                 fn -> DF.to_columns(df[0..-4//1]) end
   end
 
   test "pop/2" do
@@ -2963,7 +2967,9 @@ defmodule Explorer.DataFrameTest do
       df3 = DF.distinct(df, ..)
       assert DF.names(df3) == DF.names(df)
 
-      assert df == DF.distinct(df, 100..200)
+      assert_raise ArgumentError,
+                   ~r"range 100..200 is out of bounds for a dataframe with 10 columns",
+                   fn -> DF.drop_nil(df, 100..200) end
     end
   end
 
@@ -2985,8 +2991,9 @@ defmodule Explorer.DataFrameTest do
                  fn -> DF.drop_nil(df, [3, 4, 5]) end
 
     # It takes the slice of columns in the range
-    df4 = DF.drop_nil(df, 0..200)
-    assert DF.to_columns(df4) == %{"a" => [1], "b" => [1]}
+    assert_raise ArgumentError,
+                 ~r"range 0..200 is out of bounds for a dataframe with 2 columns",
+                 fn -> DF.drop_nil(df, 0..200) end
   end
 
   describe "relocate/3" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2689,8 +2689,6 @@ defmodule Explorer.DataFrameTest do
     assert DF.to_columns(df[["a"]]) == %{"a" => [1, 2, 3]}
     assert DF.to_columns(df[[:a, :c]]) == %{"a" => [1, 2, 3], "c" => [4.0, 5.1, 6.2]}
     assert DF.to_columns(df[0..-2//1]) == %{"a" => [1, 2, 3], "b" => ["a", "b", "c"]}
-    assert DF.to_columns(df[-3..-1]) == DF.to_columns(df)
-    assert DF.to_columns(df[1..3//3]) == %{"b" => ["a", "b", "c"]}
     assert DF.to_columns(df[..]) == DF.to_columns(df)
 
     assert %Series{} = s1 = df[0]
@@ -2723,6 +2721,17 @@ defmodule Explorer.DataFrameTest do
     assert_raise ArgumentError,
                  "range 0..-4//1 is out of bounds for a dataframe with 3 column(s)",
                  fn -> DF.to_columns(df[0..-4//1]) end
+
+    assert_raise ArgumentError,
+                 "range -3..-1 is out of bounds for a dataframe with 3 column(s)",
+                 fn -> DF.to_columns(df[-3..-1]) end
+
+    # Note: Even though `Enum.to_list(1..3//3) == [1]`, we still classify this
+    # range as out of bounds because we define in bounds as both limits of the
+    # range being in bounds.
+    assert_raise ArgumentError,
+                 "range 1..3//3 is out of bounds for a dataframe with 3 column(s)",
+                 fn -> DF.to_columns(df[1..3//3]) end
   end
 
   test "pop/2" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2715,7 +2715,9 @@ defmodule Explorer.DataFrameTest do
                  ~r"could not find column name \"class\"",
                  fn -> df[:class] end
 
-    assert DF.to_columns(df[0..100]) == DF.to_columns(df)
+    assert_raise ArgumentError,
+                 ~r"range 0..100 is out of bounds for a dataframe with 3 columns",
+                 fn -> DF.to_columns(df[0..100]) end
   end
 
   test "pop/2" do


### PR DESCRIPTION
Fixes: https://github.com/elixir-explorer/explorer/issues/1005

In the example from that issue we now get:

```elixir
iex> df = Explorer.DataFrame.new(a: [1, 2, 3])
iex> df[1..1]
# ** (ArgumentError) range 1..1 is out of bounds for a dataframe with 1 column(s)
#     (explorer 0.11.0-dev) lib/explorer/shared.ex:221: Explorer.Shared.to_existing_columns/3
#     (explorer 0.11.0-dev) lib/explorer/data_frame.ex:387: Explorer.DataFrame.fetch/2
#     (elixir 1.18.1) lib/access.ex:322: Access.get/3
#     iex:3: (file)
```