### PR TITLE
Add `join_asof/3`

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -250,6 +250,14 @@ defmodule Explorer.Backend.DataFrame do
               how :: :left | :inner | :outer | :right | :cross
             ) :: df
 
+  @callback join_asof(
+              [df()],
+              out_df :: df(),
+              on :: list({column_name(), column_name()}),
+              by :: list({column_name(), column_name()}),
+              strategy :: :backward | :forward | :nearest
+            ) :: df
+
   @callback concat_columns([df], out_df :: df()) :: df
   @callback concat_rows([df], out_df :: df()) :: df
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5524,7 +5524,9 @@ defmodule Explorer.DataFrame do
         gdp s64 [4164, 4696, 4696]
       >
 
-  The `by` argument allows joining on another column first, before the asof join. In this example we join by `country` first, then asof join by date, as above.
+  The `by` argument allows left-joining on another column (or columns) first,
+  before the asof join. In this example we left-join by `country` first, then
+  asof join by `date`, as above.
 
       iex> gdp = Explorer.DataFrame.new(
       ...>   date: [~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01], ~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01]],

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -74,6 +74,7 @@ defmodule Explorer.DataFrame do
   Multiple table verbs are used for combining tables. These are:
 
   - `join/3` for performing SQL-like joins
+  - `join_asof/3` for performing joins with as-of semantics
   - `concat_columns/1` for horizontally "stacking" dataframes
   - `concat_rows/1` for vertically "stacking" dataframes
 
@@ -5420,6 +5421,7 @@ defmodule Explorer.DataFrame do
     pairs = dtypes_pairs_for_common_join(left, right, right_on)
 
     {new_names, _} = Enum.unzip(pairs)
+
     out_df(left, new_names, Map.new(pairs))
   end
 
@@ -5435,6 +5437,167 @@ defmodule Explorer.DataFrame do
 
         {name, right.dtypes[right_name]}
       end)
+  end
+
+  @valid_strategy_types [:backward, :forward, :nearest]
+  @doc """
+  Perform an asof join.
+
+  This is similar to a left-join except that we match on nearest key rather than equal keys.
+
+  Both DataFrames must be sorted by the asof_join key.
+
+  For each row in the left DataFrame:
+    A “backward” search .
+    A “forward” search selects the first row in the right DataFrame whose ‘on’ key is greater than or equal to the left’s key.
+    A “nearest” search selects the last row in the right DataFrame whose value is nearest to the left’s key. String keys are not currently supported for a nearest search.
+
+
+  ## Join types
+
+    * `:backward` - Selects the last row in the right DataFrame whose ‘on’ key is less than or equal to the left’s key.
+    * `:forward` - Selects the first row in the right DataFrame whose ‘on’ key is greater than or equal to the left’s key.
+    * `:nearest` -  Selects the last row in the right DataFrame whose value is nearest to the left’s key. String keys are not currently supported for a nearest search.
+
+  ## Options
+
+    * `:on` - The column(s) to join on. Defaults to overlapping columns.
+    * `:by` - The column(s) to join on before doing asof join. Defaults to overlapping columns.
+    * `:strategy` - One of the join types (as an atom) described above. Defaults to `:backward`.
+
+  ## Examples
+
+  A Backwards join_asof:
+
+      iex> gdp = Explorer.DataFrame.new(date: [~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01],~D[2020-01-01]], gdp: [4164, 4411, 4566, 4696, 4827])
+      iex> population = Explorer.DataFrame.new(date: [~D[2016-03-01], ~D[2018-08-01], ~D[2019-01-01]], population: [82.19, 82.66, 83.12])
+      iex> Explorer.DataFrame.join_asof(population, gdp, on: :date)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        date date [2016-03-01, 2018-08-01, 2019-01-01]
+        population f64 [82.19, 82.66, 83.12]
+        gdp s64 [4164, 4566, 4696]
+      >
+
+  A Forward join_asof:
+
+      iex> gdp = Explorer.DataFrame.new(date: [~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01],~D[2020-01-01]], gdp: [4164, 4411, 4566, 4696, 4827])
+      iex> population = Explorer.DataFrame.new(date: [~D[2016-03-01], ~D[2018-08-01], ~D[2019-01-01]], population: [82.19, 82.66, 83.12])
+      iex> Explorer.DataFrame.join_asof(population, gdp, strategy: :forward)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        date date [2016-03-01, 2018-08-01, 2019-01-01]
+        population f64 [82.19, 82.66, 83.12]
+        gdp s64 [4411, 4696, 4696]
+      >
+
+  A Nearest join_asof:
+
+      iex> gdp = Explorer.DataFrame.new(date: [~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01],~D[2020-01-01]], gdp: [4164, 4411, 4566, 4696, 4827])
+      iex> population = Explorer.DataFrame.new(date: [~D[2016-03-01], ~D[2018-08-01], ~D[2019-01-01]], population: [82.19, 82.66, 83.12])
+      iex> Explorer.DataFrame.join_asof(population, gdp, strategy: :nearest)
+      #Explorer.DataFrame<
+        Polars[3 x 3]
+        date date [2016-03-01, 2018-08-01, 2019-01-01]
+        population f64 [82.19, 82.66, 83.12]
+        gdp s64 [4164, 4696, 4696]
+      >
+
+  They `by` argument allows joining on another column first, before the asof join. In this example we join by country first, then asof join by date, as above.
+
+      iex> gdp = Explorer.DataFrame.new(date: [~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01], ~D[2016-01-01], ~D[2017-01-01], ~D[2018-01-01], ~D[2019-01-01] ], country: ["Germany", "Germany", "Germany", "Germany", "Netherlands", "Netherlands", "Netherlands", "Netherlands"], gdp: [4164, 4411, 4566, 4696, 784, 833, 914, 1000])
+      iex> population = Explorer.DataFrame.new(date: [ ~D[2016-03-01], ~D[2018-08-01], ~D[2016-03-01], ~D[2018-08-01]], country: ["Germany", "Germany", "Netherlands", "Netherlands"], population: [82.19, 82.66, 17.08, 17.18])
+      iex> Explorer.DataFrame.join_asof(population, gdp, by: :country, on: :date, strategy: :nearest)
+      #Explorer.DataFrame<
+        Polars[4 x 4]
+        date date [2016-03-01, 2018-08-01, 2016-03-01, 2018-08-01]
+        country string ["Germany", "Germany", "Netherlands", "Netherlands"]
+        population f64 [82.19, 82.66, 17.08, 17.18]
+        gdp s64 [4164, 4696, 784, 1000]
+      >
+
+  """
+  @doc type: :multi
+  @spec join_asof(left :: DataFrame.t(), right :: DataFrame.t(), opts :: Keyword.t()) ::
+          DataFrame.t()
+  def join_asof(%DataFrame{} = left, %DataFrame{} = right, opts \\ []) do
+    left_columns = left.names
+    right_columns = right.names
+
+    opts =
+      Keyword.validate!(opts,
+        on: find_overlapping_columns(left_columns, right_columns),
+        by: [],
+        strategy: :backward
+      )
+
+    unless opts[:strategy] in @valid_strategy_types do
+      raise ArgumentError,
+            "join type is not valid: #{inspect(opts[:strategy])}. " <>
+              "Valid options are: #{Enum.map_join(@valid_strategy_types, ", ", &inspect/1)}"
+    end
+
+    strategy = opts[:strategy]
+
+    on =
+      case List.wrap(opts[:on]) do
+        [] ->
+          raise(ArgumentError, "could not find any overlapping columns for :on")
+
+        [_ | _] = on ->
+          Enum.map(on, fn
+            {l_name, r_name} ->
+              [l_column] = to_existing_columns(left, [l_name])
+              [r_column] = to_existing_columns(right, [r_name])
+              {l_column, r_column}
+
+            name ->
+              [l_column] = to_existing_columns(left, [name])
+              [r_column] = to_existing_columns(right, [name])
+
+              # This is an edge case for when an index is passed as column selection
+              if l_column != r_column do
+                raise ArgumentError,
+                      "the column given to option `:on` is not the same for both dataframes"
+              end
+
+              {l_column, r_column}
+          end)
+      end
+
+    by =
+      case List.wrap(opts[:by]) do
+        [] ->
+          []
+
+        [_ | _] = on ->
+          Enum.map(on, fn
+            {l_name, r_name} ->
+              [l_column] = to_existing_columns(left, [l_name])
+              [r_column] = to_existing_columns(right, [r_name])
+              {l_column, r_column}
+
+            name ->
+              [l_column] = to_existing_columns(left, [name])
+              [r_column] = to_existing_columns(right, [name])
+
+              # This is an edge case for when an index is passed as column selection
+              if l_column != r_column do
+                raise ArgumentError,
+                      "the column given to option `:by` is not the same for both dataframes"
+              end
+
+              {l_column, r_column}
+          end)
+      end
+
+    {_left_by, right_by} = Enum.unzip(by)
+    {_left_on, right_on} = Enum.unzip(on)
+
+    pairs = dtypes_pairs_for_common_join(left, right, right_on ++ right_by)
+    {new_names, _} = Enum.unzip(pairs)
+    out_df = out_df(left, new_names, Map.new(pairs))
+    Shared.apply_dataframe([left, right], :join_asof, [out_df, on, by, strategy])
   end
 
   @doc """

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -930,6 +930,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
+  def join_asof([left, right], out_df, on, by, strategy) do
+    left = lazy(left)
+    right = lazy(right)
+
+    ldf = LazyFrame.join_asof([left, right], out_df, on, by, strategy)
+    LazyFrame.compute(ldf)
+  end
+
+  @impl true
   def concat_rows([_head | _tail] = dfs, out_df) do
     lazy_dfs = Enum.map(dfs, &lazy/1)
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -285,6 +285,19 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_drop_nils(_df, _column_pairs), do: err()
   def lf_pivot_longer(_df, _id_vars, _value_vars, _names_to, _values_to), do: err()
   def lf_join(_df, _other, _left_on, _right_on, _how, _suffix), do: err()
+
+  def lf_join_asof(
+        _df,
+        _other,
+        _left_on,
+        _right_on,
+        _left_by,
+        _right_by,
+        _strategy,
+        _suffix
+      ),
+      do: err()
+
   def lf_concat_rows(_dfs), do: err()
   def lf_concat_columns(_ldfs), do: err()
   def lf_to_parquet(_df, _filename, _compression, _streaming), do: err()

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -39,6 +39,7 @@ version = "0.49"
 default-features = false
 features = [
   "abs",
+  "asof_join",
   "checked_arithmetic",
   "concat_str",
   "cov",

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -406,8 +406,7 @@ pub fn lf_join_asof(
             right_by: map_by(&right_by),
             // TODO: provide option
             allow_eq: true,
-            // TODO: add a check? Note that Polars prints a warning if check is true when `by` is
-            // provided
+            // TODO: add a check? Note that Polars prints a warning if `check_sortedness=true` when `by` is provided
             check_sortedness: false,
         }))
         .left_on(ex_expr_to_exprs(left_on))

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -405,6 +405,8 @@ pub fn lf_join_asof(
             tolerance_str: None,
             left_by: left_by,
             right_by: right_by,
+            allow_eq: true,
+            check_sortedness: true,
         }))
         .left_on(ex_expr_to_exprs(left_on))
         .right_on(ex_expr_to_exprs(right_on))

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -1431,6 +1431,47 @@ defmodule Explorer.DataFrame.LazyTest do
     end
   end
 
+  describe "join_asof/3" do
+    test "raises if no overlapping columns" do
+      assert_raise ArgumentError,
+                   ~r"could not find any overlapping columns",
+                   fn ->
+                     left = DF.new([a: [1, 2, 3]], lazy: true)
+                     right = DF.new([b: [1, 2, 3]], lazy: true)
+                     DF.join_asof(left, right)
+                   end
+    end
+
+    test "with a custom 'on'" do
+      left =
+        DF.new(
+          [
+            id: [1, 2, 3],
+            time: [0.9, 2.1, 2.8]
+          ],
+          lazy: true
+        )
+
+      right =
+        DF.new(
+          [
+            time: [2.0],
+            value: [100]
+          ],
+          lazy: true
+        )
+
+      ldf = DF.join_asof(left, right, on: :time, strategy: :nearest)
+      df = DF.compute(ldf)
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               id: [1, 2, 3],
+               time: [0.9, 2.1, 2.8],
+               value: [100, 100, 100]
+             }
+    end
+  end
+
   describe "concat_rows/2" do
     test "two simple DFs of the same dtypes" do
       ldf1 = DF.new([x: [1, 2, 3], y: ["a", "b", "c"]], lazy: true)

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -1442,6 +1442,16 @@ defmodule Explorer.DataFrame.LazyTest do
                    end
     end
 
+    test "raises if multiple overlapping columns" do
+      assert_raise ArgumentError,
+                   ~r"multiple columns for option `:on` is not supported for join_asof",
+                   fn ->
+                     left = DF.new([a: [1, 2, 3], b: [1, 2, 3]], lazy: true)
+                     right = DF.new([a: [1, 2, 3], b: [1, 2, 3]], lazy: true)
+                     DF.join_asof(left, right)
+                   end
+    end
+
     test "with a custom 'on'" do
       left =
         DF.new(


### PR DESCRIPTION
I have added some changes on top of #1080:

- Refined docs (mostly copied from [Polars Python API](https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.join_asof.html));
- Validating `:on` to be a single column (`join_asof` currently works only with a single column)
- Chore refactors (restore `Cargo.toml`; reduce boilerplate of `:on`/`:by` normalisation). 

Maybe as part of this PR, or as a separate one, would be nice to add other options supported by Polars:

- `:tolerance`
- `:allow_eq`
- `:check_sortedness`