### PR TITLE
Implement `fill_missing` for all float types

### DIFF
--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -500,11 +500,29 @@ pub fn s_fill_missing_with_strategy(
     Ok(ExSeries::new(series.fill_null(strat)?))
 }
 
+// Used for the non-finite atoms: [`:nan`, `:infinity`, `:neg_infinity`].
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_fill_missing_with_atom(series: ExSeries, atom: &str) -> Result<ExSeries, ExplorerError> {
-    let value = cast_str_to_f64(atom);
-    let s = series.f64()?.fill_null_with_values(value)?.into_series();
-    Ok(ExSeries::new(s))
+pub fn s_fill_missing_with_atom(
+    ex_series: ExSeries,
+    atom: &str,
+) -> Result<ExSeries, ExplorerError> {
+    let filled_series = match ex_series.dtype() {
+        DataType::Float32 => ex_series
+            .f32()?
+            .fill_null_with_values(cast_str_to_f32(atom))?
+            .into_series(),
+        DataType::Float64 => ex_series
+            .f64()?
+            .fill_null_with_values(cast_str_to_f64(atom))?
+            .into_series(),
+        // We shouldn't ever call `Native.s_fill_missing_with_atom/2` from the
+        // Elixir side with a non-float series.
+        other => {
+            panic!("s_fill_missing_with_atom/2 implemented for float types, found: {other:?}")
+        }
+    };
+
+    Ok(ExSeries::new(filled_series))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -582,6 +600,7 @@ pub fn s_fill_missing_with_float(
 // TryFrom is not implemented for f64 -> f32. This is a work around.
 // Adapted from: https://stackoverflow.com/a/72247742/5932228
 fn f64_to_f32(float64: f64) -> f32 {
+    dbg!(float64);
     let float32 = float64 as f32;
     assert_eq!(
         float64.is_finite(),
@@ -1222,6 +1241,15 @@ pub fn s_n_distinct(s: ExSeries) -> Result<usize, ExplorerError> {
 pub fn s_cast(s: ExSeries, to_type: ExSeriesDtype) -> Result<ExSeries, ExplorerError> {
     let dtype = DataType::try_from(&to_type)?;
     Ok(ExSeries::new(s.cast(&dtype)?))
+}
+
+pub fn cast_str_to_f32(atom: &str) -> f32 {
+    match atom {
+        "nan" => f32::NAN,
+        "infinity" => f32::INFINITY,
+        "neg_infinity" => f32::NEG_INFINITY,
+        _ => panic!("unknown literal {atom:?}"),
+    }
 }
 
 pub fn cast_str_to_f64(atom: &str) -> f64 {

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -820,8 +820,13 @@ defmodule Explorer.SeriesTest do
                    fn -> Series.fill_missing(s1, :mean) end
     end
 
-    test "with nan" do
+    test "with nan for f64" do
       s1 = Series.from_list([1.0, 2.0, nil, 4.5])
+      assert Series.fill_missing(s1, :nan) |> Series.to_list() == [1.0, 2.0, :nan, 4.5]
+    end
+
+    test "with nan for f32" do
+      s1 = Series.from_list([1.0, 2.0, nil, 4.5], dtype: :f32)
       assert Series.fill_missing(s1, :nan) |> Series.to_list() == [1.0, 2.0, :nan, 4.5]
     end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -615,8 +615,10 @@ defmodule Explorer.SeriesTest do
     end
 
     test "with float" do
-      s1 = Series.from_list([1.0, 2.0, nil, 4.0])
-      assert Series.fill_missing(s1, 3.5) |> Series.to_list() == [1.0, 2.0, 3.5, 4.0]
+      for float_dtype <- Explorer.Shared.float_types() do
+        series = Series.from_list([1.0, 2.0, nil, 4.0], dtype: float_dtype)
+        assert Series.fill_missing(series, 3.5) |> Series.to_list() == [1.0, 2.0, 3.5, 4.0]
+      end
     end
 
     test "with binary" do


### PR DESCRIPTION
Closes: https://github.com/elixir-explorer/explorer/issues/1081