### PR TITLE
Fix Adbc.Connection.query_pointer/5 warning when using adbc >= 0.9

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -21,10 +21,17 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @compile {:no_warn_undefined, Adbc.Connection}
   @impl true
   def from_query(conn, query, params) do
+    # query_pointer/5 callback should be 1-arity, the 2-arity version is deprecated in adbc >= 0.9
     adbc_result =
-      Adbc.Connection.query_pointer(conn, query, params, fn pointer, _num_rows ->
-        Explorer.PolarsBackend.Native.df_from_arrow_stream_pointer(pointer)
-      end)
+      if Code.ensure_loaded?(Adbc.StreamResult) do
+        Adbc.Connection.query_pointer(conn, query, params, fn stream_result ->
+          Explorer.PolarsBackend.Native.df_from_arrow_stream_pointer(stream_result.pointer)
+        end)
+      else
+        Adbc.Connection.query_pointer(conn, query, params, fn pointer, _num_rows ->
+          Explorer.PolarsBackend.Native.df_from_arrow_stream_pointer(pointer)
+        end)
+      end
 
     with {:ok, df_result} <- adbc_result,
          {:ok, df} <- df_result,


### PR DESCRIPTION
adbc 0.9 deprecated the 2-arity callback of `Adbc.Connection.query_pointer`.

When using explorer with adbc 0.9 or newer, this generates lots of deprecation warnings. This commit fixes it by using the newer 1-arity callback if available.


The docs of `Adbc.StreamResult` [mention](https://adbc.hexdocs.pm/Adbc.StreamResult.html):

> You must always hold a whole reference to the struct, and not individual fields. For example, if you only keep a reference to result.pointer, then the struct will be GCed, and so would be the stream.

I am unsure what to do with information and whether

```ex
Explorer.PolarsBackend.Native.df_from_arrow_stream_pointer(stream_result.pointer)
```

in the callback is enough to keep the reference alive long enough. 