### PR TITLE
Working macos lib config based on elixir-nx/ortex

### DIFF
--- a/native/explorer/.cargo/config.toml
+++ b/native/explorer/.cargo/config.toml
@@ -1,3 +1,12 @@
+# https://github.com/elixir-nx/ortex/blob/main/native/ortex/.cargo/config.toml
+[target.'cfg(target_os = "macos")']
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+    "-C", "link-arg=-fapple-link-rtlib",
+    "-C", "link-args=-Wl,-rpath,@loader_path",
+]
+
 # See https://github.com/rust-lang/rust/issues/59302
 [target.x86_64-unknown-linux-musl]
 rustflags = [

--- a/native/explorer/.cargo/config.toml
+++ b/native/explorer/.cargo/config.toml
@@ -1,4 +1,4 @@
-# https://github.com/elixir-nx/ortex/blob/main/native/ortex/.cargo/config.toml
+# Working config: https://github.com/elixir-nx/ortex/blob/main/native/ortex/.cargo/config.toml
 [target.'cfg(target_os = "macos")']
 rustflags = [
     "-C", "link-arg=-undefined",


### PR DESCRIPTION
I was using explorer as a reference to implement rustler_btleplug
But couldn't get it working with elixir-desktop. The elixir-nx/ortex config allowed me to get rustler_btleplug working. 

Was also using explorer to test on elixir-desktop but with same problem. the ortex config solves that issue