### PR TITLE
Use unique tmp file names to avoid race conditions

### DIFF
--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -269,7 +269,7 @@ defmodule Explorer.PolarsBackend.Shared do
   Builds and returns a path for a new file.
 
   It saves in a directory called "elixir-explorer-datasets" inside
-  the `System.tmp_dir()`.
+  the `System.tmp_dir()`, the file name contains a random component to avoid collisions.
   """
   def build_path_for_entry(%FSS.S3.Entry{} = entry) do
     bucket = entry.config.bucket || "default-explorer-bucket"
@@ -278,15 +278,18 @@ defmodule Explorer.PolarsBackend.Shared do
       :crypto.hash(:sha256, entry.config.endpoint <> "/" <> bucket <> "/" <> entry.key)
       |> Base.url_encode64(padding: false)
 
-    id = "s3-file-#{hash}"
+    rand = Base.url_encode64(:crypto.strong_rand_bytes(8), padding: false)
+
+    id = "s3-file-#{hash}-#{rand}"
 
     build_tmp_path(id)
   end
 
   def build_path_for_entry(%FSS.HTTP.Entry{} = entry) do
     hash = :crypto.hash(:sha256, entry.url) |> Base.url_encode64(padding: false)
+    rand = Base.url_encode64(:crypto.strong_rand_bytes(8), padding: false)
 
-    id = "http-file-#{hash}"
+    id = "http-file-#{hash}-#{rand}"
 
     build_tmp_path(id)
   end


### PR DESCRIPTION
## Problem

When multiple concurrent processes read the same S3 file (or HTTP URL), they would all use the same deterministic temporary filename based on the S3 object hash (or HTTP URL). This caused race conditions where one process could delete the temp file after reading it while another was still trying to read it, resulting in "No such file or directory" errors.

See below for a script to reproduce.

## Solution

Modified `Explorer.PolarsBackend.Shared.build_path_for_entry/1` to append a random suffix to the temporary filename, ensuring each download gets a unique path.

## Problem reproduce script

```elixir
Mix.install([
  {:explorer, "~> 0.11.0"}
])

defmodule BugRepro do
  def run do
    # Required env:
    #   S3_CSV_URL (e.g. s3://my-bucket/path/to.csv)
    #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
    # Optional:
    #   AWS_REGION (default: us-east-1), S3_ENDPOINT (default: https://s3.amazonaws.com)
    #   N (default: 20 concurrent tasks)
    s3_url = System.fetch_env!("S3_CSV_URL")

    config = [
      access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
      secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
      region: System.get_env("AWS_REGION") || "us-east-1",
      endpoint: System.get_env("S3_ENDPOINT") || "https://s3.amazonaws.com"
    ]

    n = String.to_integer(System.get_env("N", "20"))
    parent = self()

    tasks =
      for i <- 1..n do
        Task.async(fn ->
          send(parent, {:ready, self(), i})
          receive do :go -> :ok end
          {i, Explorer.DataFrame.from_csv(s3_url, config: config)}
        end)
      end

    for _ <- 1..n do
      receive do {:ready, _pid, _i} -> :ok end
    end

    Enum.each(tasks, fn %Task{pid: pid} -> send(pid, :go) end)

    tasks
    |> Enum.map(&Task.await(&1, :infinity))
    |> Enum.each(fn {i, res} -> IO.inspect(res, label: "task #{i}") end)
  end
end

BugRepro.run()
```