### PR TITLE
Fix warnings

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -168,7 +168,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback lazy(df) :: df
   @callback collect(df) :: df
   @callback from_tabular(Table.Reader.t(), io_dtypes) :: df
-  @callback from_series([{binary(), Series.t()}]) :: df
+  @callback from_series([{binary(), series()}]) :: df
   @callback to_rows(df, atom_keys? :: boolean()) :: [map()]
   @callback to_rows_stream(df, atom_keys? :: boolean(), chunk_size :: integer()) :: Enumerable.t()
 

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -822,7 +822,6 @@ defmodule Explorer.Backend.LazySeries do
        when op in [:first, :last, :sum, :min, :max, :product],
        do: series.dtype
 
-  defp dtype_for_agg_operation(op, _) when op in [:all?, :any?], do: :boolean
   defp dtype_for_agg_operation(:mode, series), do: {:list, series.dtype}
 
   defp dtype_for_agg_operation(_, _), do: {:f, 64}

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -1077,13 +1077,6 @@ defmodule Explorer.Backend.LazySeries do
   defp to_elixir_ast(other), do: other
 
   @impl true
-  def size(series) do
-    data = new(:size, [lazy_series!(series)], {:u, 32})
-
-    Backend.Series.new(data, {:u, 32})
-  end
-
-  @impl true
   def transform(_series, _fun) do
     raise """
     #{unsupported(:transform, 2)}

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -322,7 +322,7 @@ defmodule Explorer.PolarsBackend.Expression do
     Native.expr_int_range(to_expr(0), size_expr, 1, {:u, 32})
   end
 
-  for {op, arity} <- @all_expressions do
+  for {op, arity} <- @all_expressions -- @first_only_expressions do
     args = Macro.generate_arguments(arity, __MODULE__)
 
     updates =

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -322,7 +322,10 @@ defmodule Explorer.PolarsBackend.Expression do
     Native.expr_int_range(to_expr(0), size_expr, 1, {:u, 32})
   end
 
-  for {op, arity} <- @all_expressions -- @first_only_expressions do
+  for {op, arity} when op not in [
+    :acos, :asin, :atan, :cos, :degrees, :radians, :sin, :tan,
+    :variance, :exp, :skew, :standard_deviation
+  ] <- @all_expressions do
     args = Macro.generate_arguments(arity, __MODULE__)
 
     updates =

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1143,7 +1143,7 @@ defmodule Explorer.Series do
     do: apply_series(series, :strftime, [format_string])
 
   def strftime(%Series{dtype: dtype}, _format_string),
-    do: dtype_error("strftime/2", dtype, :datetime_like)
+    do: dtype_error("strftime/2", dtype, [:datetime_like])
 
   @doc """
   Clip (or clamp) the values in a series.

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -3483,9 +3483,6 @@ defmodule Explorer.Series do
   defp maybe_max(left, right) when K.and(is_integer(left), is_integer(right)),
     do: K.max(left, right)
 
-  defp maybe_max(left, nil), do: left
-  defp maybe_max(nil, right), do: right
-
   @doc """
   Subtracts right from left, element-wise.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -5346,15 +5346,15 @@ defmodule Explorer.Series do
 
     float_series =
       case dtype(series) do
-        :f32 ->
+        {:f, 32} ->
           series
 
-        :f64 ->
+        {:f, 64} ->
           series
 
         _ ->
           try do
-            cast(series, :f64)
+            cast(series, {:f, 64})
           rescue
             _ ->
               raise ArgumentError,

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Explorer.MixProject do
       package: package(),
       deps: deps(),
       docs: docs(),
-      preferred_cli_env: [ci: :test, "localstack.setup": :test],
+      cli: cli(),
       aliases: [
         "rust.lint": ["cmd cargo clippy --manifest-path=native/explorer/Cargo.toml -- -Dwarnings"],
         "rust.fmt": ["cmd cargo fmt --manifest-path=native/explorer/Cargo.toml --all"],
@@ -33,6 +33,10 @@ defmodule Explorer.MixProject do
       extra_applications: [:logger, :inets, :ssl],
       env: [default_backend: Explorer.PolarsBackend]
     ]
+  end
+
+  def cli do
+    [preferred_envs: [ci: :test, "localstack.setup": :test]]
   end
 
   defp elixirc_paths(:test), do: ~w(lib test/support)


### PR DESCRIPTION
Fixed a lot of compiler warnings.

Most of it comes down to functions being defined automatically inside macros, and so there were lots of duplicate definitions.

There were also several impossible clauses, matching on something that can never happen.