### PR TITLE
docs: fix formatting of mutate_with options

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2873,12 +2873,12 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `keep` - Controls which columns should be kept in the resulting dataframe.
-      Supported options for keep are:
+  * `keep` - Controls which columns should be kept in the resulting dataframe.
+    Supported options for keep are:
 
-      * `:all` - Retains all columns from the input dataframe (default).
-      * `:none` - Retains only the columns created by the mutation (and
-                  grouping columns if operating on a grouped DataFrame).
+    * `:all` - Retains all columns from the input dataframe (default).
+    * `:none` - Retains only the columns created by the mutation (and
+      grouping columns if operating on a grouped DataFrame).
 
   ## Examples
 


### PR DESCRIPTION
Bullet items need to be indented consistently or else they might be converted into code blocks (4 space indented)
