### PR TITLE
Add `DF.table_string/2`

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -6039,7 +6039,7 @@ defmodule Explorer.DataFrame do
       `:limit` rows above the `…` and half below. The top half comes from the
       head of the dataframe and the bottom from the tail. Defaults to `:split`.
 
-  Also, any valid option to `TableRex.render!/2` will be accepted and will
+  Also, any valid option to `TableRex.Table.render!/2` will be accepted and will
   override the defaults.
 
   ## Examples
@@ -6116,7 +6116,7 @@ defmodule Explorer.DataFrame do
       \"\"\"
 
   This behavior can be overriden with the `:horizontal_style` option to
-  `TableRex.render!/2`.
+  `TableRex.Table.render!/2`.
   """
   @doc type: :introspection
   @spec table_string(df :: DataFrame.t(), opts :: Keyword.t()) :: String.t()

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -6094,25 +6094,25 @@ defmodule Explorer.DataFrame do
   Row separators are included by default when the DataFrame has struct or list
   dtype columns since they tend to require multiple rows to print:
 
-      iex> data = [a: [1, 2], b: [%{"key1" => [4], "key2" => [5]}, %{"key1" => [6], "key2" => [7]}]]
+      iex> data = [col: [%{"key1" => [3], "key2" => [4]}, %{"key1" => [5], "key2" => [6]}]]
       iex> data |> Explorer.DataFrame.new() |> Explorer.DataFrame.table_string()
       \"\"\"
       +-------------------------------------------+
-      | Explorer DataFrame: [rows: 2, columns: 2] |
-      +------------------+------------------------+
-      |        a         |           b            |
-      |      <s64>       |      <struct[2]>       |
-      +==================+========================+
-      | 1                | {                      |
-      |                  |  key1: [4]             |
-      |                  |  key2: [5]             |
-      |                  | }                      |
-      +------------------+------------------------+
-      | 2                | {                      |
-      |                  |  key1: [6]             |
-      |                  |  key2: [7]             |
-      |                  | }                      |
-      +------------------+------------------------+
+      | Explorer DataFrame: [rows: 2, columns: 1] |
+      +-------------------------------------------+
+      |                    col                    |
+      |                <struct[2]>                |
+      +===========================================+
+      | {                                         |
+      |  key1: [3]                                |
+      |  key2: [4]                                |
+      | }                                         |
+      +-------------------------------------------+
+      | {                                         |
+      |  key1: [5]                                |
+      |  key2: [6]                                |
+      | }                                         |
+      +-------------------------------------------+
       \"\"\"
 
   This behavior can be overriden with the `:horizontal_style` option to


### PR DESCRIPTION
Adds `table_string/2` that formats the DataFrames for printing. This way we can include doctests which help with documentation.

It may also be useful for testing.