### PR TITLE
Add nulls_equal option to DataFrame.join/3

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -243,7 +243,8 @@ defmodule Explorer.Backend.DataFrame do
               [df()],
               out_df :: df(),
               on :: list({column_name(), column_name()}),
-              how :: :left | :inner | :outer | :right | :cross
+              how :: :left | :inner | :outer | :right | :cross,
+              nulls_equal :: boolean()
             ) :: df
 
   @callback join_asof(

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -916,11 +916,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
   # Two or more table verbs
 
   @impl true
-  def join([left, right], out_df, on, how) do
+  def join([left, right], out_df, on, how, nulls_equal) do
     left = lazy(left)
     right = lazy(right)
 
-    ldf = LazyFrame.join([left, right], out_df, on, how)
+    ldf = LazyFrame.join([left, right], out_df, on, how, nulls_equal)
     LazyFrame.collect(ldf)
   end
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -287,7 +287,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_rename_columns(_df, _column_pairs), do: err()
   def lf_drop_nils(_df, _column_pairs), do: err()
   def lf_pivot_longer(_df, _id_vars, _value_vars, _names_to, _values_to), do: err()
-  def lf_join(_df, _other, _left_on, _right_on, _how, _suffix), do: err()
+  def lf_join(_df, _other, _left_on, _right_on, _how, _opts), do: err()
 
   def lf_join_asof(
         _df,

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -3,6 +3,13 @@ use crate::{
     ExplorerError,
 };
 use polars::{lazy::dsl::Selector, prelude::*};
+use rustler::NifMap;
+
+#[derive(NifMap)]
+pub struct ExJoinOptions {
+    pub suffix: String,
+    pub nulls_equal: bool,
+}
 
 // Loads the IO functions for read/writing CSV, NDJSON, Parquet, etc.
 pub mod io;
@@ -320,7 +327,7 @@ pub fn lf_join(
     left_on: Vec<ExExpr>,
     right_on: Vec<ExExpr>,
     how: &str,
-    suffix: &str,
+    opts: ExJoinOptions,
 ) -> Result<ExLazyFrame, ExplorerError> {
     let how = match how {
         "left" => JoinType::Left,
@@ -344,7 +351,8 @@ pub fn lf_join(
             .join_builder()
             .with(ldf1)
             .how(JoinType::Cross)
-            .suffix(suffix)
+            .suffix(&opts.suffix)
+            .join_nulls(opts.nulls_equal)
             .finish(),
         _ => ldf
             .join_builder()
@@ -352,7 +360,8 @@ pub fn lf_join(
             .how(how)
             .left_on(ex_expr_to_exprs(left_on))
             .right_on(ex_expr_to_exprs(right_on))
-            .suffix(suffix)
+            .suffix(&opts.suffix)
+            .join_nulls(opts.nulls_equal)
             .finish(),
     };
 


### PR DESCRIPTION
Adds support for Polars' nulls_equal join parameter to DataFrame.join/3, allowing NULL values to match during join operations. Defaults to false (standard SQL semantics where NULL != NULL).

## Changes

- Added :nulls_equal option to DataFrame.join/3 public API
- Refactored NIF boundary to use an options map (ExJoinOptions struct with #[derive(NifMap)]) to make other options easier to add in the future
- Added tests for all join types with nulls_equal: true

## Example
```elixir
left = Explorer.DataFrame.new(a: [1, nil], b: ["a", "b"])
right = Explorer.DataFrame.new(a: [1, nil], c: ["d", "e"])

# Default behavior (SQL semantics): nil != nil
Explorer.DataFrame.join(left, right)
# => 1 row (only matches on a=1)

# With nulls_equal: true
Explorer.DataFrame.join(left, right, nulls_equal: true)
# => 2 rows (matches on a=1 and a=nil)
```