### PR TITLE
Fix printing lazy data frame with default print options

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -6193,7 +6193,7 @@ defmodule Explorer.DataFrame do
           n_rows(limit_plus_1) <= opts[:limit] ->
             [limit_plus_1]
 
-          opts[:limit_dots] == :split and opts[:limit] >= 2 ->
+          not lazy?(df) and opts[:limit_dots] == :split and opts[:limit] >= 2 ->
             bottom_limit = div(opts[:limit], 2)
             # For odd limits, the extra row goes on top.
             top_limit = opts[:limit] - bottom_limit

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2623,6 +2623,27 @@ defmodule Explorer.DataFrameTest do
              """
     end
 
+    test "works with lazy and default limit value" do
+      df = Datasets.iris() |> DF.lazy()
+
+      assert capture_io(fn -> DF.print(df) end) |> tap(&IO.puts/1) == """
+             +-----------------------------------------------------------------------+
+             |              Explorer DataFrame: [rows: ???, columns: 5]              |
+             +--------------+-------------+--------------+-------------+-------------+
+             | sepal_length | sepal_width | petal_length | petal_width |   species   |
+             |    <f64>     |    <f64>    |    <f64>     |    <f64>    |  <string>   |
+             +==============+=============+==============+=============+=============+
+             | 5.1          | 3.5         | 1.4          | 0.2         | Iris-setosa |
+             | 4.9          | 3.0         | 1.4          | 0.2         | Iris-setosa |
+             | 4.7          | 3.2         | 1.3          | 0.2         | Iris-setosa |
+             | 4.6          | 3.1         | 1.5          | 0.2         | Iris-setosa |
+             | 5.0          | 3.6         | 1.4          | 0.2         | Iris-setosa |
+             | …            | …           | …            | …           | …           |
+             +--------------+-------------+--------------+-------------+-------------+
+
+             """
+    end
+
     test "works with tuple dtypes" do
       df =
         [datetime1: [~N[2023-09-14 00:00:00]], datetime2: [~N[2023-09-14 01:00:00]]]


### PR DESCRIPTION
I encountered the following error when printing a lazyframe

```
** (ArithmeticError) bad argument in arithmetic expression: "???" - 5
    (erts 14.2.5) :erlang.-("???", 5)
    (explorer 0.11.0) lib/explorer/data_frame.ex:6201: Explorer.DataFrame.non_empty_table_string/2
    (explorer 0.11.0) lib/explorer/data_frame.ex:6024: Explorer.DataFrame.print/2
    <rest omitted>
```

This patch only applies the "splitting" behavior to computed frames, because the full size
of a lazy frame is not known.
