### PR TITLE
Bump macos version in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           # https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/...
           # choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
           - { target: aarch64-apple-darwin, os: macos-15 }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true, rustflags: "-C target-feature=-crt-static" }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
           - { target: aarch64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
           - { target: x86_64-apple-darwin, os: macos-15 }
           - { target: x86_64-pc-windows-gnu, os: windows-2025, rustflags: "-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma" }

--- a/native/explorer/Cross.toml
+++ b/native/explorer/Cross.toml
@@ -1,5 +1,2 @@
 [build.env]
-passthrough = [
-  "RUSTLER_NIF_VERSION",
-  "RUSTFLAGS"
-]
+passthrough = ["RUSTFLAGS"]


### PR DESCRIPTION
Support for `macos-13` appears to have been dropped:

https://github.com/elixir-explorer/explorer/actions/runs/21784038730/job/62852503419

> The configuration 'macos-13-us-default' is not supported

This PR bumps the version to `macos-15` and adds a link to the list of available OS names:

https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories

It also puts `Cross.toml` back which was incorrectly removed as part of #1139. (I misread the [documentation](https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#additional-configuration-before-build) concerning what was deprecated in Rustler post-0.29.)