### PR TITLE
Add the option to set the `quote_char` setting when opening a CSV file.

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -60,7 +60,8 @@ defmodule Explorer.Backend.DataFrame do
               columns :: columns_for_io(),
               infer_schema_length :: option(integer()),
               parse_dates :: boolean(),
-              eol_delimiter :: option(String.t())
+              eol_delimiter :: option(String.t()),
+              quote_char :: option(String.t())
             ) :: io_result(df)
   @callback to_csv(
               df,
@@ -91,7 +92,8 @@ defmodule Explorer.Backend.DataFrame do
               columns :: columns_for_io(),
               infer_schema_length :: option(integer()),
               parse_dates :: boolean(),
-              eol_delimiter :: option(String.t())
+              eol_delimiter :: option(String.t()),
+              quote_char :: option(String.t())
             ) :: io_result(df)
 
   # IO: Parquet

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -601,6 +601,9 @@ defmodule Explorer.DataFrame do
     * `:encoding` - Encoding to use when reading the file. For now, the only possible values are `utf8` and `utf8-lossy`.
       The utf8-lossy option means that invalid utf8 values are replaced with � characters. (default: `"utf8"`)
 
+    * `:quote_char` - A single character used for csv quoting. Set to `nil` to turn off special handling and escaping
+      of quotes. (default: `"\""`)
+
   """
   @doc type: :io
   @spec from_csv(filename :: String.t() | fs_entry(), opts :: Keyword.t()) ::
@@ -622,7 +625,8 @@ defmodule Explorer.DataFrame do
         columns: nil,
         infer_schema_length: @default_infer_schema_length,
         parse_dates: false,
-        eol_delimiter: nil
+        eol_delimiter: nil,
+        quote_char: "\""
       )
 
     backend = backend_from_options!(backend_opts)
@@ -641,7 +645,8 @@ defmodule Explorer.DataFrame do
         to_columns_for_io(opts[:columns]),
         opts[:infer_schema_length],
         opts[:parse_dates],
-        opts[:eol_delimiter]
+        opts[:eol_delimiter],
+        opts[:quote_char]
       ]
 
       Shared.apply_init(backend, :from_csv, args, backend_opts)
@@ -803,7 +808,8 @@ defmodule Explorer.DataFrame do
         columns: nil,
         infer_schema_length: @default_infer_schema_length,
         parse_dates: false,
-        eol_delimiter: nil
+        eol_delimiter: nil,
+        quote_char: "\""
       )
 
     backend = backend_from_options!(backend_opts)
@@ -821,7 +827,8 @@ defmodule Explorer.DataFrame do
       to_columns_for_io(opts[:columns]),
       opts[:infer_schema_length],
       opts[:parse_dates],
-      opts[:eol_delimiter]
+      opts[:eol_delimiter],
+      opts[:quote_char]
     ]
 
     Shared.apply_init(backend, :load_csv, args, backend_opts)

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -49,7 +49,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         columns,
         infer_schema_length,
         parse_dates,
-        eol_delimiter
+        eol_delimiter,
+        quote_char
       )
       when module in [S3.Entry, HTTP.Entry] do
     path = Shared.build_path_for_entry(entry)
@@ -71,7 +72,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
           columns,
           infer_schema_length,
           parse_dates,
-          eol_delimiter
+          eol_delimiter,
+          quote_char
         )
 
       File.rm(path)
@@ -93,7 +95,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         columns,
         infer_schema_length,
         parse_dates,
-        eol_delimiter
+        eol_delimiter,
+        quote_char
       ) do
     infer_schema_length =
       if infer_schema_length == nil,
@@ -118,7 +121,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         encoding,
         nil_values,
         parse_dates,
-        char_byte(eol_delimiter)
+        char_byte(eol_delimiter),
+        char_byte(quote_char)
       )
 
     case df do
@@ -200,7 +204,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         columns,
         infer_schema_length,
         parse_dates,
-        eol_delimiter
+        eol_delimiter,
+        quote_char
       ) do
     infer_schema_length =
       if infer_schema_length == nil,
@@ -225,7 +230,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         encoding,
         nil_values,
         parse_dates,
-        char_byte(eol_delimiter)
+        char_byte(eol_delimiter),
+        char_byte(quote_char)
       )
 
     case df do

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -136,6 +136,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
         _,
         _,
         _,
+        _,
         _
       ) do
     {:error,
@@ -156,7 +157,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
         columns,
         infer_schema_length,
         parse_dates,
-        eol_delimiter
+        eol_delimiter,
+        quote_char
       )
       when is_nil(columns) do
     infer_schema_length =
@@ -178,7 +180,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
         encoding,
         nil_values,
         parse_dates,
-        char_byte(eol_delimiter)
+        char_byte(eol_delimiter),
+        char_byte(quote_char)
       )
 
     case result do
@@ -190,6 +193,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   @impl true
   def from_csv(
         %Local.Entry{},
+        _,
         _,
         _,
         _,
@@ -311,7 +315,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
         columns,
         infer_schema_length,
         parse_dates,
-        eol_delimiter
+        eol_delimiter,
+        quote_char
       ) do
     with {:ok, df} <-
            Eager.load_csv(
@@ -327,7 +332,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
              columns,
              infer_schema_length,
              parse_dates,
-             eol_delimiter
+             eol_delimiter,
+             quote_char
            ) do
       {:ok, Eager.lazy(df)}
     end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -109,7 +109,8 @@ defmodule Explorer.PolarsBackend.Native do
         _encoding,
         _nil_vals,
         _parse_dates,
-        _eol_delimiter
+        _eol_delimiter,
+        _quote_char
       ),
       do: err()
 
@@ -145,7 +146,8 @@ defmodule Explorer.PolarsBackend.Native do
         _encoding,
         _nil_vals,
         _parse_dates,
-        _eol_delimiter
+        _eol_delimiter,
+        _quote_char
       ),
       do: err()
 
@@ -255,7 +257,8 @@ defmodule Explorer.PolarsBackend.Native do
         _encoding,
         _nil_vals,
         _parse_dates,
-        _eol_delimiter
+        _eol_delimiter,
+        _quote_char
       ),
       do: err()
 

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -47,6 +47,7 @@ pub fn df_from_csv(
     null_vals: Vec<String>,
     parse_dates: bool,
     eol_delimiter: Option<u8>,
+    quote_char: Option<u8>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let encoding = match encoding {
         "utf8-lossy" => CsvEncoding::LossyUtf8,
@@ -71,6 +72,7 @@ pub fn df_from_csv(
         .with_parse_options(
             CsvParseOptions::default()
                 .with_encoding(encoding)
+                .with_quote_char(quote_char)
                 .with_truncate_ragged_lines(true)
                 .with_try_parse_dates(parse_dates)
                 .with_separator(delimiter_as_byte)
@@ -180,6 +182,7 @@ pub fn df_load_csv(
     null_vals: Vec<String>,
     parse_dates: bool,
     eol_delimiter: Option<u8>,
+    quote_char: Option<u8>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let encoding = match encoding {
         "utf8-lossy" => CsvEncoding::LossyUtf8,
@@ -211,6 +214,7 @@ pub fn df_load_csv(
                     null_vals.iter().map(|x| x.into()).collect(),
                 )))
                 .with_try_parse_dates(parse_dates)
+                .with_quote_char(quote_char)
                 .with_eol_char(eol_delimiter.unwrap_or(b'\n')),
         )
         .into_reader_with_file_handle(cursor)

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -262,6 +262,7 @@ pub fn lf_from_csv(
     null_vals: Vec<String>,
     parse_dates: bool,
     eol_delimiter: Option<u8>,
+    quote_char: Option<u8>,
 ) -> Result<ExLazyFrame, ExplorerError> {
     let encoding = match encoding {
         "utf8-lossy" => CsvEncoding::LossyUtf8,
@@ -283,6 +284,7 @@ pub fn lf_from_csv(
             null_vals.iter().map(|x| x.into()).collect(),
         )))
         .with_eol_char(eol_delimiter.unwrap_or(b'\n'))
+        .with_quote_char(quote_char)
         .finish()?;
 
     Ok(ExLazyFrame::new(df))


### PR DESCRIPTION
The current implementation of the `Explorer.DataFrame.load_csv/2` and `Explorer.DataFrame.from_csv/2` function don't allow users to pass the `:quote_char` option. The description of the option on the polar documentation is: 


Single byte character used for csv quoting, default = `"`. Set to None to turn off special handling and escaping of quotes.


I was working with a dataset where the `"` character was used as part of the value, not some kind of special case, which caused an error when loading the csv as a dataframe. 

I was not sure what name to use for the parameter in the elixir code, so I used the same name as polars. 